### PR TITLE
Revise denoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ An assetlist json contains the following structure:
             "symbol": "STK",
             "ibc": {
                 "source-channel": "channel-35",
-                "dest-channel": "channel-1",
-                "ibc-denom": ""
+                "dest-channel": "channel-1"
             },
             "logoURIs": {
                 "png": "https://github.com/linkto/image.png",
@@ -58,8 +57,7 @@ An assetlist json contains the following structure:
             "symbol": "FOO",
             "ibc": {
                 "source-channel": "channel-35",
-                "dest-channel": "channel-1",
-                "ibc-denom": ""
+                "dest-channel": "channel-1"
             },
             "logoURIs": {
                 "png": "ipfs://QmXfzKRvjZz3u5JRgC4v5mGVbm9ahrUiB4DgzHBsnWbTMM",

--- a/osmo-testnet-2/assetlist.json
+++ b/osmo-testnet-2/assetlist.json
@@ -1,131 +1,123 @@
 {
-    "chain-id": "osmo-testnet-2",
-    "assets": [
-      {
-        "description": "The native token of Osmosis",
-        "denom_units": [
-          {
-            "denom": "uosmo",
-            "exponent": 0,
-            "aliases": []
-          },
-          {
-            "denom": "osmo",
-            "exponent": 6,
-            "aliases": []
-          }
-        ],
-        "base": "uosmo",
-        "display": "osmo",
-        "symbol": "OSMO",
-        "ibc": {
-          "source-channel": "",
-          "dest-channel": "",
-          "ibc-denom": ""
+  "chain-id": "osmo-testnet-2",
+  "assets": [
+    {
+      "description": "The native token of Osmosis",
+      "denom_units": [
+        {
+          "denom": "uosmo",
+          "exponent": 0,
+          "aliases": []
         },
-        "logoURIs": {
-          "png": "images/osmo.png",
-          "svg": "images/osmo.svg"
+        {
+          "denom": "osmo",
+          "exponent": 6,
+          "aliases": []
         }
+      ],
+      "base": "uosmo",
+      "display": "osmo",
+      "symbol": "OSMO",
+      "ibc": {
+        "source-channel": "",
+        "dest-channel": ""
       },
-      {
-        "description": "Cosmos Hub ATOM testnet token",
-        "denom_units": [
-          {
-            "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "exponent": 0,
-            "aliases": [
-              "uatom"
-            ]
-          },
-          {
-            "denom": "atom",
-            "exponent": 6,
-            "aliases": []
-          }
-        ],
-        "base": "uatom",
-        "display": "atom",
-        "symbol": "ATOM",
-        "ibc": {
-          "source-channel": "channel-1",
-          "dest-channel": "channel-0"
-        },
-        "logoURIs": {
-          "png": "images/atom.png",
-          "svg": "images/atom.svg"
-        }
-      },
-      {
-        "description": "IRISnet IRIS testnet token",
-        "denom_units": [
-          {
-            "denom": "ibc/6ED71011FFBD0D137AFDB6AC574E9E100F61BA3DD44A8C05ECCE7E59D40A7B3E",
-            "exponent": 0,
-            "aliases": [
-              "uiris"
-            ]
-          },
-          {
-            "denom": "iris",
-            "exponent": 6,
-            "aliases": []
-          }
-        ],
-        "base": "uiris",
-        "display": "iris",
-        "symbol": "IRIS",
-        "ibc": {
-          "source-channel": "channel-1",
-          "dest-channel": "channel-1"
-        },
-        "logoURIs": {
-          "png": "images/iris.png",
-          "svg": "images/iris.svg"
-        }
-      },
-      {
-        "description": "Test token for osmo-testnet-2",
-        "denom_units": [
-          {
-            "denom": "poopcoin",
-            "exponent": 0,
-            "aliases": []
-          }
-        ],
-        "base": "poopcoin",
-        "display": "poop",
-        "symbol": "POOP",
-        "ibc": {
-          "source-channel": "",
-          "dest-channel": ""
-        },
-        "logoURIs": {
-          "png": "",
-          "svg": ""
-        }
-      },
-      {
-        "description": "Secondary test token for osmo-testnet-2",
-        "denom_units": [
-          {
-            "denom": "ion",
-            "exponent": 0,
-            "aliases": []
-          }
-        ],
-        "base": "ion",
-        "display": "ion",
-        "symbol": "ION",
-        "ibc": {
-          "source-channel": "",
-          "dest-channel": "",
-          "ibc-denom": ""
-        },
-        "logoURIs": {
-          "png": "",
-          "svg": ""
-        }
+      "logoURIs": {
+        "png": "images/osmo.png",
+        "svg": "images/osmo.svg"
       }
-    ]
-  }
+    },
+    {
+      "description": "Cosmos Hub ATOM testnet token",
+      "denom_units": [
+        {
+          "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          "exponent": 0,
+          "aliases": [
+            "uatom"
+          ]
+        },
+        {
+          "denom": "atom",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "base": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "display": "atom",
+      "symbol": "ATOM",
+      "ibc": {
+        "source-channel": "channel-1",
+        "dest-channel": "channel-0"
+      },
+      "logoURIs": {
+        "png": "images/atom.png",
+        "svg": "images/atom.svg"
+      }
+    },
+    {
+      "description": "IRISnet IRIS testnet token",
+      "denom_units": [
+        {
+          "denom": "ibc/6ED71011FFBD0D137AFDB6AC574E9E100F61BA3DD44A8C05ECCE7E59D40A7B3E",
+          "exponent": 0,
+          "aliases": [
+            "uiris"
+          ]
+        },
+        {
+          "denom": "iris",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "base": "ibc/6ED71011FFBD0D137AFDB6AC574E9E100F61BA3DD44A8C05ECCE7E59D40A7B3E",
+      "display": "iris",
+      "symbol": "IRIS",
+      "ibc": {
+        "source-channel": "channel-1",
+        "dest-channel": "channel-1"
+      },
+      "logoURIs": {
+        "png": "images/iris.png",
+        "svg": "images/iris.svg"
+      }
+    },
+    {
+      "description": "Test token for osmo-testnet-2",
+      "denom_units": [
+        {
+          "denom": "poopcoin",
+          "exponent": 0,
+          "aliases": []
+        }
+      ],
+      "base": "poopcoin",
+      "display": "poopcoin",
+      "symbol": "POOP",
+      "ibc": {},
+      "logoURIs": {
+        "png": "",
+        "svg": ""
+      }
+    },
+    {
+      "description": "Secondary test token for osmo-testnet-2",
+      "denom_units": [
+        {
+          "denom": "ion",
+          "exponent": 0,
+          "aliases": []
+        }
+      ],
+      "base": "ion",
+      "display": "ion",
+      "symbol": "ION",
+      "ibc": {},
+      "logoURIs": {
+        "png": "",
+        "svg": ""
+      }
+    }
+  ]
+}

--- a/osmo-testnet-2/assetlist.json
+++ b/osmo-testnet-2/assetlist.json
@@ -29,7 +29,7 @@
         }
       },
       {
-        "description": "The native token of the Cosmos Hub",
+        "description": "Cosmos Hub ATOM testnet token",
         "denom_units": [
           {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
@@ -54,6 +54,34 @@
         "logoURIs": {
           "png": "images/atom.png",
           "svg": "images/atom.svg"
+        }
+      },
+      {
+        "description": "IRISnet IRIS testnet token",
+        "denom_units": [
+          {
+            "denom": "ibc/6ED71011FFBD0D137AFDB6AC574E9E100F61BA3DD44A8C05ECCE7E59D40A7B3E",
+            "exponent": 0,
+            "aliases": [
+              "uiris"
+            ]
+          },
+          {
+            "denom": "iris",
+            "exponent": 6,
+            "aliases": []
+          }
+        ],
+        "base": "uiris",
+        "display": "iris",
+        "symbol": "IRIS",
+        "ibc": {
+          "source-channel": "channel-1",
+          "dest-channel": "channel-1"
+        },
+        "logoURIs": {
+          "png": "images/iris.png",
+          "svg": "images/iris.svg"
         }
       },
       {

--- a/osmo-testnet-2/assetlist.json
+++ b/osmo-testnet-2/assetlist.json
@@ -1,221 +1,103 @@
 {
     "chain-id": "osmo-testnet-2",
     "assets": [
-        {
-            "description": "The native token of Osmosis",
-            "denom_units": [
-                {
-                    "denom": "uosmo",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "osmo",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "uosmo",
-            "display": "osmo",
-            "symbol": "OSMO",
-            "ibc": {
-                "source-channel": "",
-                "dest-channel": "",
-                "ibc-denom": ""
-            },
-            "logoURIs": {
-                "png": "images/osmo.png",
-                "svg": "images/osmo.svg"
-            }
+      {
+        "description": "The native token of Osmosis",
+        "denom_units": [
+          {
+            "denom": "uosmo",
+            "exponent": 0,
+            "aliases": []
+          },
+          {
+            "denom": "osmo",
+            "exponent": 6,
+            "aliases": []
+          }
+        ],
+        "base": "uosmo",
+        "display": "osmo",
+        "symbol": "OSMO",
+        "ibc": {
+          "source-channel": "",
+          "dest-channel": "",
+          "ibc-denom": ""
         },
-        {
-            "description": "The native token of the Cosmos Hub",
-            "denom_units": [
-                {
-                    "denom": "uatom",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "atom",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "uatom",
-            "display": "atom",
-            "symbol": "ATOM",
-            "ibc": {
-                "source-channel": "channel-1",
-                "dest-channel": "channel-0",
-                "ibc-denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
-            },
-            "logoURIs": {
-                "png": "images/atom.png",
-                "svg": "images/atom.svg"
-            }
-        },
-        {
-            "description": "The native token of Irisnet",
-            "denom_units": [
-                {
-                    "denom": "uiris",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "iris",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "uiris",
-            "display": "iris",
-            "symbol": "IRIS",
-            "ibc": {
-                "source-channel": "channel-1",
-                "dest-channel": "channel-1",
-                "ibc-denom": "ibc/6ED71011FFBD0D137AFDB6AC574E9E100F61BA3DD44A8C05ECCE7E59D40A7B3E"
-            },
-            "logoURIs": {
-                "png": "images/iris.png",
-                "svg": ""
-            }
-            
-        },
-        {
-            "description": "The native token of Akash Network",
-            "denom_units": [
-                {
-                    "denom": "uakt",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "akt",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "uakt",
-            "display": "akt",
-            "symbol": "AKT",
-            "ibc": {
-                "source-channel": "",
-                "dest-channel": "",
-                "ibc-denom": ""
-            },
-            "logoURIs": {
-                "png": "images/akt.png",
-                "svg": "images/akt.svg"
-            }
-        },
-        {
-            "description": "The native token of Regen Network",
-            "denom_units": [
-                {
-                    "denom": "uregen",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "regen",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "uregen",
-            "display": "regen",
-            "symbol": "REGEN",
-            "ibc": {
-                "source-channel": "",
-                "dest-channel": "",
-                "ibc-denom": ""
-            },
-            "logoURIs": {
-                "png": "images/regen.png",
-                "svg": ""
-            }
-        },
-        {
-            "description": "The native token of Crypto.org",
-            "denom_units": [
-                {
-                    "denom": "basecro",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "cro",
-                    "exponent": 8,
-                    "aliases": []
-                }
-            ],
-            "base": "basecro",
-            "display": "cro",
-            "symbol": "CRO",
-            "ibc": {
-                "source-channel": "",
-                "dest-channel": "",
-                "ibc-denom": ""
-            },
-            "logoURIs": {
-                "png": "images/cro.png",
-                "svg": ""
-            },
-        },
-        {
-            "description": "The native token of Persistence",
-            "denom_units": [
-                {
-                    "denom": "uxprt",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "xprt",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "uxprt",
-            "display": "xprt",
-            "symbol": "XPRT",
-            "ibc": {
-                "source-channel": "",
-                "dest-channel": ""
-            },
-            "logoURIs": {
-                "png": "images/xprt.png",
-                "svg": ""
-            }
-        },
-        {
-            "description": "The native token of Sentinel Hub",
-            "denom_units": [
-                {
-                    "denom": "udvpn",
-                    "exponent": 0,
-                    "aliases": []
-                },
-                {
-                    "denom": "dvpn",
-                    "exponent": 6,
-                    "aliases": []
-                }
-            ],
-            "base": "udvpn",
-            "display": "dvpn",
-            "symbol": "DVPN",
-            "ibc": {
-                "source-channel": "",
-                "dest-channel": "",
-                "ibc-denom": ""
-            },
-            "logoURIs": {
-                "png": "images/dvpn.png",
-                "svg": ""
-            }
+        "logoURIs": {
+          "png": "images/osmo.png",
+          "svg": "images/osmo.svg"
         }
+      },
+      {
+        "description": "The native token of the Cosmos Hub",
+        "denom_units": [
+          {
+            "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+            "exponent": 0,
+            "aliases": [
+              "uatom"
+            ]
+          },
+          {
+            "denom": "atom",
+            "exponent": 6,
+            "aliases": []
+          }
+        ],
+        "base": "uatom",
+        "display": "atom",
+        "symbol": "ATOM",
+        "ibc": {
+          "source-channel": "channel-1",
+          "dest-channel": "channel-0"
+        },
+        "logoURIs": {
+          "png": "images/atom.png",
+          "svg": "images/atom.svg"
+        }
+      },
+      {
+        "description": "Test token for osmo-testnet-2",
+        "denom_units": [
+          {
+            "denom": "poopcoin",
+            "exponent": 0,
+            "aliases": []
+          }
+        ],
+        "base": "poopcoin",
+        "display": "poop",
+        "symbol": "POOP",
+        "ibc": {
+          "source-channel": "",
+          "dest-channel": ""
+        },
+        "logoURIs": {
+          "png": "",
+          "svg": ""
+        }
+      },
+      {
+        "description": "Secondary test token for osmo-testnet-2",
+        "denom_units": [
+          {
+            "denom": "ion",
+            "exponent": 0,
+            "aliases": []
+          }
+        ],
+        "base": "ion",
+        "display": "ion",
+        "symbol": "ION",
+        "ibc": {
+          "source-channel": "",
+          "dest-channel": "",
+          "ibc-denom": ""
+        },
+        "logoURIs": {
+          "png": "",
+          "svg": ""
+        }
+      }
     ]
-}
+  }


### PR DESCRIPTION
* Realized that we don't need a separate 'ibc-denom' since 'denom' in itself should be the ibc-denom.
* Went ahead and removed assets that don't exist on `osmo-testnet-2` (i.e. AKT, REGEN, etc)
* Add additional assets that do exist on `osmo-testnet-2` (poopcoin, ion)