### PR TITLE
konstellation coingecko_id to "darcmatter-coin"

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -1094,7 +1094,7 @@
         "png": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/darc.png",
         "svg": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/darc.svg"
       },
-      "coingecko_id": "konstellation"
+      "coingecko_id": "darcmatter-coin"
     },
     {
       "description": "The native staking and governance token of the Umee Network.",


### PR DESCRIPTION

current coingecko_id is wrong in assetlist, but maybe needs to be confirmed first with their team? On CG it is currently actually the following:
[https://api.coingecko.com/api/v3/coins/darcmatter-coin](https://api.coingecko.com/api/v3/coins/darcmatter-coin)