### PR TITLE
Frontier: corrected coingecko_id for Assetmantle "mantle"

### DIFF
--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -1649,7 +1649,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/mntl.png"
       },
-      "coingecko_id": "assetmantle"
+      "coingecko_id": "mantle"
     },
     {
       "description": "Hash is the staking token of the Provenance Blockchain",


### PR DESCRIPTION
incorrect: "assetmantle"
correct: "mantle"
as per API: https://api.coingecko.com/api/v3/coins/mantle