### PR TITLE
Fix INJ denoms and ibchash

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -1380,25 +1380,29 @@
       "description": "The INJ token is the native governance token for the Injective chain.",
       "denom_units": [
         {
-          "denom": "ibc/F2D281A7E86F6206C7DA560774B079EBEA17CFE292A1FCC1306E5DAABBB7D016",
+          "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
           "exponent": 0,
           "aliases": [
-            "uinj"
+            "inj"
           ]
         },
         {
-          "denom": "inj",
-          "exponent": 6
+          "denom": "uinj",
+          "exponent": 12
+        },
+        {
+          "denom": "INJ",
+          "exponent": 18
         }
       ],
-      "base": "ibc/F2D281A7E86F6206C7DA560774B079EBEA17CFE292A1FCC1306E5DAABBB7D016",
+      "base": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "name": "Injective",
-      "display": "inj",
+      "display": "INJ",
       "symbol": "INJ",
       "ibc": {
         "source_channel": "channel-8",
         "dst_channel": "channel-122",
-        "source_denom": "uinj"
+        "source_denom": "inj"
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",

--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -1320,7 +1320,7 @@
       ],
       "base": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "name": "Injective",
-      "display": "INJ,
+      "display": "INJ",
       "symbol": "INJ",
       "ibc": {
         "source_channel": "channel-8",

--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -1303,25 +1303,29 @@
       "description": "The INJ token is the native governance token for the Injective chain.",
       "denom_units": [
         {
-          "denom": "ibc/F2D281A7E86F6206C7DA560774B079EBEA17CFE292A1FCC1306E5DAABBB7D016",
+          "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
           "exponent": 0,
           "aliases": [
-            "uinj"
+            "inj"
           ]
         },
         {
-          "denom": "inj",
+          "denom": "uinj",
+          "exponent": 6
+        },
+        {
+          "denom": "INJ",
           "exponent": 6
         }
       ],
-      "base": "ibc/F2D281A7E86F6206C7DA560774B079EBEA17CFE292A1FCC1306E5DAABBB7D016",
+      "base": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "name": "Injective",
-      "display": "inj",
+      "display": "INJ,
       "symbol": "INJ",
       "ibc": {
         "source_channel": "channel-8",
         "dst_channel": "channel-122",
-        "source_denom": "uinj"
+        "source_denom": "inj"
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",

--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -1311,11 +1311,11 @@
         },
         {
           "denom": "uinj",
-          "exponent": 6
+          "exponent": 12
         },
         {
           "denom": "INJ",
-          "exponent": 6
+          "exponent": 18
         }
       ],
       "base": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",


### PR DESCRIPTION
Injective base unit is inj, so base needs to change, as with the ibc hash. INJ in caps is the full token, which has 18 decimals. uinj is made up, but can be used for one millionth of an INJ, so 12 decimals.