### PR TITLE
Update Main to use bridge suffix

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -1114,7 +1114,7 @@
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "name": "USD Coin",
       "display": "axlusdc",
-      "symbol": "USDC.axl",
+      "symbol": "USDC",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1143,7 +1143,7 @@
       "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "name": "Wrapped Ether",
       "display": "axlweth",
-      "symbol": "WETH.axl",
+      "symbol": "WETH",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1171,7 +1171,7 @@
       "base": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "name": "Dai Stablecoin",
       "display": "axldai",
-      "symbol": "DAI.axl",
+      "symbol": "DAI",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1282,7 +1282,7 @@
       "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "name": "Wrapped Bitcoin",
       "display": "axlwbtc",
-      "symbol": "WBTC.axl",
+      "symbol": "WBTC",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -1114,7 +1114,7 @@
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "name": "USD Coin",
       "display": "axlusdc",
-      "symbol": "axlUSDC",
+      "symbol": "USDC.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1143,7 +1143,7 @@
       "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "name": "Wrapped Ether",
       "display": "axlweth",
-      "symbol": "axlWETH",
+      "symbol": "WETH.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1171,7 +1171,7 @@
       "base": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "name": "Dai Stablecoin",
       "display": "axldai",
-      "symbol": "axlDAI",
+      "symbol": "DAI.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1266,34 +1266,6 @@
       "coingecko_id": "assetmantle"
     },
     {
-      "description": "Wrapped Ether on Axelar",
-      "type_asset": "erc20",
-      "denom_units": [
-        {
-          "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-          "exponent": 0,
-          "aliases": ["weth-wei"]
-        },
-        {
-          "denom": "axlweth",
-          "exponent": 18
-        }
-      ],
-      "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "name": "Wrapped Ether",
-      "display": "axlweth",
-      "symbol": "axlWETH",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "weth-wei"
-      },
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png"
-      },
-      "coingecko_id": "weth"
-    },
-    {
       "description": "Wrapped Bitcoin on Axelar",
       "type_asset": "erc20",
       "denom_units": [
@@ -1310,7 +1282,7 @@
       "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "name": "Wrapped Bitcoin",
       "display": "axlwbtc",
-      "symbol": "axlWBTC",
+      "symbol": "WBTC.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",

--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -1407,7 +1407,7 @@
       "base": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "name": "Tether USD",
       "display": "axlusdt",
-      "symbol": "USDT",
+      "symbol": "USDT.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1436,7 +1436,7 @@
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "name": "USD Coin",
       "display": "axlusdc",
-      "symbol": "USDC",
+      "symbol": "USDC.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1465,7 +1465,7 @@
       "base": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
       "name": "Frax",
       "display": "axlfrax",
-      "symbol": "FRAX",
+      "symbol": "FRAX.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1494,7 +1494,7 @@
       "base": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "name": "Dai Stablecoin",
       "display": "axldai",
-      "symbol": "DAI",
+      "symbol": "DAI.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1523,7 +1523,7 @@
       "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "name": "Wrapped Ether",
       "display": "axlweth",
-      "symbol": "WETH",
+      "symbol": "WETH.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",
@@ -1551,7 +1551,7 @@
       "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "name": "Wrapped Bitcoin",
       "display": "axlwbtc",
-      "symbol": "WBTC",
+      "symbol": "WBTC.axl",
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-208",


### PR DESCRIPTION
Resolves #200 
update bridge prefixed symbols to use suffix:
axlSYMBOL -> SYMBOL.axl on Frontier (for both Axelar and GBridge)
Main list does not use any suffix.
also: removing one copy of WETH.axl because it is a duplicate.