### PR TITLE
Delist Microtick

### DIFF
--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -295,34 +295,6 @@
       "coingecko_id": "starname"
     },
     {
-      "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",
-      "denom_units": [
-        {
-          "denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
-          "exponent": 0,
-          "aliases": ["utick"]
-        },
-        {
-          "denom": "tick",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
-      "display": "tick",
-      "name": "Microtick",
-      "symbol": "TICK",
-      "ibc": {
-        "source_channel": "channel-16",
-        "dst_channel": "channel-39",
-        "source_denom": "utick"
-      },
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
-      },
-      "coingecko_id": "microtick"
-    },
-    {
       "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
       "denom_units": [
         {


### PR DESCRIPTION
The Microtick chain has been stopped by governance for the move to Ethereum as the rebranding to DiscoveryDEX (Microtick v.2).