### PR TITLE
Use correct display value for boot

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -580,7 +580,7 @@
       ],
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "name": "Bostrom",
-      "display": "boot",
+      "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "symbol": "BOOT",
       "ibc": {
         "source_channel": "channel-2",

--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -695,7 +695,7 @@
       ],
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "name": "Bostrom",
-      "display": "boot",
+      "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "symbol": "BOOT",
       "ibc": {
         "source_channel": "channel-2",


### PR DESCRIPTION
Currently the display value for BOOT is `boot`, however this is not the name of any denom_unit, so is invalid