### PR TITLE
Update Echelon Denom

### DIFF
--- a/osmosis-1/osmosis-frontier.assetlist.json
+++ b/osmosis-1/osmosis-frontier.assetlist.json
@@ -1925,7 +1925,7 @@
       "description": "The native EVM, governance, bridge, and staking token of Echelon",
       "denom_units": [
         {
-          "denom": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+          "denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
           "exponent": 0,
           "aliases": ["aechelon"]
         },
@@ -1934,13 +1934,13 @@
           "exponent": 18
         }
       ],
-      "base": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+      "base": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "name": "Echelon",
       "display": "echelon",
       "symbol": "ECH",
       "ibc": {
-        "source_channel": "channel-8",
-        "dst_channel": "channel-262",
+        "source_channel": "channel-11",
+        "dst_channel": "channel-403",
         "source_denom": "aechelon"
       },
       "logo_URIs": {


### PR DESCRIPTION
Updating Echelon denom as old client expired during chain halt. Created updated client with updated channels. Therefore needing to update the denom.