### PR TITLE
Combine Assets to a Single file, add Verified Boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ An example assetlist json contains the following structure:
             "logo_URIs": {
                 "png": "https://github.com/linkto/image.png",
                 "svg": "https://stake.com/linkto/steak.svg"
-            }
+            },
+            "keywords": [
+                "osmosis-main"
+            ]
         },
         {
             "description": "Foocoin is the native token of the Foochain",
@@ -63,7 +66,9 @@ An example assetlist json contains the following structure:
                 "svg": ""
             },
             "coingecko_id": "foocoin-token",
-            "verified": false
+            "keywords": [
+                "osmosis-frontier"
+            ]
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ An example assetlist json contains the following structure:
             "logo_URIs": {
                 "png": "ipfs://QmXfzKRvjZz3u5JRgC4v5mGVbm9ahrUiB4DgzHBsnWbTMM",
                 "svg": ""
-            }
+            },
+            "coingecko_id": "foocoin-token",
+            "verified": false
         }
     ]
 }

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -103,9 +103,12 @@
                     "type": "string",
                     "description": "[OPTIONAL] The coingecko id to fetch asset data from coingecko v3 api. See https://api.coingecko.com/api/v3/coins/list"
                 },
-                "verified": {
-                    "type": "boolean",
-                    "description": "Whether the token is to be listed on the Main Osmosis site as a verified asset vs only listed on Frontier"
+                "keywords": {
+                    "type": "array",
+                    "maxContains": 20,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "if": {

--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -102,6 +102,10 @@
                 "coingecko_id": {
                     "type": "string",
                     "description": "[OPTIONAL] The coingecko id to fetch asset data from coingecko v3 api. See https://api.coingecko.com/api/v3/coins/list"
+                },
+                "verified": {
+                    "type": "boolean",
+                    "description": "Whether the token is to be listed on the Main Osmosis site as a verified asset vs only listed on Frontier"
                 }
             },
             "if": {

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -26,7 +26,7 @@
       "coingecko_id": "osmosis",
       "keywords": [
         "verified"
-      ],
+      ]
     },
     {
       "denom_units": [
@@ -50,7 +50,7 @@
       "coingecko_id": "ion",
       "keywords": [
         "verified"
-      ],
+      ]
     },
     {
       "description": "The native staking and governance token of the Cosmos Hub.",
@@ -81,7 +81,7 @@
       "coingecko_id": "cosmos",
       "keywords": [
         "verified"
-      ],
+      ]
     },
     {
       "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
@@ -112,7 +112,7 @@
       "coingecko_id": "akash-network",
       "keywords": [
         "verified"
-      ],
+      ]
     },
     {
       "description": "The XPRT token is primarily a governance token for the Persistence chain.",
@@ -142,7 +142,7 @@
       "coingecko_id": "persistence",
       "keywords": [
         "verified"
-      ],
+      ]
     },
     {
       "description": "The PSTAKE token is primarily a governance token for the Liquid Staking Protocol.",
@@ -172,7 +172,7 @@
       "coingecko_id": "pstake-finance",
       "keywords": [
         "verified"
-      ],
+      ]
     },
     {
       "description": "The IRIS token is the native governance token for the IrisNet chain.",

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -24,7 +24,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
       },
       "coingecko_id": "osmosis",
-      "verified": true
+      "keywords": [
+        "verified"
+      ],
     },
     {
       "denom_units": [
@@ -46,7 +48,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
       },
       "coingecko_id": "ion",
-      "verified": true
+      "keywords": [
+        "verified"
+      ],
     },
     {
       "description": "The native staking and governance token of the Cosmos Hub.",
@@ -75,7 +79,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
       },
       "coingecko_id": "cosmos",
-      "verified": true
+      "keywords": [
+        "verified"
+      ],
     },
     {
       "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
@@ -104,7 +110,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
       },
       "coingecko_id": "akash-network",
-      "verified": true
+      "keywords": [
+        "verified"
+      ],
     },
     {
       "description": "The XPRT token is primarily a governance token for the Persistence chain.",
@@ -132,7 +140,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png"
       },
       "coingecko_id": "persistence",
-      "verified": true
+      "keywords": [
+        "verified"
+      ],
     },
     {
       "description": "The PSTAKE token is primarily a governance token for the Liquid Staking Protocol.",
@@ -160,7 +170,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
       },
       "coingecko_id": "pstake-finance",
-      "verified": true
+      "keywords": [
+        "verified"
+      ],
     },
     {
       "description": "The IRIS token is the native governance token for the IrisNet chain.",
@@ -188,7 +200,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png"
       },
       "coingecko_id": "iris-network",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "DVPN is the native token of the Sentinel Hub.",
@@ -216,7 +230,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
       },
       "coingecko_id": "sentinel",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "CRO coin is the token for the Crypto.com platform.",
@@ -244,7 +260,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png"
       },
       "coingecko_id": "crypto-com-chain",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Wrapped BNB on Axelar",
@@ -274,7 +292,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
       },
       "coingecko_id": "wbnb",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "REGEN coin is the token for the Regen Network Platform",
@@ -302,7 +322,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
       },
       "coingecko_id": "regen",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "IOV coin is the token for the Starname (IOV) Asset Name Service",
@@ -331,7 +353,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
       },
       "coingecko_id": "starname",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
@@ -360,7 +384,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
       },
       "coingecko_id": "e-money",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "e-Money EUR stablecoin. Audited and backed by fiat EUR deposits and government bonds.",
@@ -388,7 +414,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
       },
       "coingecko_id": "e-money-eur",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The BCNA coin is the transactional token within the BitCanna network, serving the legal cannabis industry through its payment network, supply chain and trust network.",
@@ -417,7 +445,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
       },
       "coingecko_id": "bitcanna",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of JUNO Chain",
@@ -446,7 +476,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
       },
       "coingecko_id": "juno-network",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of IXO Chain",
@@ -473,8 +505,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
       },
-      "coingecko_id": "ixo",
-      "verified": true
+      "coingecko_id": "ixo"
     },
     {
       "description": "LIKE is the native staking and governance token of LikeCoin chain, a Decentralized Publishing Infrastructure to empower content ownership, authenticity, and provenance.",
@@ -503,7 +534,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
       },
       "coingecko_id": "likecoin",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "BitSong Native Token",
@@ -532,7 +565,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
       },
       "coingecko_id": "bitsong",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Ki Chain",
@@ -561,7 +596,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
       },
       "coingecko_id": "ki",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Secret Network",
@@ -590,7 +627,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
       },
       "coingecko_id": "secret",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Panacea is a public blockchain launched by MediBloc, which is the key infrastructure for reinventing the patient-centered healthcare data ecosystem",
@@ -618,7 +657,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
       },
       "coingecko_id": "medibloc",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The staking token of Bostrom",
@@ -641,8 +682,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
       },
-      "coingecko_id": "bostrom",
-      "verified": true
+      "coingecko_id": "bostrom"
     },
     {
       "description": "Native Token of Comdex Protocol",
@@ -670,7 +710,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
       },
       "coingecko_id": "comdex",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Native token for the cheqd network",
@@ -699,7 +741,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
       },
       "coingecko_id": "cheqd-network",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Stargaze",
@@ -727,7 +771,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
       },
       "coingecko_id": "stargaze",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Native token of the Lum Network",
@@ -755,7 +801,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
       },
       "coingecko_id": "lum-network",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Chihuahua Chain",
@@ -783,7 +831,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png"
       },
       "coingecko_id": "chihuahua-token",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Vidulum",
@@ -812,7 +862,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
       },
       "coingecko_id": "vidulum",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Desmos",
@@ -841,7 +893,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
       },
       "coingecko_id": "desmos",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Dig Chain.",
@@ -869,7 +923,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
       },
       "coingecko_id": "dig-chain",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Sommelier Chain.",
@@ -898,7 +954,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
       },
       "coingecko_id": "sommelier",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of BandChain",
@@ -927,7 +985,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
       },
       "coingecko_id": "band-protocol",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native staking and governance token of the Konstellation Network.",
@@ -956,7 +1016,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
       },
       "coingecko_id": "darcmatter-coin",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native staking and governance token of the Umee Network.",
@@ -984,7 +1046,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
       },
       "coingecko_id": "umee",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Gravity Bridge",
@@ -1013,7 +1077,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
       },
       "coingecko_id": "graviton",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token cw20 for Neta on Juno Chain",
@@ -1045,8 +1111,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
       },
-      "coingecko_id": "neta",
-      "verified": true
+      "coingecko_id": "neta"
     },
     {
       "description": "The native token cw20 for Marble DAO on Juno Chain",
@@ -1078,8 +1143,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
       },
-      "coingecko_id": "marble",
-      "verified": true
+      "coingecko_id": "marble"
     },
     {
       "description": "DEC is the native token of Decentr.",
@@ -1108,7 +1172,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
       },
       "coingecko_id": "decentr",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Carbon",
@@ -1137,7 +1203,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
       },
       "coingecko_id": "switcheo",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Circle's stablecoin on Axelar",
@@ -1166,7 +1234,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uausdc L@3x.png"
       },
       "coingecko_id": "usd-coin",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Wrapped Ether on Axelar",
@@ -1195,7 +1265,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth-wei L@3x.png"
       },
       "coingecko_id": "weth",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Dai stablecoin on Axelar",
@@ -1224,7 +1296,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai-wei L@3x.png"
       },
       "coingecko_id": "dai",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Fetch.ai Chain",
@@ -1253,7 +1327,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
       },
       "coingecko_id": "fetch-ai",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of AssetMantle",
@@ -1281,7 +1357,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
       },
       "coingecko_id": "assetmantle",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Wrapped Bitcoin on Axelar",
@@ -1310,7 +1388,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc-satoshi L@3x.png"
       },
       "coingecko_id": "wrapped-bitcoin",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native staking and governance token of Kava",
@@ -1338,7 +1418,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
       },
       "coingecko_id": "kava",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native EVM, governance and staking token of the Evmos Hub",
@@ -1367,7 +1449,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
       },
       "coingecko_id": "evmos",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The INJ token is the native governance token for the Injective chain.",
@@ -1395,7 +1479,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
       },
       "coingecko_id": "injective-protocol",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Tgrade",
@@ -1423,7 +1509,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
       },
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native staking and governance token of the Kujira chain.",
@@ -1451,7 +1539,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
       },
       "coingecko_id": "kujira",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Chainlink on Axelar",
@@ -1480,7 +1570,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/link-wei L@3x.png"
       },
       "coingecko_id": "chainlink",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Maker on Axelar",
@@ -1509,7 +1601,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/mkr-wei L@3x.png"
       },
       "coingecko_id": "maker",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Wrapped Polkadot on Axelar",
@@ -1541,7 +1635,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dot-planck L@3x.png"
       },
       "coingecko_id": "polkadot",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.",
@@ -1568,7 +1664,9 @@
         "dst_channel": "channel-320",
         "source_denom": "ubld"
       },
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native token of Stride",
@@ -1598,7 +1696,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
       },
       "coingecko_id": "stride",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "Staking derivative stATOM for staked ATOM by Stride",
@@ -1627,7 +1727,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
       },
       "coingecko_id": "stride-staked-atom",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "The native staking and governance token of the Axelar chain",
@@ -1656,7 +1758,9 @@
         "source_denom": "uaxl"
       },
       "coingecko_id": "axelar",
-      "verified": true
+      "keywords": [
+        "verified"
+      ]
     },
     {
       "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -23,7 +23,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
       },
-      "coingecko_id": "osmosis"
+      "coingecko_id": "osmosis",
+      "verified": true
     },
     {
       "denom_units": [
@@ -44,7 +45,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
       },
-      "coingecko_id": "ion"
+      "coingecko_id": "ion",
+      "verified": true
     },
     {
       "description": "The native staking and governance token of the Cosmos Hub.",
@@ -72,7 +74,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
       },
-      "coingecko_id": "cosmos"
+      "coingecko_id": "cosmos",
+      "verified": true
     },
     {
       "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
@@ -100,7 +103,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
       },
-      "coingecko_id": "akash-network"
+      "coingecko_id": "akash-network",
+      "verified": true
     },
     {
       "description": "The XPRT token is primarily a governance token for the Persistence chain.",
@@ -127,7 +131,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png"
       },
-      "coingecko_id": "persistence"
+      "coingecko_id": "persistence",
+      "verified": true
     },
     {
       "description": "The PSTAKE token is primarily a governance token for the Liquid Staking Protocol.",
@@ -154,7 +159,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
       },
-      "coingecko_id": "pstake-finance"
+      "coingecko_id": "pstake-finance",
+      "verified": true
     },
     {
       "description": "The IRIS token is the native governance token for the IrisNet chain.",
@@ -181,7 +187,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png"
       },
-      "coingecko_id": "iris-network"
+      "coingecko_id": "iris-network",
+      "verified": true
     },
     {
       "description": "DVPN is the native token of the Sentinel Hub.",
@@ -208,7 +215,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
       },
-      "coingecko_id": "sentinel"
+      "coingecko_id": "sentinel",
+      "verified": true
     },
     {
       "description": "CRO coin is the token for the Crypto.com platform.",
@@ -235,7 +243,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png"
       },
-      "coingecko_id": "crypto-com-chain"
+      "coingecko_id": "crypto-com-chain",
+      "verified": true
     },
     {
       "description": "Wrapped BNB on Axelar",
@@ -264,7 +273,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
       },
-      "coingecko_id": "wbnb"
+      "coingecko_id": "wbnb",
+      "verified": true
     },
     {
       "description": "REGEN coin is the token for the Regen Network Platform",
@@ -291,7 +301,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
       },
-      "coingecko_id": "regen"
+      "coingecko_id": "regen",
+      "verified": true
     },
     {
       "description": "IOV coin is the token for the Starname (IOV) Asset Name Service",
@@ -319,7 +330,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
       },
-      "coingecko_id": "starname"
+      "coingecko_id": "starname",
+      "verified": true
     },
     {
       "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
@@ -347,7 +359,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
       },
-      "coingecko_id": "e-money"
+      "coingecko_id": "e-money",
+      "verified": true
     },
     {
       "description": "e-Money EUR stablecoin. Audited and backed by fiat EUR deposits and government bonds.",
@@ -374,7 +387,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
       },
-      "coingecko_id": "e-money-eur"
+      "coingecko_id": "e-money-eur",
+      "verified": true
     },
     {
       "description": "The BCNA coin is the transactional token within the BitCanna network, serving the legal cannabis industry through its payment network, supply chain and trust network.",
@@ -402,7 +416,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
       },
-      "coingecko_id": "bitcanna"
+      "coingecko_id": "bitcanna",
+      "verified": true
     },
     {
       "description": "The native token of JUNO Chain",
@@ -430,7 +445,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
       },
-      "coingecko_id": "juno-network"
+      "coingecko_id": "juno-network",
+      "verified": true
     },
     {
       "description": "The native token of IXO Chain",
@@ -457,7 +473,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
       },
-      "coingecko_id": "ixo"
+      "coingecko_id": "ixo",
+      "verified": true
     },
     {
       "description": "LIKE is the native staking and governance token of LikeCoin chain, a Decentralized Publishing Infrastructure to empower content ownership, authenticity, and provenance.",
@@ -485,7 +502,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
       },
-      "coingecko_id": "likecoin"
+      "coingecko_id": "likecoin",
+      "verified": true
     },
     {
       "description": "BitSong Native Token",
@@ -513,7 +531,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
       },
-      "coingecko_id": "bitsong"
+      "coingecko_id": "bitsong",
+      "verified": true
     },
     {
       "description": "The native token of Ki Chain",
@@ -541,7 +560,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
       },
-      "coingecko_id": "ki"
+      "coingecko_id": "ki",
+      "verified": true
     },
     {
       "description": "The native token of Secret Network",
@@ -569,7 +589,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
       },
-      "coingecko_id": "secret"
+      "coingecko_id": "secret",
+      "verified": true
     },
     {
       "description": "Panacea is a public blockchain launched by MediBloc, which is the key infrastructure for reinventing the patient-centered healthcare data ecosystem",
@@ -596,7 +617,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
       },
-      "coingecko_id": "medibloc"
+      "coingecko_id": "medibloc",
+      "verified": true
     },
     {
       "description": "The staking token of Bostrom",
@@ -619,7 +641,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
       },
-      "coingecko_id": "bostrom"
+      "coingecko_id": "bostrom",
+      "verified": true
     },
     {
       "description": "Native Token of Comdex Protocol",
@@ -646,7 +669,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
       },
-      "coingecko_id": "comdex"
+      "coingecko_id": "comdex",
+      "verified": true
     },
     {
       "description": "Native token for the cheqd network",
@@ -674,7 +698,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
       },
-      "coingecko_id": "cheqd-network"
+      "coingecko_id": "cheqd-network",
+      "verified": true
     },
     {
       "description": "The native token of Stargaze",
@@ -701,7 +726,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
       },
-      "coingecko_id": "stargaze"
+      "coingecko_id": "stargaze",
+      "verified": true
     },
     {
       "description": "Native token of the Lum Network",
@@ -728,7 +754,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
       },
-      "coingecko_id": "lum-network"
+      "coingecko_id": "lum-network",
+      "verified": true
     },
     {
       "description": "The native token of Chihuahua Chain",
@@ -755,7 +782,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png"
       },
-      "coingecko_id": "chihuahua-token"
+      "coingecko_id": "chihuahua-token",
+      "verified": true
     },
     {
       "description": "The native token of Vidulum",
@@ -783,7 +811,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
       },
-      "coingecko_id": "vidulum"
+      "coingecko_id": "vidulum",
+      "verified": true
     },
     {
       "description": "The native token of Desmos",
@@ -811,7 +840,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
       },
-      "coingecko_id": "desmos"
+      "coingecko_id": "desmos",
+      "verified": true
     },
     {
       "description": "The native token of Dig Chain.",
@@ -838,34 +868,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
       },
-      "coingecko_id": "dig-chain"
-    },
-    {
-      "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
-      "denom_units": [
-        {
-          "denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-          "exponent": 0
-        },
-        {
-          "denom": "rowan",
-          "exponent": 18
-        }
-      ],
-      "base": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-      "name": "Sifchain Rowan",
-      "display": "rowan",
-      "symbol": "ROWAN",
-      "ibc": {
-        "source_channel": "channel-17",
-        "dst_channel": "channel-47",
-        "source_denom": "rowan"
-      },
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
-      },
-      "coingecko_id": "sifchain"
+      "coingecko_id": "dig-chain",
+      "verified": true
     },
     {
       "description": "The native token of Sommelier Chain.",
@@ -893,7 +897,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
       },
-      "coingecko_id": "sommelier"
+      "coingecko_id": "sommelier",
+      "verified": true
     },
     {
       "description": "The native token of BandChain",
@@ -921,7 +926,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
       },
-      "coingecko_id": "band-protocol"
+      "coingecko_id": "band-protocol",
+      "verified": true
     },
     {
       "description": "The native staking and governance token of the Konstellation Network.",
@@ -949,7 +955,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
       },
-      "coingecko_id": "darcmatter-coin"
+      "coingecko_id": "darcmatter-coin",
+      "verified": true
     },
     {
       "description": "The native staking and governance token of the Umee Network.",
@@ -976,7 +983,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
       },
-      "coingecko_id": "umee"
+      "coingecko_id": "umee",
+      "verified": true
     },
     {
       "description": "The native token of Gravity Bridge",
@@ -1004,7 +1012,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
       },
-      "coingecko_id": "graviton"
+      "coingecko_id": "graviton",
+      "verified": true
     },
     {
       "description": "The native token cw20 for Neta on Juno Chain",
@@ -1036,7 +1045,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
       },
-      "coingecko_id": "neta"
+      "coingecko_id": "neta",
+      "verified": true
     },
     {
       "description": "The native token cw20 for Marble DAO on Juno Chain",
@@ -1068,7 +1078,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
       },
-      "coingecko_id": "marble"
+      "coingecko_id": "marble",
+      "verified": true
     },
     {
       "description": "DEC is the native token of Decentr.",
@@ -1096,7 +1107,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
       },
-      "coingecko_id": "decentr"
+      "coingecko_id": "decentr",
+      "verified": true
     },
     {
       "description": "The native token of Carbon",
@@ -1124,7 +1136,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
       },
-      "coingecko_id": "switcheo"
+      "coingecko_id": "switcheo",
+      "verified": true
     },
     {
       "description": "Circle's stablecoin on Axelar",
@@ -1152,7 +1165,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uausdc L@3x.png"
       },
-      "coingecko_id": "usd-coin"
+      "coingecko_id": "usd-coin",
+      "verified": true
     },
     {
       "description": "Wrapped Ether on Axelar",
@@ -1180,7 +1194,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth-wei L@3x.png"
       },
-      "coingecko_id": "weth"
+      "coingecko_id": "weth",
+      "verified": true
     },
     {
       "description": "Dai stablecoin on Axelar",
@@ -1208,34 +1223,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai-wei L@3x.png"
       },
-      "coingecko_id": "dai"
-    },
-    {
-      "description": "The native token of Cerberus",
-      "denom_units": [
-        {
-          "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-          "exponent": 0,
-          "aliases": ["ucrbrus"]
-        },
-        {
-          "denom": "crbrus",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-      "name": "Cerberus",
-      "display": "crbrus",
-      "symbol": "CRBRUS",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-212",
-        "source_denom": "ucrbrus"
-      },
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
-      },
-      "coingecko_id": "cerberus-2"
+      "coingecko_id": "dai",
+      "verified": true
     },
     {
       "description": "The native token of Fetch.ai Chain",
@@ -1263,7 +1252,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
       },
-      "coingecko_id": "fetch-ai"
+      "coingecko_id": "fetch-ai",
+      "verified": true
     },
     {
       "description": "The native token of AssetMantle",
@@ -1290,7 +1280,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
       },
-      "coingecko_id": "assetmantle"
+      "coingecko_id": "assetmantle",
+      "verified": true
     },
     {
       "description": "Wrapped Bitcoin on Axelar",
@@ -1318,7 +1309,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc-satoshi L@3x.png"
       },
-      "coingecko_id": "wrapped-bitcoin"
+      "coingecko_id": "wrapped-bitcoin",
+      "verified": true
     },
     {
       "description": "The native staking and governance token of Kava",
@@ -1345,7 +1337,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
       },
-      "coingecko_id": "kava"
+      "coingecko_id": "kava",
+      "verified": true
     },
     {
       "description": "The native EVM, governance and staking token of the Evmos Hub",
@@ -1373,7 +1366,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
       },
-      "coingecko_id": "evmos"
+      "coingecko_id": "evmos",
+      "verified": true
     },
     {
       "description": "The INJ token is the native governance token for the Injective chain.",
@@ -1400,7 +1394,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
       },
-      "coingecko_id": "injective-protocol"
+      "coingecko_id": "injective-protocol",
+      "verified": true
     },
     {
       "description": "The native token of Tgrade",
@@ -1427,7 +1422,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
-      }
+      },
+      "verified": true
     },
     {
       "description": "The native staking and governance token of the Kujira chain.",
@@ -1454,7 +1450,37 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
       },
-      "coingecko_id": "kujira"
+      "coingecko_id": "kujira",
+      "verified": true
+    },
+    {
+      "description": "Chainlink on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+          "exponent": 0,
+          "aliases": ["link-wei"]
+        },
+        {
+          "denom": "axllink",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+      "name": "Chainlink",
+      "display": "axllink",
+      "symbol": "LINK.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "link-wei"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/link-wei L@3x.png"
+      },
+      "coingecko_id": "chainlink",
+      "verified": true
     },
     {
       "description": "Maker on Axelar",
@@ -1482,7 +1508,8 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/mkr-wei L@3x.png"
       },
-      "coingecko_id": "maker"
+      "coingecko_id": "maker",
+      "verified": true
     },
     {
       "description": "Wrapped Polkadot on Axelar",
@@ -1513,7 +1540,8 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dot-planck L@3x.png"
       },
-      "coingecko_id": "polkadot"
+      "coingecko_id": "polkadot",
+      "verified": true
     },
     {
       "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.",
@@ -1539,7 +1567,38 @@
         "source_channel": "channel-1",
         "dst_channel": "channel-320",
         "source_denom": "ubld"
-      }
+      },
+      "verified": true
+    },
+    {
+      "description": "The native token of Stride",
+      "denom_units": [
+        {
+          "denom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+          "exponent": 0,
+          "aliases": ["ustrd"]
+        },
+        {
+          "denom": "strd",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "base": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+      "name": "Stride",
+      "display": "strd",
+      "symbol": "STRD",
+      "ibc": {
+        "source_channel": "channel-5",
+        "dst_channel": "channel-326",
+        "source_denom": "ustrd"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
+      },
+      "coingecko_id": "stride",
+      "verified": true
     },
     {
       "description": "Staking derivative stATOM for staked ATOM by Stride",
@@ -1567,7 +1626,1623 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
       },
-      "coingecko_id": "stride-staked-atom"
+      "coingecko_id": "stride-staked-atom",
+      "verified": true
+    },
+    {
+      "description": "The native staking and governance token of the Axelar chain",
+      "denom_units": [
+        {
+          "denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+          "exponent": 0,
+          "aliases": ["uaxl"]
+        },
+        {
+          "denom": "axl",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+      "name": "Axelar",
+      "display": "axl",
+      "symbol": "AXL",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.png",
+        "svg": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg"
+      },
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "uaxl"
+      },
+      "coingecko_id": "axelar",
+      "verified": true
+    },
+    {
+      "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",
+      "denom_units": [
+        {
+          "denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+          "exponent": 0,
+          "aliases": ["utick"]
+        },
+        {
+          "denom": "tick",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+      "display": "tick",
+      "name": "Microtick",
+      "symbol": "TICK",
+      "ibc": {
+        "source_channel": "channel-16",
+        "dst_channel": "channel-39",
+        "source_denom": "utick"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
+      },
+      "coingecko_id": "microtick"
+    },
+    {
+      "description": "The native staking token of Terra Classic.",
+      "denom_units": [
+        {
+          "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+          "exponent": 0,
+          "aliases": ["ulunc"]
+        },
+        {
+          "denom": "lunc",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "name": "Luna Classic",
+      "display": "lunc",
+      "symbol": "LUNC",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-72",
+        "source_denom": "uluna"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
+      },
+      "coingecko_id": "terra-luna"
+    },
+    {
+      "description": "The USD stablecoin of Terra Classic.",
+      "denom_units": [
+        {
+          "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+          "exponent": 0,
+          "aliases": ["uust"]
+        },
+        {
+          "denom": "ust",
+          "exponent": 6,
+          "aliases": ["ustc"]
+        }
+      ],
+      "base": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "name": "TerraClassicUSD",
+      "display": "ust",
+      "symbol": "USTC",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-72",
+        "source_denom": "uust"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
+      },
+      "coingecko_id": "terrausd"
+    },
+    {
+      "description": "The KRW stablecoin of Terra Classic.",
+      "denom_units": [
+        {
+          "denom": "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+          "exponent": 0,
+          "aliases": ["ukrw"]
+        },
+        {
+          "denom": "krt",
+          "exponent": 6,
+          "aliases": ["krtc"]
+        }
+      ],
+      "base": "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+      "name": "TerraClassicKRW",
+      "display": "krt",
+      "symbol": "KRTC",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-72",
+        "source_denom": "ukrw"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png"
+      },
+      "coingecko_id": "terra-krw"
+    },
+    {
+      "description": "The native staking token of Terra 2.0",
+      "denom_units": [
+        {
+          "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+          "exponent": 0,
+          "aliases": ["uluna"]
+        },
+        {
+          "denom": "luna",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "name": "Luna",
+      "display": "luna",
+      "symbol": "LUNA",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-251",
+        "source_denom": "uluna"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
+      },
+      "coingecko_id": "terra-luna-2"
+    },
+    {
+      "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
+      "denom_units": [
+        {
+          "denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+          "exponent": 0
+        },
+        {
+          "denom": "rowan",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+      "name": "Sifchain Rowan",
+      "display": "rowan",
+      "symbol": "ROWAN",
+      "ibc": {
+        "source_channel": "channel-17",
+        "dst_channel": "channel-47",
+        "source_denom": "rowan"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
+      },
+      "coingecko_id": "sifchain"
+    },
+    {
+      "description": "Hope Galaxy is an NFT collection based on its own native Token $HOPE, a cw20 token on Juno chain.",
+      "type_asset": "cw20",
+      "address": "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
+      "denom_units": [
+        {
+          "denom": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
+          ]
+        },
+        {
+          "denom": "hope",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+      "name": "Hope Galaxy",
+      "display": "hope",
+      "symbol": "HOPE",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
+      },
+      "coingecko_id": "hope-galaxy"
+    },
+    {
+      "description": "The native token of Cerberus",
+      "denom_units": [
+        {
+          "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+          "exponent": 0,
+          "aliases": ["ucrbrus"]
+        },
+        {
+          "denom": "crbrus",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "name": "Cerberus",
+      "display": "crbrus",
+      "symbol": "CRBRUS",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-212",
+        "source_denom": "ucrbrus"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
+      },
+      "coingecko_id": "cerberus-2"
+    },
+    {
+      "description": "Racoon aims to simplify accessibility to AI, NFTs and Gambling on the Cosmos Ecosystem",
+      "type_asset": "cw20",
+      "address": "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
+      "denom_units": [
+        {
+          "denom": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
+          ]
+        },
+        {
+          "denom": "rac",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+      "name": "Racoon",
+      "display": "rac",
+      "symbol": "RAC",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
+      },
+      "coingecko_id": "racoon"
+    },
+    {
+      "description": "The DAO token to build consensus among Hong Kong People",
+      "type_asset": "cw20",
+      "address": "juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49",
+      "denom_units": [
+        {
+          "denom": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+          "exponent": 0,
+          "aliases": ["dhk"]
+        }
+      ],
+      "base": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+      "name": "DHK",
+      "display": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+      "symbol": "DHK",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
+      }
+    },
+    {
+      "description": "Tether's USD stablecoin on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+          "exponent": 0,
+          "aliases": ["uusdt"]
+        },
+        {
+          "denom": "axlusdt",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+      "name": "Tether USD",
+      "display": "axlusdt",
+      "symbol": "USDT.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "uusdt"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uusdt L@3x.png"
+      },
+      "coingecko_id": "tether"
+    },
+    {
+      "description": "Frax's fractional-algorithmic stablecoin on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+          "exponent": 0,
+          "aliases": ["frax-wei"]
+        },
+        {
+          "denom": "axlfrax",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+      "name": "Frax",
+      "display": "axlfrax",
+      "symbol": "FRAX.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "frax-wei"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax-wei L@3x.png"
+      },
+      "coingecko_id": "frax"
+    },
+    {
+      "description": "Gravity Bridge ETH",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+          "exponent": 0,
+          "aliases": ["gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
+        },
+        {
+          "denom": "gweth",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "name": "Wrapped Ethereum",
+      "display": "gweth",
+      "symbol": "WETH.grv",
+      "ibc": {
+        "source_channel": "channel-10",
+        "dst_channel": "channel-144",
+        "source_denom": "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
+      },
+      "coingecko_id": "weth"
+    },
+    {
+      "description": "Gravity Bridge WBTC",
+      "denom_units": [
+        {
+          "denom": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+          "exponent": 0,
+          "aliases": ["satoshi"]
+        },
+        {
+          "denom": "gwbtc",
+          "exponent": 8
+        }
+      ],
+      "base": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+      "name": "Wrapped Bitcoin",
+      "display": "gwbtc",
+      "symbol": "WBTC.grv",
+      "ibc": {
+        "source_channel": "channel-10",
+        "dst_channel": "channel-144",
+        "source_denom": "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
+      },
+      "coingecko_id": "wrapped-bitcoin"
+    },
+    {
+      "description": "Gravity Bridge USDC",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+          "exponent": 0,
+          "aliases": ["gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"]
+        },
+        {
+          "denom": "gusdc",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "name": "USD Coin",
+      "display": "gusdc",
+      "symbol": "USDC.grv",
+      "ibc": {
+        "source_channel": "channel-10",
+        "dst_channel": "channel-144",
+        "source_denom": "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.png"
+      },
+      "coingecko_id": "usd-coin"
+    },
+    {
+      "description": "Gravity Bridge Dai",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+          "exponent": 0,
+          "aliases": ["gravity0x6B175474E89094C44Da98b954EedeAC495271d0F"]
+        },
+        {
+          "denom": "gdai",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+      "name": "Dai Stablecoin",
+      "display": "gdai",
+      "symbol": "DAI.grv",
+      "ibc": {
+        "source_channel": "channel-10",
+        "dst_channel": "channel-144",
+        "source_denom": "gravity0x6B175474E89094C44Da98b954EedeAC495271d0F"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.png"
+      },
+      "coingecko_id": "dai"
+    },
+    {
+      "description": "Hash is the staking token of the Provenance Blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+          "exponent": 0,
+          "aliases": ["nhash"]
+        },
+        {
+          "denom": "hash",
+          "exponent": 9
+        }
+      ],
+      "base": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+      "name": "Provenance",
+      "display": "hash",
+      "symbol": "HASH",
+      "ibc": {
+        "source_channel": "channel-7",
+        "dst_channel": "channel-222",
+        "source_denom": "nhash"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg"
+      },
+      "coingecko_id": "provenance-blockchain"
+    },
+    {
+      "description": "GLX is the staking token of the Galaxy Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+          "exponent": 0,
+          "aliases": ["uglx"]
+        },
+        {
+          "denom": "glx",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+      "name": "Galaxy",
+      "display": "glx",
+      "symbol": "GLX",
+      "ibc": {
+        "source_channel": "channel-0",
+        "dst_channel": "channel-236",
+        "source_denom": "uglx"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.svg"
+      }
+    },
+    {
+      "description": "The BLOCK token of Marble DEX on Juno Chain",
+      "type_asset": "cw20",
+      "address": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+      "denom_units": [
+        {
+          "denom": "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq"
+          ]
+        },
+        {
+          "denom": "block",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+      "name": "Block",
+      "display": "block",
+      "symbol": "BLOCK",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
+      }
+    },
+    {
+      "description": "Token governance for Junoswap",
+      "type_asset": "cw20",
+      "address": "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+      "denom_units": [
+        {
+          "denom": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+          ]
+        },
+        {
+          "denom": "raw",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+      "name": "JunoSwap",
+      "display": "raw",
+      "symbol": "RAW",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png"
+      }
+    },
+    {
+      "description": "MEME Token (MEME) is the native staking token of the MEME Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+          "exponent": 0,
+          "aliases": ["umeme"]
+        },
+        {
+          "denom": "meme",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+      "name": "Meme",
+      "display": "meme",
+      "symbol": "MEME",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-238",
+        "source_denom": "umeme"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
+      }
+    },
+    {
+      "description": "Profit sharing token for Another.Software validator. Hold and receive dividends from Another.Software validator commissions!",
+      "type_asset": "cw20",
+      "address": "juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w",
+      "denom_units": [
+        {
+          "denom": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w"
+          ]
+        },
+        {
+          "denom": "asvt",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
+      "name": "Another.Software Validator Token",
+      "display": "asvt",
+      "symbol": "ASVT",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
+      }
+    },
+    {
+      "description": "The native EVM, governance, bridge, and staking token of Echelon",
+      "denom_units": [
+        {
+          "denom": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+          "exponent": 0,
+          "aliases": ["aechelon"]
+        },
+        {
+          "denom": "echelon",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+      "name": "Echelon",
+      "display": "echelon",
+      "symbol": "ECH",
+      "ibc": {
+        "source_channel": "channel-8",
+        "dst_channel": "channel-262",
+        "source_denom": "aechelon"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/logo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
+      },
+      "coingecko_id": "echelon"
+    },
+    {
+      "description": "DAO dedicated to building tools on the Juno Network",
+      "type_asset": "cw20",
+      "address": "juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
+      "denom_units": [
+        {
+          "denom": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
+          ]
+        },
+        {
+          "denom": "joe",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+      "name": "JoeDAO",
+      "display": "joe",
+      "symbol": "JOE",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
+      }
+    },
+    {
+      "description": "L1 coin is the GenesisL1 blockchain utility, governance and EVM token",
+      "denom_units": [
+        {
+          "denom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+          "exponent": 0,
+          "aliases": ["el1"]
+        },
+        {
+          "denom": "l1",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+      "name": "GenesisL1",
+      "display": "l1",
+      "symbol": "L1",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-253",
+        "source_denom": "el1"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
+      }
+    },
+    {
+      "description": "Atolo the native token of Rizon Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+          "exponent": 0,
+          "aliases": ["uatolo"]
+        },
+        {
+          "denom": "atolo",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+      "name": "Atolo",
+      "display": "atolo",
+      "symbol": "ATOLO",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-221",
+        "source_denom": "uatolo"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
+      },
+      "coingecko_id": "rizon"
+    },
+    {
+      "description": "Staking and goverance token for ODIN Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+          "exponent": 0,
+          "aliases": ["loki"]
+        },
+        {
+          "denom": "odin",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+      "name": "ODIN",
+      "display": "odin",
+      "symbol": "ODIN",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-258",
+        "source_denom": "loki"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
+      },
+      "coingecko_id": "odin-protocol"
+    },
+    {
+      "description": "Geo token for ODIN Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+          "exponent": 0,
+          "aliases": ["mGeo"]
+        },
+        {
+          "denom": "geo",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+      "name": "GEO",
+      "display": "geo",
+      "symbol": "GEO",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-258",
+        "source_denom": "mGeo"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
+      }
+    },
+    {
+      "description": "O9W token for ODIN Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+          "exponent": 0,
+          "aliases": ["mO9W"]
+        },
+        {
+          "denom": "O9W",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+      "name": "O9W",
+      "display": "O9W",
+      "symbol": "O9W",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-258",
+        "source_denom": "mO9W"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
+      }
+    },
+    {
+      "description": "The native token of Shentu",
+      "denom_units": [
+        {
+          "denom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+          "exponent": 0,
+          "aliases": ["uctk"]
+        },
+        {
+          "denom": "ctk",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+      "name": "Shentu",
+      "display": "ctk",
+      "symbol": "CTK",
+      "ibc": {
+        "source_channel": "channel-8",
+        "dst_channel": "channel-146",
+        "source_denom": "uctk"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
+      },
+      "coingecko_id": "certik"
+    },
+    {
+      "description": "The native over-collateralized stablecoin from the Kujira chain.",
+      "denom_units": [
+        {
+          "denom": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+          "exponent": 0,
+          "aliases": ["uusk"]
+        },
+        {
+          "denom": "usk",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+      "name": "USK",
+      "display": "USK",
+      "symbol": "USK",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-259",
+        "source_denom": "factory:kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7:uusk"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
+      },
+      "coingecko_id": "usk"
+    },
+    {
+      "description": "Governance token of Kava Lend Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/D6C28E07F7343360AC41E15DDD44D79701DDCA2E0C2C41279739C8D4AE5264BC",
+          "exponent": 0,
+          "aliases": ["hard"]
+        },
+        {
+          "denom": "HARD",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/D6C28E07F7343360AC41E15DDD44D79701DDCA2E0C2C41279739C8D4AE5264BC",
+      "name": "Hard",
+      "display": "HARD",
+      "symbol": "HARD",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-143",
+        "source_denom": "hard"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
+      },
+      "coingecko_id": "kava-lend"
+    },
+    {
+      "description": "Governance token of Kava Swap Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
+          "exponent": 0,
+          "aliases": ["swp"]
+        },
+        {
+          "denom": "SWP",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
+      "name": "Swap",
+      "display": "SWP",
+      "symbol": "SWP",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-143",
+        "source_denom": "swp"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
+      },
+      "coingecko_id": "kava-swap"
+    },
+    {
+      "description": "The native stablecoin of Kava",
+      "denom_units": [
+        {
+          "denom": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+          "exponent": 0,
+          "aliases": ["usdx"]
+        },
+        {
+          "denom": "USDX",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+      "name": "USDX",
+      "display": "USDX",
+      "symbol": "USDX",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-143",
+        "source_denom": "usdx"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png"
+      },
+      "coingecko_id": "usdx"
+    },
+    {
+      "description": "Gravity Bridge USDT",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+          "exponent": 0,
+          "aliases": ["gravity0xdAC17F958D2ee523a2206206994597C13D831ec7"]
+        },
+        {
+          "denom": "gusdt",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+      "name": "Tether USD",
+      "display": "gusdt",
+      "symbol": "USDT.grv",
+      "ibc": {
+        "source_channel": "channel-10",
+        "dst_channel": "channel-144",
+        "source_denom": "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
+      },
+      "coingecko_id": "tether"
+    },
+    {
+      "description": "Aave on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+          "exponent": 0,
+          "aliases": ["aave-wei"]
+        },
+        {
+          "denom": "axlaave",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+      "name": "Aave",
+      "display": "axlaave",
+      "symbol": "AAVE.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "aave-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave-wei L@3x.png"
+      },
+      "coingecko_id": "aave"
+    },
+    {
+      "description": "ApeCoin on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
+          "exponent": 0,
+          "aliases": ["ape-wei"]
+        },
+        {
+          "denom": "axlape",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
+      "name": "ApeCoin",
+      "display": "axlape",
+      "symbol": "APE.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "ape-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape-wei L@3x.png"
+      },
+      "coingecko_id": "apecoin"
+    },
+    {
+      "description": "Axie Infinity Shard on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
+          "exponent": 0,
+          "aliases": ["axs-wei"]
+        },
+        {
+          "denom": "axlaxs",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
+      "name": "Axie Infinity Shard",
+      "display": "axlaxs",
+      "symbol": "AXS.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "axs-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs-wei L@3x.png"
+      },
+      "coingecko_id": "axie-infinity"
+    },
+    {
+      "description": "Rai Reflex Index on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
+          "exponent": 0,
+          "aliases": ["rai-wei"]
+        },
+        {
+          "denom": "axlrai",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
+      "name": "Rai Reflex Index",
+      "display": "axlrai",
+      "symbol": "RAI.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "rai-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai-wei L@3x.png"
+      },
+      "coingecko_id": "rai"
+    },
+    {
+      "description": "Shiba Inu on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+          "exponent": 0,
+          "aliases": ["shib-wei"]
+        },
+        {
+          "denom": "axlshib",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+      "name": "Shiba Inu",
+      "display": "axlshib",
+      "symbol": "SHIB.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "shib-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib-wei L@3x.png"
+      },
+      "coingecko_id": "shiba-inu"
+    },
+    {
+      "description": "Uniswap on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
+          "exponent": 0,
+          "aliases": ["uni-wei"]
+        },
+        {
+          "denom": "axluni",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
+      "name": "Uniswap",
+      "display": "axluni",
+      "symbol": "UNI.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "uni-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni-wei L@3x.png"
+      },
+      "coingecko_id": "uniswap"
+    },
+    {
+      "description": "Chain on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
+          "exponent": 0,
+          "aliases": ["xcn-wei"]
+        },
+        {
+          "denom": "axlxcn",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
+      "name": "Chain",
+      "display": "axlxcn",
+      "symbol": "XCN.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "xcn-wei"
+      },
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn-wei L@3x.png"
+      },
+      "coingecko_id": "chain-2"
+    },
+    {
+      "description": "ELEVENPARIS loyalty token on KiChain",
+      "type_asset": "cw20",
+      "address": "ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
+      "denom_units": [
+        {
+          "denom": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+          "exponent": 0,
+          "aliases": [
+            "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
+            "ulvn"
+          ]
+        },
+        {
+          "denom": "lvn",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+      "name": "Lvn",
+      "display": "lvn",
+      "symbol": "LVN",
+      "ibc": {
+        "source_channel": "channel-18",
+        "dst_channel": "channel-261",
+        "source_denom": "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
+      },
+      "coingecko_id": "lvn"
+    },
+    {
+      "description": "Wrapped GLMR on Axelar",
+      "type_asset": "erc20",
+      "denom_units": [
+        {
+          "denom": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+          "exponent": 0,
+          "aliases": ["wglmr-wei", "0xacc15dc74880c9944775448304b263d191c6077f"]
+        },
+        {
+          "denom": "axlwglmr",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+      "name": "Wrapped GLMR",
+      "display": "axlwglmr",
+      "symbol": "WGLMR.axl",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-208",
+        "source_denom": "wglmr-wei"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wdev-wei.png"
+      },
+      "coingecko_id": "wrapped-moonbeam"
+    },
+    {
+      "description": "DeFi gaming platform built on Juno",
+      "type_asset": "cw20",
+      "address": "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
+      "denom_units": [
+        {
+          "denom": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
+          ]
+        },
+        {
+          "denom": "glto",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+      "name": "Gelotto",
+      "display": "glto",
+      "symbol": "GLTO",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png"
+      }
+    },
+    {
+      "description": "Gelotto Year 1 Grand Prize Token",
+      "type_asset": "cw20",
+      "address": "juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
+      "denom_units": [
+        {
+          "denom": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh"
+          ]
+        },
+        {
+          "denom": "gkey",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+      "name": "GKey",
+      "display": "gkey",
+      "symbol": "GKEY",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png"
+      }
+    },
+    {
+      "description": "CRE is the native token of the Crescent Network.",
+      "denom_units": [
+        {
+          "denom": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+          "exponent": 0,
+          "aliases": ["ucre"]
+        },
+        {
+          "denom": "cre",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+      "name": "Crescent",
+      "display": "cre",
+      "symbol": "CRE",
+      "ibc": {
+        "source_channel": "channel-9",
+        "dst_channel": "channel-297",
+        "source_denom": "ucre"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
+      },
+      "coingecko_id": "crescent-network"
+    },
+    {
+      "description": "The native token of Lumen Network",
+      "denom_units": [
+        {
+          "denom": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+          "exponent": 0,
+          "aliases": ["ulumen"]
+        },
+        {
+          "denom": "lumen",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+      "name": "LumenX",
+      "display": "lumen",
+      "symbol": "LUMEN",
+      "ibc": {
+        "source_channel": "channel-3",
+        "dst_channel": "channel-286",
+        "source_denom": "ulumen"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png"
+      }
+    },
+    {
+      "description": "The native token of Oraichain",
+      "denom_units": [
+        {
+          "denom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+          "exponent": 0,
+          "aliases": ["orai"]
+        },
+        {
+          "denom": "ORAI",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+      "name": "Oraichain",
+      "display": "ORAI",
+      "symbol": "ORAI",
+      "ibc": {
+        "source_channel": "channel-13",
+        "dst_channel": "channel-216",
+        "source_denom": "orai"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
+      },
+      "coingecko_id": "oraichain-token"
+    },
+    {
+      "description": "IST is a decentralized and fully collateralized stable token built for the Cosmos ecosystem.",
+      "denom_units": [
+        {
+          "denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+          "exponent": 0,
+          "aliases": ["uist"]
+        },
+        {
+          "denom": "ist",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "name": "Inter Protocol USD",
+      "display": "ist",
+      "symbol": "IST",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-320",
+        "source_denom": "uist"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
+      }
+    }, 
+    {
+      "description": "The native token of the Cudos blockchain",
+      "denom_units": [
+        {
+          "denom": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+          "exponent": 0,
+          "aliases": ["acudos"]
+        },
+        {
+          "denom": "cudos",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+      "name": "Cudos",
+      "display": "cudos",
+      "symbol": "CUDOS",
+      "ibc": {
+        "source_channel": "channel-1",
+        "dst_channel": "channel-298",
+        "source_denom": "acudos"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
+      },
+      "coingecko_id": "cudos"
+    },
+    {
+      "description": "Staking derivative seJUNO for staked JUNO",
+      "type_asset": "cw20",
+      "address": "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "denom_units": [
+        {
+          "denom": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+          ]
+        },
+        {
+          "denom": "sejuno",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+      "name": "StakeEasy seJUNO",
+      "display": "sejuno",
+      "symbol": "seJUNO",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
+      }
+    },
+    {
+      "description": "Staking derivative bJUNO for staked JUNO",
+      "type_asset": "cw20",
+      "address": "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "denom_units": [
+        {
+          "denom": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
+          ]
+        },
+        {
+          "denom": "bjuno",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+      "name": "StakeEasy bJUNO",
+      "display": "bjuno",
+      "symbol": "bJUNO",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
+      }
+    },
+    {
+      "description": "Staking derivative stSTARS for staked STARS by Stride",
+      "denom_units": [
+        {
+          "denom": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+          "exponent": 0,
+          "aliases": ["stustars"]
+        },
+        {
+          "denom": "ststars",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+      "name": "Stride Staked Stars",
+      "display": "ststars",
+      "symbol": "stSTARS",
+      "ibc": {
+        "source_channel": "channel-5",
+        "dst_channel": "channel-326",
+        "source_denom": "stustars"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
+      }
+    },
+    {
+      "description": "Solarbank DAO Governance Token for speeding up the shift to renewable and green energy",
+      "type_asset": "cw20",
+      "address": "juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse",
+      "denom_units": [
+        {
+          "denom": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse"
+          ]
+        },
+        {
+          "denom": "solar",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+      "name": "Solarbank DAO",
+      "display": "solar",
+      "symbol": "SOLAR",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
+      }
+    },
+    {
+      "description": "StakeEasy governance token",
+      "type_asset": "cw20",
+      "address": "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+      "denom_units": [
+        {
+          "denom": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
+          ]
+        },
+        {
+          "denom": "seasy",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+      "name": "StakeEasy SEASY",
+      "display": "seasy",
+      "symbol": "SEASY",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
+      }
     },
     {
       "description": "The native staking and governance token of the Axelar chain",
@@ -1596,6 +3271,230 @@
         "source_denom": "uaxl"
       },
       "coingecko_id": "axelar"
+    },
+    {
+      "description": "REBUS coin is the token for the Rebuschain Platform",
+      "denom_units": [
+        {
+          "denom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+          "exponent": 0,
+          "aliases": ["arebus"]
+        },
+        {
+          "denom": "rebus",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+      "name": "Rebuschain",
+      "display": "rebus",
+      "symbol": "REBUS",
+      "ibc": {
+        "source_channel": "channel-0",
+        "dst_channel": "channel-355",
+        "source_denom": "arebus"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
+      },
+      "coingecko_id": "rebus"
+    },
+    {
+      "description": "The native staking and governance token of the Teritori chain",
+      "denom_units": [
+        {
+          "denom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+          "exponent": 0,
+          "aliases": ["utori"]
+        },
+        {
+          "denom": "tori",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+      "name": "teritori",
+      "display": "tori",
+      "symbol": "TORI",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/tori.svg"
+      },
+      "ibc": {
+        "source_channel": "channel-0",
+        "dst_channel": "channel-362",
+        "source_denom": "utori"
+      },
+      "coingecko_id": ""
+    },
+    {
+      "description": "Staking derivative stJUNO for staked JUNO by Stride",
+      "denom_units": [
+        {
+          "denom": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+          "exponent": 0,
+          "aliases": ["stujuno"]
+        },
+        {
+          "denom": "stjuno",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+      "name": "Stride Juno",
+      "display": "stjuno",
+      "symbol": "stJUNO",
+      "ibc": {
+        "source_channel": "channel-5",
+        "dst_channel": "channel-326",
+        "source_denom": "stujuno"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
+      }
+    },
+    {
+      "description": "The native token of Lambda",
+      "denom_units": [
+        {
+          "denom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+          "exponent": 0,
+          "aliases": ["ulamb"]
+        },
+        {
+          "denom": "lamb",
+          "exponent": 18
+        }
+      ],
+      "base": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+      "name": "Lambda",
+      "display": "lamb",
+      "symbol": "LAMB",
+      "ibc": {
+        "source_channel": "channel-2",
+        "dst_channel": "channel-378",
+        "source_denom": "ulamb"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
+      },
+      "coingecko_id": "lambda"
+    },
+    {
+      "description": "MUSE Governance Token",
+      "type_asset": "cw20",
+      "address": "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
+      "denom_units": [
+        {
+          "denom": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
+          "exponent": 0,
+          "aliases": [
+            "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
+          ]
+        },
+        {
+          "denom": "muse",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
+      "name": "MUSE",
+      "display": "muse",
+      "symbol": "MUSE",
+      "ibc": {
+        "source_channel": "channel-47",
+        "dst_channel": "channel-169",
+        "source_denom": "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
+      }
+    },
+    {
+      "description": "The native staking and governance coin of the Unification Blockchain.",
+      "denom_units": [
+        {
+          "denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+          "exponent": 0,
+          "aliases": ["nund"]
+        },
+        {
+          "denom": "fund",
+          "exponent": 9
+        }
+      ],
+      "base": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+      "name": "Unification",
+      "display": "fund",
+      "symbol": "FUND",
+      "ibc": {
+        "source_channel": "channel-0",
+        "dst_channel": "channel-382",
+        "source_denom": "nund"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
+      },
+      "coingecko_id": "unification"
+    },
+    {
+      "description": "Jackal Native Token",
+      "denom_units": [
+        {
+          "denom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+          "exponent": 0,
+          "aliases": ["ujkl"]
+        },
+        {
+          "denom": "jkl",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+      "name": "Jackal",
+      "display": "jkl",
+      "symbol": "JKL",
+      "ibc": {
+        "source_channel": "channel-0",
+        "dst_channel": "channel-412",
+        "source_denom": "ujkl"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
+
+      },
+      "coingecko_id": ""
+    },
+    {
+      "description": "Staking derivative stOSMO for staked OSMO by Stride",
+      "denom_units": [
+        {
+          "denom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+          "exponent": 0,
+          "aliases": ["stuosmo"]
+        },
+        {
+          "denom": "stosmo",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+      "name": "Stride Staked osmo",
+      "display": "stosmo",
+      "symbol": "stOSMO",
+      "ibc": {
+        "source_channel": "channel-5",
+        "dst_channel": "channel-326",
+        "source_denom": "stuosmo"
+      },
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
+      },
+      "coingecko_id": "stride-staked-osmo"
     }
   ]
 }

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -25,7 +25,7 @@
       },
       "coingecko_id": "osmosis",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -49,7 +49,7 @@
       },
       "coingecko_id": "ion",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -80,7 +80,7 @@
       },
       "coingecko_id": "cosmos",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -111,7 +111,7 @@
       },
       "coingecko_id": "akash-network",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -141,7 +141,7 @@
       },
       "coingecko_id": "persistence",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -171,7 +171,7 @@
       },
       "coingecko_id": "pstake-finance",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -201,7 +201,7 @@
       },
       "coingecko_id": "iris-network",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -231,7 +231,7 @@
       },
       "coingecko_id": "sentinel",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -261,7 +261,7 @@
       },
       "coingecko_id": "crypto-com-chain",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -293,7 +293,7 @@
       },
       "coingecko_id": "wbnb",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -323,7 +323,7 @@
       },
       "coingecko_id": "regen",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -354,7 +354,7 @@
       },
       "coingecko_id": "starname",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -385,7 +385,7 @@
       },
       "coingecko_id": "e-money",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -415,7 +415,7 @@
       },
       "coingecko_id": "e-money-eur",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -446,7 +446,7 @@
       },
       "coingecko_id": "bitcanna",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -477,7 +477,7 @@
       },
       "coingecko_id": "juno-network",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -505,7 +505,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
       },
-      "coingecko_id": "ixo"
+      "coingecko_id": "ixo",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "LIKE is the native staking and governance token of LikeCoin chain, a Decentralized Publishing Infrastructure to empower content ownership, authenticity, and provenance.",
@@ -535,7 +538,7 @@
       },
       "coingecko_id": "likecoin",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -566,7 +569,7 @@
       },
       "coingecko_id": "bitsong",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -597,7 +600,7 @@
       },
       "coingecko_id": "ki",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -628,7 +631,7 @@
       },
       "coingecko_id": "secret",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -658,7 +661,7 @@
       },
       "coingecko_id": "medibloc",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -682,7 +685,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
       },
-      "coingecko_id": "bostrom"
+      "coingecko_id": "bostrom",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Native Token of Comdex Protocol",
@@ -711,7 +717,7 @@
       },
       "coingecko_id": "comdex",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -742,7 +748,7 @@
       },
       "coingecko_id": "cheqd-network",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -772,7 +778,7 @@
       },
       "coingecko_id": "stargaze",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -802,7 +808,7 @@
       },
       "coingecko_id": "lum-network",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -832,7 +838,7 @@
       },
       "coingecko_id": "chihuahua-token",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -863,7 +869,7 @@
       },
       "coingecko_id": "vidulum",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -894,7 +900,7 @@
       },
       "coingecko_id": "desmos",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -924,7 +930,7 @@
       },
       "coingecko_id": "dig-chain",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -955,7 +961,7 @@
       },
       "coingecko_id": "sommelier",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -986,7 +992,7 @@
       },
       "coingecko_id": "band-protocol",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1017,7 +1023,7 @@
       },
       "coingecko_id": "darcmatter-coin",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1047,7 +1053,7 @@
       },
       "coingecko_id": "umee",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1078,7 +1084,7 @@
       },
       "coingecko_id": "graviton",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1111,7 +1117,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
       },
-      "coingecko_id": "neta"
+      "coingecko_id": "neta",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native token cw20 for Marble DAO on Juno Chain",
@@ -1143,7 +1152,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
       },
-      "coingecko_id": "marble"
+      "coingecko_id": "marble",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "DEC is the native token of Decentr.",
@@ -1173,7 +1185,7 @@
       },
       "coingecko_id": "decentr",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1204,7 +1216,7 @@
       },
       "coingecko_id": "switcheo",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1235,7 +1247,7 @@
       },
       "coingecko_id": "usd-coin",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1266,7 +1278,7 @@
       },
       "coingecko_id": "weth",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1297,7 +1309,7 @@
       },
       "coingecko_id": "dai",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1328,7 +1340,7 @@
       },
       "coingecko_id": "fetch-ai",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1358,7 +1370,7 @@
       },
       "coingecko_id": "assetmantle",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1389,7 +1401,7 @@
       },
       "coingecko_id": "wrapped-bitcoin",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1419,7 +1431,7 @@
       },
       "coingecko_id": "kava",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1450,7 +1462,7 @@
       },
       "coingecko_id": "evmos",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1480,7 +1492,7 @@
       },
       "coingecko_id": "injective-protocol",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1510,7 +1522,7 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
       },
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1540,7 +1552,7 @@
       },
       "coingecko_id": "kujira",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1571,7 +1583,7 @@
       },
       "coingecko_id": "chainlink",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1602,7 +1614,7 @@
       },
       "coingecko_id": "maker",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1636,7 +1648,7 @@
       },
       "coingecko_id": "polkadot",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1665,7 +1677,7 @@
         "source_denom": "ubld"
       },
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1697,7 +1709,7 @@
       },
       "coingecko_id": "stride",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1728,7 +1740,7 @@
       },
       "coingecko_id": "stride-staked-atom",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1759,7 +1771,7 @@
       },
       "coingecko_id": "axelar",
       "keywords": [
-        "verified"
+        "osmosis-main"
       ]
     },
     {
@@ -1788,7 +1800,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
       },
-      "coingecko_id": "microtick"
+      "coingecko_id": "microtick",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native staking token of Terra Classic.",
@@ -1816,7 +1831,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
       },
-      "coingecko_id": "terra-luna"
+      "coingecko_id": "terra-luna",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The USD stablecoin of Terra Classic.",
@@ -1844,7 +1862,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
       },
-      "coingecko_id": "terrausd"
+      "coingecko_id": "terrausd",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The KRW stablecoin of Terra Classic.",
@@ -1872,7 +1893,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png"
       },
-      "coingecko_id": "terra-krw"
+      "coingecko_id": "terra-krw",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native staking token of Terra 2.0",
@@ -1899,7 +1923,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
       },
-      "coingecko_id": "terra-luna-2"
+      "coingecko_id": "terra-luna-2",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
@@ -1926,7 +1953,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
       },
-      "coingecko_id": "sifchain"
+      "coingecko_id": "sifchain",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Hope Galaxy is an NFT collection based on its own native Token $HOPE, a cw20 token on Juno chain.",
@@ -1958,7 +1988,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
       },
-      "coingecko_id": "hope-galaxy"
+      "coingecko_id": "hope-galaxy",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native token of Cerberus",
@@ -1985,7 +2018,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
       },
-      "coingecko_id": "cerberus-2"
+      "coingecko_id": "cerberus-2",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Racoon aims to simplify accessibility to AI, NFTs and Gambling on the Cosmos Ecosystem",
@@ -2017,7 +2053,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
       },
-      "coingecko_id": "racoon"
+      "coingecko_id": "racoon",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The DAO token to build consensus among Hong Kong People",
@@ -2042,7 +2081,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Tether's USD stablecoin on Axelar",
@@ -2070,7 +2112,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uusdt L@3x.png"
       },
-      "coingecko_id": "tether"
+      "coingecko_id": "tether",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Frax's fractional-algorithmic stablecoin on Axelar",
@@ -2098,7 +2143,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax-wei L@3x.png"
       },
-      "coingecko_id": "frax"
+      "coingecko_id": "frax",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Gravity Bridge ETH",
@@ -2126,7 +2174,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
       },
-      "coingecko_id": "weth"
+      "coingecko_id": "weth",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Gravity Bridge WBTC",
@@ -2153,7 +2204,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
       },
-      "coingecko_id": "wrapped-bitcoin"
+      "coingecko_id": "wrapped-bitcoin",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Gravity Bridge USDC",
@@ -2181,7 +2235,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.png"
       },
-      "coingecko_id": "usd-coin"
+      "coingecko_id": "usd-coin",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Gravity Bridge Dai",
@@ -2209,7 +2266,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.png"
       },
-      "coingecko_id": "dai"
+      "coingecko_id": "dai",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Hash is the staking token of the Provenance Blockchain",
@@ -2237,7 +2297,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg"
       },
-      "coingecko_id": "provenance-blockchain"
+      "coingecko_id": "provenance-blockchain",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "GLX is the staking token of the Galaxy Chain",
@@ -2264,7 +2327,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The BLOCK token of Marble DEX on Juno Chain",
@@ -2295,7 +2361,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Token governance for Junoswap",
@@ -2325,7 +2394,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "MEME Token (MEME) is the native staking token of the MEME Chain",
@@ -2352,7 +2424,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Profit sharing token for Another.Software validator. Hold and receive dividends from Another.Software validator commissions!",
@@ -2382,7 +2457,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native EVM, governance, bridge, and staking token of Echelon",
@@ -2410,7 +2488,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/logo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
       },
-      "coingecko_id": "echelon"
+      "coingecko_id": "echelon",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "DAO dedicated to building tools on the Juno Network",
@@ -2440,7 +2521,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "L1 coin is the GenesisL1 blockchain utility, governance and EVM token",
@@ -2467,7 +2551,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Atolo the native token of Rizon Chain",
@@ -2495,7 +2582,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
       },
-      "coingecko_id": "rizon"
+      "coingecko_id": "rizon",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Staking and goverance token for ODIN Protocol",
@@ -2523,7 +2613,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
       },
-      "coingecko_id": "odin-protocol"
+      "coingecko_id": "odin-protocol",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Geo token for ODIN Protocol",
@@ -2550,7 +2643,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "O9W token for ODIN Protocol",
@@ -2577,7 +2673,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native token of Shentu",
@@ -2604,7 +2703,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
       },
-      "coingecko_id": "certik"
+      "coingecko_id": "certik",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native over-collateralized stablecoin from the Kujira chain.",
@@ -2631,7 +2733,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
       },
-      "coingecko_id": "usk"
+      "coingecko_id": "usk",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Governance token of Kava Lend Protocol",
@@ -2659,7 +2764,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
       },
-      "coingecko_id": "kava-lend"
+      "coingecko_id": "kava-lend",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Governance token of Kava Swap Protocol",
@@ -2687,7 +2795,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
       },
-      "coingecko_id": "kava-swap"
+      "coingecko_id": "kava-swap",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native stablecoin of Kava",
@@ -2714,7 +2825,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png"
       },
-      "coingecko_id": "usdx"
+      "coingecko_id": "usdx",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Gravity Bridge USDT",
@@ -2743,7 +2857,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
       },
-      "coingecko_id": "tether"
+      "coingecko_id": "tether",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Aave on Axelar",
@@ -2771,7 +2888,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave-wei L@3x.png"
       },
-      "coingecko_id": "aave"
+      "coingecko_id": "aave",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "ApeCoin on Axelar",
@@ -2799,7 +2919,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape-wei L@3x.png"
       },
-      "coingecko_id": "apecoin"
+      "coingecko_id": "apecoin",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Axie Infinity Shard on Axelar",
@@ -2827,7 +2950,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs-wei L@3x.png"
       },
-      "coingecko_id": "axie-infinity"
+      "coingecko_id": "axie-infinity",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Rai Reflex Index on Axelar",
@@ -2855,7 +2981,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai-wei L@3x.png"
       },
-      "coingecko_id": "rai"
+      "coingecko_id": "rai",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Shiba Inu on Axelar",
@@ -2883,7 +3012,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib-wei L@3x.png"
       },
-      "coingecko_id": "shiba-inu"
+      "coingecko_id": "shiba-inu",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Uniswap on Axelar",
@@ -2911,7 +3043,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni-wei L@3x.png"
       },
-      "coingecko_id": "uniswap"
+      "coingecko_id": "uniswap",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Chain on Axelar",
@@ -2939,7 +3074,10 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn-wei L@3x.png"
       },
-      "coingecko_id": "chain-2"
+      "coingecko_id": "chain-2",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "ELEVENPARIS loyalty token on KiChain",
@@ -2971,7 +3109,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
       },
-      "coingecko_id": "lvn"
+      "coingecko_id": "lvn",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Wrapped GLMR on Axelar",
@@ -2999,7 +3140,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wdev-wei.png"
       },
-      "coingecko_id": "wrapped-moonbeam"
+      "coingecko_id": "wrapped-moonbeam",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "DeFi gaming platform built on Juno",
@@ -3029,7 +3173,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Gelotto Year 1 Grand Prize Token",
@@ -3059,7 +3206,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "CRE is the native token of the Crescent Network.",
@@ -3087,7 +3237,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
       },
-      "coingecko_id": "crescent-network"
+      "coingecko_id": "crescent-network",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native token of Lumen Network",
@@ -3113,7 +3266,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native token of Oraichain",
@@ -3141,7 +3297,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
       },
-      "coingecko_id": "oraichain-token"
+      "coingecko_id": "oraichain-token",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "IST is a decentralized and fully collateralized stable token built for the Cosmos ecosystem.",
@@ -3167,7 +3326,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     }, 
     {
       "description": "The native token of the Cudos blockchain",
@@ -3195,7 +3357,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
       },
-      "coingecko_id": "cudos"
+      "coingecko_id": "cudos",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Staking derivative seJUNO for staked JUNO",
@@ -3226,7 +3391,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Staking derivative bJUNO for staked JUNO",
@@ -3257,7 +3425,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Staking derivative stSTARS for staked STARS by Stride",
@@ -3284,7 +3455,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Solarbank DAO Governance Token for speeding up the shift to renewable and green energy",
@@ -3315,7 +3489,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "StakeEasy governance token",
@@ -3346,35 +3523,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
-      }
-    },
-    {
-      "description": "The native staking and governance token of the Axelar chain",
-      "denom_units": [
-        {
-          "denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-          "exponent": 0,
-          "aliases": ["uaxl"]
-        },
-        {
-          "denom": "axl",
-          "exponent": 6
-        }
-      ],
-      "base": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-      "name": "Axelar",
-      "display": "axl",
-      "symbol": "AXL",
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.png",
-        "svg": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg"
       },
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "uaxl"
-      },
-      "coingecko_id": "axelar"
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "REBUS coin is the token for the Rebuschain Platform",
@@ -3402,7 +3554,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
       },
-      "coingecko_id": "rebus"
+      "coingecko_id": "rebus",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native staking and governance token of the Teritori chain",
@@ -3430,7 +3585,10 @@
         "dst_channel": "channel-362",
         "source_denom": "utori"
       },
-      "coingecko_id": ""
+      "coingecko_id": "",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Staking derivative stJUNO for staked JUNO by Stride",
@@ -3457,7 +3615,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native token of Lambda",
@@ -3484,7 +3645,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
       },
-      "coingecko_id": "lambda"
+      "coingecko_id": "lambda",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "MUSE Governance Token",
@@ -3514,7 +3678,10 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
-      }
+      },
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "The native staking and governance coin of the Unification Blockchain.",
@@ -3541,7 +3708,10 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
       },
-      "coingecko_id": "unification"
+      "coingecko_id": "unification",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Jackal Native Token",
@@ -3570,7 +3740,10 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
 
       },
-      "coingecko_id": ""
+      "coingecko_id": "",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     },
     {
       "description": "Staking derivative stOSMO for staked OSMO by Stride",
@@ -3598,7 +3771,10 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
       },
-      "coingecko_id": "stride-staked-osmo"
+      "coingecko_id": "stride-staked-osmo",
+      "keywords": [
+        "osmosis-frontier"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Combine Assets to a Single file, add "Keywords" string array, like in Chain Registry, to be able to show "verified".
Not required, because I don't think a team is intuitively going to think that their token is unverified. So, I've added `"keywords": ["verified"]` for main app tokens, and simply didn't add the property for Frontier tokens.

Once applications are configured to work with a single file, we can then delete the osmosis-frontier file, which needlessly duplicated listings and confused first-time contributors.

e.g., 
```
...
      "coingecko_id": "axelar",
      "keywords": ["verified"]
    },
    {
      "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",
      "denom_units": [
        {
           ...
```