### PR TITLE
Update Schema for "pools" Requirement when using osmosis-frontier Keyword

### DIFF
--- a/assetlist.schema.json
+++ b/assetlist.schema.json
@@ -108,6 +108,18 @@
                   "maxContains": 20,
                   "items": {
                       "type": "string"
+                  },
+                  "if": {
+                    "contains": {
+                      "type": "string",
+                      "pattern": "^osmosis-main$"
+                    }
+                  },
+                  "then": {
+                    "contains": {
+                      "type": "string",
+                      "pattern": "^osmosis-frontier$"
+                    }
                   }
               },
               "pools": {
@@ -155,6 +167,25 @@
                 "required": [
                     "address"
                 ]
+            },
+            "if": {
+              "properties": {
+                "keywords": {
+                  "type": "array",
+                  "contains": {
+                    "type": "string",
+                    "pattern": "^osmosis-frontier$"
+                  }
+                }
+              },
+              "required": [
+                "keywords"
+              ]
+            },
+            "then": {
+              "required": [
+                "pools" 
+              ]
             }
         },
         "denom_unit": {

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -27,7 +27,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier"
-      ]
+      ],
+      "pools": {
+        "ATOM": 1,
+        "USDC.axl": 678
+      }
     },
     {
       "denom_units": [
@@ -2127,10 +2131,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png"
       },
-      "coingecko_id": "terra-krw",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "terra-krw"
     },
     {
       "description": "The native staking token of Terra 2.0",
@@ -2364,10 +2365,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uusdt L@3x.png"
       },
-      "coingecko_id": "tether",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "tether"
     },
     {
       "description": "Frax's fractional-algorithmic stablecoin on Axelar",
@@ -2395,10 +2393,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax-wei L@3x.png"
       },
-      "coingecko_id": "frax",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "frax"
     },
     {
       "description": "Gravity Bridge ETH",
@@ -2459,10 +2454,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
       },
-      "coingecko_id": "wrapped-bitcoin",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "wrapped-bitcoin"
     },
     {
       "description": "Gravity Bridge USDC",
@@ -2524,10 +2516,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.png"
       },
-      "coingecko_id": "dai",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "dai"
     },
     {
       "description": "Hash is the staking token of the Provenance Blockchain",
@@ -2730,10 +2719,7 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
-      },
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      }
     },
     {
       "description": "The native EVM, governance, bridge, and staking token of Echelon",
@@ -2864,10 +2850,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
       },
-      "coingecko_id": "rizon",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "rizon"
     },
     {
       "description": "Staking and goverance token for ODIN Protocol",
@@ -2994,10 +2977,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
       },
-      "coingecko_id": "certik",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "certik"
     },
     {
       "description": "The native over-collateralized stablecoin from the Kujira chain.",
@@ -3024,10 +3004,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
       },
-      "coingecko_id": "usk",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "usk"
     },
     {
       "description": "Governance token of Kava Lend Protocol",
@@ -3055,10 +3032,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
       },
-      "coingecko_id": "kava-lend",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "kava-lend"
     },
     {
       "description": "Governance token of Kava Swap Protocol",
@@ -3086,10 +3060,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
       },
-      "coingecko_id": "kava-swap",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "kava-swap"
     },
     {
       "description": "The native stablecoin of Kava",
@@ -3116,10 +3087,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png"
       },
-      "coingecko_id": "usdx",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "usdx"
     },
     {
       "description": "Gravity Bridge USDT",
@@ -3182,10 +3150,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave-wei L@3x.png"
       },
-      "coingecko_id": "aave",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "aave"
     },
     {
       "description": "ApeCoin on Axelar",
@@ -3213,10 +3178,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape-wei L@3x.png"
       },
-      "coingecko_id": "apecoin",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "apecoin"
     },
     {
       "description": "Axie Infinity Shard on Axelar",
@@ -3244,10 +3206,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs-wei L@3x.png"
       },
-      "coingecko_id": "axie-infinity",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "axie-infinity"
     },
     {
       "description": "Rai Reflex Index on Axelar",
@@ -3275,10 +3234,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai-wei L@3x.png"
       },
-      "coingecko_id": "rai",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "rai"
     },
     {
       "description": "Shiba Inu on Axelar",
@@ -3306,10 +3262,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib-wei L@3x.png"
       },
-      "coingecko_id": "shiba-inu",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "shiba-inu"
     },
     {
       "description": "Uniswap on Axelar",
@@ -3337,10 +3290,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni-wei L@3x.png"
       },
-      "coingecko_id": "uniswap",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "uniswap"
     },
     {
       "description": "Chain on Axelar",
@@ -3368,10 +3318,7 @@
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn-wei L@3x.png"
       },
-      "coingecko_id": "chain-2",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "chain-2"
     },
     {
       "description": "ELEVENPARIS loyalty token on KiChain",
@@ -3437,10 +3384,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wdev-wei.png"
       },
-      "coingecko_id": "wrapped-moonbeam",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "wrapped-moonbeam"
     },
     {
       "description": "DeFi gaming platform built on Juno",
@@ -3606,10 +3550,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
       },
-      "coingecko_id": "oraichain-token",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "oraichain-token"
     },
     {
       "description": "IST is a decentralized and fully collateralized stable token built for the Cosmos ecosystem.",
@@ -3743,10 +3684,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
-      },
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      }
     },
     {
       "description": "Staking derivative stSTARS for staked STARS by Stride",
@@ -3810,10 +3748,7 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
-      },
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      }
     },
     {
       "description": "StakeEasy governance token",
@@ -4014,10 +3949,7 @@
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
-      },
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      }
     },
     {
       "description": "The native staking and governance coin of the Unification Blockchain.",
@@ -4264,10 +4196,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
       },
-      "coingecko_id": "buttcoin-2",
-      "keywords": [
-        "osmosis-frontier"
-      ]
+      "coingecko_id": "buttcoin-2"
     },
     {
       "description": "The native token cw20 for Alter on Secret Network",


### PR DESCRIPTION
Update Schema for "pools" Requirement when using osmosis-frontier Keyword
+
requires osmosis-frontier when using osmosis-main, to guarantee that all osmosis-main tokens are also on Frontier.

There are quite a few tokens on Frontier that do not have defined pools. We must remain caution when setting up automation that those don't get suddenly removed from frontend due to not having the osmosis-frontier keyword. (But this is ultimately the goal)