### PR TITLE
Fix USK source base from : to /

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -5099,7 +5099,7 @@
       "ibc": {
         "source_channel": "channel-3",
         "dst_channel": "channel-259",
-        "source_denom": "factory:kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7:uusk"
+        "source_denom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
       },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
@@ -5116,7 +5116,7 @@
           "type": "ibc",
           "counterparty": {
             "chain_name": "kujira",
-            "base_denom": "factory:kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7:uusk",
+            "base_denom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
             "channel_id": "channel-3"
           },
           "chain": {


### PR DESCRIPTION
it uses : for the ibc transfer, but is actually / on kujira factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk