### PR TITLE
Remove type_asset erc20 for sdk coins

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -65,7 +65,6 @@
     },
     {
       "description": "Circle's stablecoin on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
@@ -116,7 +115,6 @@
     },
     {
       "description": "Wrapped Ether on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
@@ -167,7 +165,6 @@
     },
     {
       "description": "Wrapped Bitcoin on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
@@ -218,7 +215,6 @@
     },
     {
       "description": "Dai stablecoin on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
@@ -269,7 +265,6 @@
     },
     {
       "description": "Binance USD on Axelar.",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
@@ -420,7 +415,6 @@
     },
     {
       "description": "Wrapped BNB on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
@@ -472,7 +466,6 @@
     },
     {
       "description": "Wrapped Matic on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
@@ -574,7 +567,6 @@
     },
     {
       "description": "Wrapped Polkadot on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
@@ -3059,7 +3051,6 @@
     },
     {
       "description": "Tether's USD stablecoin on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
@@ -3109,7 +3100,6 @@
     },
     {
       "description": "Frax's fractional-algorithmic stablecoin on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
@@ -3194,7 +3184,6 @@
     },
     {
       "description": "Gravity Bridge ETH",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
@@ -3244,7 +3233,6 @@
     },
     {
       "description": "Gravity Bridge USDC",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
@@ -3294,7 +3282,6 @@
     },
     {
       "description": "Gravity Bridge Dai",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
@@ -3337,7 +3324,6 @@
     },
     {
       "description": "Gravity Bridge USDT",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
@@ -3963,7 +3949,6 @@
     },
     {
       "description": "Chainlink on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
@@ -4063,7 +4048,6 @@
     },
     {
       "description": "Aave on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
@@ -4106,7 +4090,6 @@
     },
     {
       "description": "ApeCoin on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
@@ -4149,7 +4132,6 @@
     },
     {
       "description": "Axie Infinity Shard on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
@@ -4192,7 +4174,6 @@
     },
     {
       "description": "Maker on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
@@ -4242,7 +4223,6 @@
     },
     {
       "description": "Rai Reflex Index on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
@@ -4285,7 +4265,6 @@
     },
     {
       "description": "Shiba Inu on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
@@ -4328,7 +4307,6 @@
     },
     {
       "description": "Uniswap on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
@@ -4371,7 +4349,6 @@
     },
     {
       "description": "Chain on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
@@ -4765,7 +4742,6 @@
     },
     {
       "description": "Wrapped GLMR on Axelar",
-      "type_asset": "erc20",
       "denom_units": [
         {
           "denom": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",


### PR DESCRIPTION
this property was added to bridged coins originating from Ethereum or similar chain, but after moving to bridge chains like Axelar, they lose erc20 status. The address property should be required for erc20 tokens, but these are not provided and wouldn't describe the latest stage of the token (only the origin).