### PR TITLE
Remove ibc property

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -27,12 +27,10 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
-      ],
-      "pools": {
-        "ATOM": 1,
-        "USDC.axl": 678
-      }
+        "osmosis-info",
+        "ATOM:1",
+        "USDC.axl:678"
+      ]
     },
     {
       "denom_units": [
@@ -57,11 +55,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
-      ],
-      "pools": {
-        "OSMO": 2
-      }
+        "osmosis-info",
+        "OSMO:2"
+      ]
     },
     {
       "description": "Circle's stablecoin on Axelar",
@@ -74,13 +70,13 @@
           ]
         },
         {
-          "denom": "axlusdc",
+          "denom": "usdc",
           "exponent": 6
         }
       ],
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "name": "USD Coin",
-      "display": "axlusdc",
+      "display": "usdc",
       "symbol": "USDC",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uausdc L@3x.png"
@@ -89,11 +85,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:678"
       ],
-      "pools": {
-        "OSMO": 678
-      },
       "traces": [
         {
           "type": "ibc",
@@ -119,13 +113,13 @@
           ]
         },
         {
-          "denom": "axlweth",
+          "denom": "weth",
           "exponent": 18
         }
       ],
       "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "name": "Wrapped Ether",
-      "display": "axlweth",
+      "display": "weth",
       "symbol": "WETH",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth-wei L@3x.png"
@@ -134,11 +128,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:704"
       ],
-      "pools": {
-        "OSMO": 704
-      },
       "traces": [
         {
           "type": "ibc",
@@ -164,13 +156,13 @@
           ]
         },
         {
-          "denom": "axlwbtc",
+          "denom": "wbtc",
           "exponent": 8
         }
       ],
       "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "name": "Wrapped Bitcoin",
-      "display": "axlwbtc",
+      "display": "wbtc",
       "symbol": "WBTC",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc-satoshi L@3x.png"
@@ -179,11 +171,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:712"
       ],
-      "pools": {
-        "OSMO": 712
-      },
       "traces": [
         {
           "type": "ibc",
@@ -209,13 +199,13 @@
           ]
         },
         {
-          "denom": "axldai",
+          "denom": "dai",
           "exponent": 18
         }
       ],
       "base": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "name": "Dai Stablecoin",
-      "display": "axldai",
+      "display": "dai",
       "symbol": "DAI",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai-wei L@3x.png"
@@ -224,11 +214,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:674"
       ],
-      "pools": {
-        "OSMO": 674
-      },
       "traces": [
         {
           "type": "ibc",
@@ -254,25 +242,23 @@
           ]
         },
         {
-          "denom": "axlbusd",
+          "denom": "busd",
           "exponent": 18
         }
       ],
       "base": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
       "name": "Binance USD",
-      "display": "axlbusd",
-      "symbol": "BUSD.axl",
+      "display": "busd",
+      "symbol": "BUSD",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
       },
       "coingecko_id": "binance-usd",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "USDC.axl:877"
       ],
-      "pools": {
-        "USDC.axl": 877
-      },
       "traces": [
         {
           "type": "ibc",
@@ -314,11 +300,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:1"
       ],
-      "pools": {
-        "OSMO": 1
-      },
       "traces": [
         {
           "type": "ibc",
@@ -359,11 +343,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:9"
       ],
-      "pools": {
-        "OSMO": 9
-      },
       "traces": [
         {
           "type": "ibc",
@@ -389,14 +371,14 @@
           ]
         },
         {
-          "denom": "axlwbnb",
+          "denom": "wbnb",
           "exponent": 18
         }
       ],
       "base": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
       "name": "Wrapped BNB",
-      "display": "axlwbnb",
-      "symbol": "WBNB.axl",
+      "display": "wbnb",
+      "symbol": "WBNB",
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
@@ -405,11 +387,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:840"
       ],
-      "pools": {
-        "OSMO": 840
-      },
       "traces": [
         {
           "type": "ibc",
@@ -435,14 +415,14 @@
           ]
         },
         {
-          "denom": "axlwmatic",
+          "denom": "wmatic",
           "exponent": 18
         }
       ],
       "base": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
       "name": "Wrapped Matic",
-      "display": "axlwmatic",
-      "symbol": "WMATIC.axl",
+      "display": "wmatic",
+      "symbol": "WMATIC",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png"
       },
@@ -450,11 +430,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:789"
       ],
-      "pools": {
-        "OSMO": 789
-      },
       "traces": [
         {
           "type": "ibc",
@@ -496,11 +474,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:497"
       ],
-      "pools": {
-        "OSMO": 497
-      },
       "traces": [
         {
           "type": "ibc",
@@ -527,14 +503,14 @@
           ]
         },
         {
-          "denom": "axldot",
+          "denom": "dot",
           "exponent": 10
         }
       ],
       "base": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "name": "DOT",
-      "display": "axldot",
-      "symbol": "DOT.axl",
+      "display": "dot",
+      "symbol": "DOT",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dot-planck L@3x.png"
       },
@@ -542,11 +518,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:773"
       ],
-      "pools": {
-        "OSMO": 773
-      },
       "traces": [
         {
           "type": "ibc",
@@ -588,11 +562,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:722"
       ],
-      "pools": {
-        "OSMO": 722
-      },
       "traces": [
         {
           "type": "ibc",
@@ -633,11 +605,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:730"
       ],
-      "pools": {
-        "OSMO": 730
-      },
       "traces": [
         {
           "type": "ibc",
@@ -679,11 +649,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:584"
       ],
-      "pools": {
-        "OSMO": 584
-      },
       "traces": [
         {
           "type": "ibc",
@@ -724,11 +692,9 @@
       "coingecko_id": "terra-luna",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:800"
       ],
-      "pools": {
-        "OSMO": 800
-      },
       "traces": [
         {
           "type": "ibc",
@@ -772,11 +738,9 @@
       "coingecko_id": "terrausd",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:560"
       ],
-      "pools": {
-        "OSMO": 560
-      },
       "traces": [
         {
           "type": "ibc",
@@ -817,11 +781,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:604"
       ],
-      "pools": {
-        "OSMO": 604
-      },
       "traces": [
         {
           "type": "ibc",
@@ -863,11 +825,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:605"
       ],
-      "pools": {
-        "OSMO": 605
-      },
       "traces": [
         {
           "type": "ibc",
@@ -908,11 +868,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:15"
       ],
-      "pools": {
-        "OSMO": 15
-      },
       "traces": [
         {
           "type": "ibc",
@@ -951,11 +909,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:648"
       ],
-      "pools": {
-        "OSMO": 648
-      },
       "traces": [
         {
           "type": "liquid-stake",
@@ -1025,11 +981,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:3"
       ],
-      "pools": {
-        "OSMO": 3
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1070,11 +1024,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:42"
       ],
-      "pools": {
-        "OSMO": 42
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1115,11 +1067,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:5"
       ],
-      "pools": {
-        "OSMO": 5
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1160,11 +1110,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:7"
       ],
-      "pools": {
-        "OSMO": 7
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1206,11 +1154,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:197"
       ],
-      "pools": {
-        "OSMO": 197
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1252,11 +1198,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:463"
       ],
-      "pools": {
-        "OSMO": 463
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1295,11 +1239,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:481"
       ],
-      "pools": {
-        "OSMO": 481
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1341,11 +1283,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:553"
       ],
-      "pools": {
-        "OSMO": 553
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1385,11 +1325,9 @@
       "coingecko_id": "ixo",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:557"
       ],
-      "pools": {
-        "OSMO": 557
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1431,11 +1369,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:571"
       ],
-      "pools": {
-        "OSMO": 571
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1477,11 +1413,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:573"
       ],
-      "pools": {
-        "OSMO": 573
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1523,11 +1457,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:577"
       ],
-      "pools": {
-        "OSMO": 577
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1568,11 +1500,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:586"
       ],
-      "pools": {
-        "OSMO": 586
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1607,11 +1537,9 @@
       },
       "coingecko_id": "bostrom",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:597"
       ],
-      "pools": {
-        "OSMO": 597
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1652,11 +1580,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:601"
       ],
-      "pools": {
-        "OSMO": 601
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1698,11 +1624,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:602"
       ],
-      "pools": {
-        "OSMO": 602
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1743,11 +1667,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:608"
       ],
-      "pools": {
-        "OSMO": 608
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1789,11 +1711,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:613"
       ],
-      "pools": {
-        "OSMO": 613
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1835,11 +1755,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:619"
       ],
-      "pools": {
-        "OSMO": 619
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1880,11 +1798,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:621"
       ],
-      "pools": {
-        "OSMO": 621
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1926,11 +1842,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:627"
       ],
-      "pools": {
-        "OSMO": 627
-      },
       "traces": [
         {
           "type": "ibc",
@@ -1972,11 +1886,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:626"
       ],
-      "pools": {
-        "OSMO": 626
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2017,11 +1929,9 @@
       "coingecko_id": "darcmatter-coin",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:637"
       ],
-      "pools": {
-        "OSMO": 637
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2062,11 +1972,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:641"
       ],
-      "pools": {
-        "OSMO": 641
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2108,11 +2016,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:625"
       ],
-      "pools": {
-        "OSMO": 625
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2154,11 +2060,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:644"
       ],
-      "pools": {
-        "OSMO": 644
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2201,11 +2105,9 @@
       "coingecko_id": "marble",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:649"
       ],
-      "pools": {
-        "OSMO": 649
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2249,11 +2151,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:651"
       ],
-      "pools": {
-        "OSMO": 651
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2293,11 +2193,9 @@
       "coingecko_id": "cerberus-2",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:662"
       ],
-      "pools": {
-        "OSMO": 662
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2339,11 +2237,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:681"
       ],
-      "pools": {
-        "OSMO": 681
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2384,11 +2280,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:690"
       ],
-      "pools": {
-        "OSMO": 690
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2431,11 +2325,9 @@
       "coingecko_id": "neta",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:631"
       ],
-      "pools": {
-        "OSMO": 631
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2475,11 +2367,9 @@
       "coingecko_id": "injective-protocol",
       "keywords": [
         "osmosis-main",
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:725"
       ],
-      "pools": {
-        "OSMO": 725
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2560,11 +2450,9 @@
       "coingecko_id": "microtick",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "ATOM:547"
       ],
-      "pools": {
-        "ATOM": 547
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2602,11 +2490,9 @@
       "coingecko_id": "sifchain",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:629"
       ],
-      "pools": {
-        "OSMO": 629
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2685,11 +2571,9 @@
       },
       "coingecko_id": "hope-galaxy",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:653"
       ],
-      "pools": {
-        "OSMO": 653
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2733,11 +2617,9 @@
       },
       "coingecko_id": "racoon",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:669"
       ],
-      "pools": {
-        "OSMO": 669
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2765,25 +2647,23 @@
           ]
         },
         {
-          "denom": "axlusdt",
+          "denom": "usdt",
           "exponent": 6
         }
       ],
       "base": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "name": "Tether USD",
-      "display": "axlusdt",
-      "symbol": "USDT.axl",
+      "display": "usdt",
+      "symbol": "USDT",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uusdt L@3x.png"
       },
       "coingecko_id": "tether",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "USDC.axl:877"
       ],
-      "pools": {
-        "USDC.axl": 877
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2809,14 +2689,14 @@
           ]
         },
         {
-          "denom": "axlfrax",
+          "denom": "frax",
           "exponent": 18
         }
       ],
       "base": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
       "name": "Frax",
-      "display": "axlfrax",
-      "symbol": "FRAX.axl",
+      "display": "frax",
+      "symbol": "FRAX",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax-wei L@3x.png"
       },
@@ -2897,11 +2777,9 @@
       "coingecko_id": "weth",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:634"
       ],
-      "pools": {
-        "OSMO": 634
-      },
       "traces": [
         {
           "type": "ibc",
@@ -2941,11 +2819,9 @@
       "coingecko_id": "usd-coin",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:633"
       ],
-      "pools": {
-        "OSMO": 633
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3023,11 +2899,9 @@
       "coingecko_id": "tether",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:818"
       ],
-      "pools": {
-        "OSMO": 818
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3068,11 +2942,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
       },
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:691"
       ],
-      "pools": {
-        "OSMO": 691
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3115,11 +2987,9 @@
       "coingecko_id": "provenance-blockchain",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:693"
       ],
-      "pools": {
-        "OSMO": 693
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3158,11 +3028,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.svg"
       },
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:697"
       ],
-      "pools": {
-        "OSMO": 697
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3200,11 +3068,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:695"
       ],
-      "pools": {
-        "OSMO": 695
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3247,11 +3113,9 @@
       },
       "coingecko_id": "junoswap-raw-dao",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:700"
       ],
-      "pools": {
-        "OSMO": 700
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3293,11 +3157,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:701"
       ],
-      "pools": {
-        "OSMO": 701
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3378,11 +3240,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:718"
       ],
-      "pools": {
-        "OSMO": 718
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3424,11 +3284,9 @@
       "coingecko_id": "terra-luna-2",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:726"
       ],
-      "pools": {
-        "OSMO": 726
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3568,14 +3426,14 @@
           ]
         },
         {
-          "denom": "axllink",
+          "denom": "link",
           "exponent": 18
         }
       ],
       "base": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
       "name": "Chainlink",
-      "display": "axllink",
-      "symbol": "LINK.axl",
+      "display": "link",
+      "symbol": "LINK",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/link-wei L@3x.png"
       },
@@ -3583,11 +3441,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:731"
       ],
-      "pools": {
-        "OSMO": 731
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3627,11 +3483,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:732"
       ],
-      "pools": {
-        "OSMO": 732
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3657,14 +3511,14 @@
           ]
         },
         {
-          "denom": "axlaave",
+          "denom": "aave",
           "exponent": 18
         }
       ],
       "base": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
       "name": "Aave",
-      "display": "axlaave",
-      "symbol": "AAVE.axl",
+      "display": "aave",
+      "symbol": "AAVE",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/aave-wei L@3x.png"
       },
@@ -3694,14 +3548,14 @@
           ]
         },
         {
-          "denom": "axlape",
+          "denom": "ape",
           "exponent": 18
         }
       ],
       "base": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
       "name": "ApeCoin",
-      "display": "axlape",
-      "symbol": "APE.axl",
+      "display": "ape",
+      "symbol": "APE",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/ape-wei L@3x.png"
       },
@@ -3731,14 +3585,14 @@
           ]
         },
         {
-          "denom": "axlaxs",
+          "denom": "axs",
           "exponent": 18
         }
       ],
       "base": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
       "name": "Axie Infinity Shard",
-      "display": "axlaxs",
-      "symbol": "AXS.axl",
+      "display": "axs",
+      "symbol": "AXS",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axs-wei L@3x.png"
       },
@@ -3768,25 +3622,23 @@
           ]
         },
         {
-          "denom": "axlmkr",
+          "denom": "mkr",
           "exponent": 18
         }
       ],
       "base": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
       "name": "Maker",
-      "display": "axlmkr",
-      "symbol": "MKR.axl",
+      "display": "mkr",
+      "symbol": "MKR",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/mkr-wei L@3x.png"
       },
       "coingecko_id": "maker",
       "keywords": [
         "osmosis-main",
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:733"
       ],
-      "pools": {
-        "OSMO": 733
-      },
       "traces": [
         {
           "type": "ibc",
@@ -3812,14 +3664,14 @@
           ]
         },
         {
-          "denom": "axlrai",
+          "denom": "rai",
           "exponent": 18
         }
       ],
       "base": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
       "name": "Rai Reflex Index",
-      "display": "axlrai",
-      "symbol": "RAI.axl",
+      "display": "rai",
+      "symbol": "RAI",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/rai-wei L@3x.png"
       },
@@ -3849,14 +3701,14 @@
           ]
         },
         {
-          "denom": "axlshib",
+          "denom": "shib",
           "exponent": 18
         }
       ],
       "base": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
       "name": "Shiba Inu",
-      "display": "axlshib",
-      "symbol": "SHIB.axl",
+      "display": "shib",
+      "symbol": "SHIB",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/shib-wei L@3x.png"
       },
@@ -3886,14 +3738,14 @@
           ]
         },
         {
-          "denom": "axluni",
+          "denom": "uni",
           "exponent": 18
         }
       ],
       "base": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
       "name": "Uniswap",
-      "display": "axluni",
-      "symbol": "UNI.axl",
+      "display": "uni",
+      "symbol": "UNI",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uni-wei L@3x.png"
       },
@@ -3923,14 +3775,14 @@
           ]
         },
         {
-          "denom": "axlxcn",
+          "denom": "xcn",
           "exponent": 18
         }
       ],
       "base": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
       "name": "Chain",
-      "display": "axlxcn",
-      "symbol": "XCN.axl",
+      "display": "xcn",
+      "symbol": "XCN",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/xcn-wei L@3x.png"
       },
@@ -3975,11 +3827,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:744"
       ],
-      "pools": {
-        "OSMO": 744
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4020,11 +3870,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:769"
       ],
-      "pools": {
-        "OSMO": 769
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4064,11 +3912,9 @@
       },
       "coingecko_id": "echelon",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:848"
       ],
-      "pools": {
-        "OSMO": 848
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4109,11 +3955,9 @@
       "coingecko_id": "odin-protocol",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:777"
       ],
-      "pools": {
-        "OSMO": 777
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4154,11 +3998,9 @@
       "coingecko_id": "geodb",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:787"
       ],
-      "pools": {
-        "OSMO": 787
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4197,11 +4039,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
       },
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:805"
       ],
-      "pools": {
-        "OSMO": 805
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4244,11 +4084,9 @@
       "coingecko_id": "lvn",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:774"
       ],
-      "pools": {
-        "OSMO": 774
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4277,14 +4115,14 @@
           ]
         },
         {
-          "denom": "axlwglmr",
+          "denom": "wglmr",
           "exponent": 18
         }
       ],
       "base": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
       "name": "Wrapped GLMR",
-      "display": "axlwglmr",
-      "symbol": "WGLMR.axl",
+      "display": "wglmr",
+      "symbol": "WGLMR",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wdev-wei.png"
       },
@@ -4329,11 +4167,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:778"
       ],
-      "pools": {
-        "OSMO": 778
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4376,11 +4212,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:790"
       ],
-      "pools": {
-        "OSMO": 790
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4423,11 +4257,9 @@
       "coingecko_id": "crescent-network",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:786"
       ],
-      "pools": {
-        "OSMO": 786
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4465,11 +4297,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png"
       },
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:788"
       ],
-      "pools": {
-        "OSMO": 788
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4548,11 +4378,9 @@
       "coingecko_id": "cudos",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:796"
       ],
-      "pools": {
-        "OSMO": 796
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4629,11 +4457,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:795"
       ],
-      "pools": {
-        "OSMO": 795
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4674,11 +4500,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:837"
       ],
-      "pools": {
-        "OSMO": 837
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4721,11 +4545,9 @@
       "coingecko_id": "stakeeasy-juno-derivative",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:793"
       ],
-      "pools": {
-        "OSMO": 793
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4812,11 +4634,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:806"
       ],
-      "pools": {
-        "OSMO": 806
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4858,11 +4678,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "ATOM:803"
       ],
-      "pools": {
-        "ATOM": 803
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4902,11 +4720,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "STARS:810"
       ],
-      "pools": {
-        "STARS": 810
-      },
       "traces": [
         {
           "type": "ibc",
@@ -4989,11 +4805,9 @@
       },
       "coingecko_id": "seasy",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:808"
       ],
-      "pools": {
-        "OSMO": 808
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5037,11 +4851,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:812"
       ],
-      "pools": {
-        "OSMO": 812
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5082,11 +4894,9 @@
       "coingecko_id": "rebus",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:813"
       ],
-      "pools": {
-        "OSMO": 813
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5127,11 +4937,9 @@
       "coingecko_id": "teritori",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:816"
       ],
-      "pools": {
-        "OSMO": 816
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5171,11 +4979,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "JUNO:817"
       ],
-      "pools": {
-        "JUNO": 817
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5217,11 +5023,9 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:833"
       ],
-      "pools": {
-        "OSMO": 833
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5301,11 +5105,9 @@
       "coingecko_id": "lambda",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:826"
       ],
-      "pools": {
-        "OSMO": 826
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5344,11 +5146,9 @@
       },
       "coingecko_id": "usk",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:819"
       ],
-      "pools": {
-        "OSMO": 819
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5387,11 +5187,9 @@
       },
       "coingecko_id": "unification",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:830"
       ],
-      "pools": {
-        "OSMO": 830
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5432,11 +5230,9 @@
       "coingecko_id": "",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:832"
       ],
-      "pools": {
-        "OSMO": 832
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5479,11 +5275,9 @@
       "coingecko_id": "alter",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:845"
       ],
-      "pools": {
-        "OSMO": 845
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5570,11 +5364,9 @@
       "coingecko_id": "shade-protocol",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:846"
       ],
-      "pools": {
-        "OSMO": 846
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5618,11 +5410,9 @@
       },
       "coingecko_id": "sienna",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:853"
       ],
-      "pools": {
-        "OSMO": 853
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5666,11 +5456,9 @@
       },
       "coingecko_id": "stkd-scrt",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "SCRT:854"
       ],
-      "pools": {
-        "SCRT": 854
-      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5713,11 +5501,9 @@
       "coingecko_id": "bzedge",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:856"
       ],
-      "pools": {
-        "OSMO": 856
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5798,11 +5584,9 @@
       },
       "coingecko_id": "arable-protocol",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:858"
       ],
-      "pools": {
-        "OSMO": 858
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5841,11 +5625,9 @@
       },
       "coingecko_id": "",
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "OSMO:857"
       ],
-      "pools": {
-        "OSMO": 857
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5884,11 +5666,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
       },
       "keywords": [
-        "osmosis-frontier"
+        "osmosis-frontier",
+        "USDC.axl:866"
       ],
-      "pools": {
-        "USDC.axl": 866
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5928,11 +5708,9 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "OSMO:859"
       ],
-      "pools": {
-        "OSMO": 859
-      },
       "traces": [
         {
           "type": "ibc",
@@ -5975,11 +5753,9 @@
       "coingecko_id": "posthuman",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info"
+        "osmosis-info",
+        "ATOM:867"
       ],
-      "pools": {
-        "ATOM": 867
-      },
       "traces": [
         {
           "type": "ibc-cw20",

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -27,10 +27,12 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "ATOM:1",
-        "USDC.axl:678"
-      ]
+        "osmosis-info"
+      ],
+      "pools": {
+        "ATOM": 1,
+        "USDC.axl": 678
+      }
     },
     {
       "denom_units": [
@@ -55,9 +57,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:2"
-      ]
+        "osmosis-info"
+      ],
+      "pools": {
+        "OSMO": 2
+      }
     },
     {
       "description": "Circle's stablecoin on Axelar",
@@ -70,19 +74,14 @@
           ]
         },
         {
-          "denom": "usdc",
+          "denom": "axlusdc",
           "exponent": 6
         }
       ],
       "base": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "name": "USD Coin",
-      "display": "usdc",
+      "display": "axlusdc",
       "symbol": "USDC",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "uusdc"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uausdc L@3x.png"
       },
@@ -90,9 +89,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:678"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 678
+      },
       "traces": [
         {
           "type": "ibc",
@@ -118,19 +119,14 @@
           ]
         },
         {
-          "denom": "weth",
+          "denom": "axlweth",
           "exponent": 18
         }
       ],
       "base": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "name": "Wrapped Ether",
-      "display": "weth",
+      "display": "axlweth",
       "symbol": "WETH",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "weth-wei"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth-wei L@3x.png"
       },
@@ -138,9 +134,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:704"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 704
+      },
       "traces": [
         {
           "type": "ibc",
@@ -166,19 +164,14 @@
           ]
         },
         {
-          "denom": "wbtc",
+          "denom": "axlwbtc",
           "exponent": 8
         }
       ],
       "base": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "name": "Wrapped Bitcoin",
-      "display": "wbtc",
+      "display": "axlwbtc",
       "symbol": "WBTC",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "wbtc-satoshi"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc-satoshi L@3x.png"
       },
@@ -186,9 +179,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:712"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 712
+      },
       "traces": [
         {
           "type": "ibc",
@@ -214,19 +209,14 @@
           ]
         },
         {
-          "denom": "dai",
+          "denom": "axldai",
           "exponent": 18
         }
       ],
       "base": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "name": "Dai Stablecoin",
-      "display": "dai",
+      "display": "axldai",
       "symbol": "DAI",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "dai-wei"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai-wei L@3x.png"
       },
@@ -234,9 +224,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:674"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 674
+      },
       "traces": [
         {
           "type": "ibc",
@@ -262,28 +254,25 @@
           ]
         },
         {
-          "denom": "busd",
+          "denom": "axlbusd",
           "exponent": 18
         }
       ],
       "base": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
       "name": "Binance USD",
-      "display": "busd",
-      "symbol": "BUSD",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "busd-wei"
-      },
+      "display": "axlbusd",
+      "symbol": "BUSD.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
       },
       "coingecko_id": "binance-usd",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "USDC.axl:877"
+        "osmosis-info"
       ],
+      "pools": {
+        "USDC.axl": 877
+      },
       "traces": [
         {
           "type": "ibc",
@@ -317,11 +306,6 @@
       "name": "Cosmos",
       "display": "atom",
       "symbol": "ATOM",
-      "ibc": {
-        "source_channel": "channel-141",
-        "dst_channel": "channel-0",
-        "source_denom": "uatom"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
@@ -330,9 +314,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:1"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 1
+      },
       "traces": [
         {
           "type": "ibc",
@@ -366,11 +352,6 @@
       "name": "Cronos",
       "display": "cro",
       "symbol": "CRO",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-5",
-        "source_denom": "basecro"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png"
       },
@@ -378,9 +359,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:9"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 9
+      },
       "traces": [
         {
           "type": "ibc",
@@ -406,19 +389,14 @@
           ]
         },
         {
-          "denom": "wbnb",
+          "denom": "axlwbnb",
           "exponent": 18
         }
       ],
       "base": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
       "name": "Wrapped BNB",
-      "display": "wbnb",
-      "symbol": "WBNB",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "wbnb-wei"
-      },
+      "display": "axlwbnb",
+      "symbol": "WBNB.axl",
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
@@ -427,9 +405,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:840"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 840
+      },
       "traces": [
         {
           "type": "ibc",
@@ -455,19 +435,14 @@
           ]
         },
         {
-          "denom": "wmatic",
+          "denom": "axlwmatic",
           "exponent": 18
         }
       ],
       "base": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
       "name": "Wrapped Matic",
-      "display": "wmatic",
-      "symbol": "WMATIC",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "wmatic-wei"
-      },
+      "display": "axlwmatic",
+      "symbol": "WMATIC.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png"
       },
@@ -475,9 +450,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:789"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 789
+      },
       "traces": [
         {
           "type": "ibc",
@@ -511,11 +488,6 @@
       "name": "Juno",
       "display": "juno",
       "symbol": "JUNO",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-42",
-        "source_denom": "ujuno"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
@@ -524,9 +496,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:497"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 497
+      },
       "traces": [
         {
           "type": "ibc",
@@ -553,19 +527,14 @@
           ]
         },
         {
-          "denom": "dot",
+          "denom": "axldot",
           "exponent": 10
         }
       ],
       "base": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "name": "DOT",
-      "display": "dot",
-      "symbol": "DOT",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "dot-planck"
-      },
+      "display": "axldot",
+      "symbol": "DOT.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dot-planck L@3x.png"
       },
@@ -573,9 +542,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:773"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 773
+      },
       "traces": [
         {
           "type": "ibc",
@@ -609,11 +580,6 @@
       "name": "Evmos",
       "display": "evmos",
       "symbol": "EVMOS",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-204",
-        "source_denom": "aevmos"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
@@ -622,9 +588,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:722"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 722
+      },
       "traces": [
         {
           "type": "ibc",
@@ -658,11 +626,6 @@
       "name": "Kava",
       "display": "kava",
       "symbol": "KAVA",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-143",
-        "source_denom": "ukava"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
       },
@@ -670,9 +633,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:730"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 730
+      },
       "traces": [
         {
           "type": "ibc",
@@ -706,11 +671,6 @@
       "name": "Secret Network",
       "display": "scrt",
       "symbol": "SCRT",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-88",
-        "source_denom": "uscrt"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
@@ -719,9 +679,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:584"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 584
+      },
       "traces": [
         {
           "type": "ibc",
@@ -755,11 +717,6 @@
       "name": "Luna Classic",
       "display": "lunc",
       "symbol": "LUNC",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-72",
-        "source_denom": "uluna"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
@@ -767,9 +724,11 @@
       "coingecko_id": "terra-luna",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:800"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 800
+      },
       "traces": [
         {
           "type": "ibc",
@@ -807,20 +766,17 @@
       "name": "TerraClassicUSD",
       "display": "ust",
       "symbol": "USTC",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-72",
-        "source_denom": "uusd"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
       },
       "coingecko_id": "terrausd",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:560"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 560
+      },
       "traces": [
         {
           "type": "ibc",
@@ -854,11 +810,6 @@
       "name": "Stargaze",
       "display": "stars",
       "symbol": "STARS",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-75",
-        "source_denom": "ustars"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
       },
@@ -866,9 +817,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:604"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 604
+      },
       "traces": [
         {
           "type": "ibc",
@@ -902,11 +855,6 @@
       "name": "Chihuahua",
       "display": "huahua",
       "symbol": "HUAHUA",
-      "ibc": {
-        "source_channel": "channel-7",
-        "dst_channel": "channel-113",
-        "source_denom": "uhuahua"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.svg"
@@ -915,9 +863,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:605"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 605
+      },
       "traces": [
         {
           "type": "ibc",
@@ -951,11 +901,6 @@
       "name": "Persistence",
       "display": "xprt",
       "symbol": "XPRT",
-      "ibc": {
-        "source_channel": "channel-6",
-        "dst_channel": "channel-4",
-        "source_denom": "uxprt"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png"
       },
@@ -963,9 +908,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:15"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 15
+      },
       "traces": [
         {
           "type": "ibc",
@@ -996,11 +943,6 @@
       "name": "PSTAKE",
       "display": "pstake",
       "symbol": "PSTAKE",
-      "ibc": {
-        "source_channel": "channel-6",
-        "dst_channel": "channel-4",
-        "source_denom": "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
@@ -1009,9 +951,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:648"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 648
+      },
       "traces": [
         {
           "type": "liquid-stake",
@@ -1073,11 +1017,6 @@
       "name": "Akash Network",
       "display": "akt",
       "symbol": "AKT",
-      "ibc": {
-        "source_channel": "channel-9",
-        "dst_channel": "channel-1",
-        "source_denom": "uakt"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
@@ -1086,9 +1025,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:3"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 3
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1122,11 +1063,6 @@
       "name": "Regen Network",
       "display": "regen",
       "symbol": "REGEN",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-8",
-        "source_denom": "uregen"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
       },
@@ -1134,9 +1070,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:42"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 42
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1170,11 +1108,6 @@
       "name": "Sentinel",
       "display": "dvpn",
       "symbol": "DVPN",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-2",
-        "source_denom": "udvpn"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
       },
@@ -1182,9 +1115,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:5"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 5
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1218,11 +1153,6 @@
       "name": "IRISnet",
       "display": "iris",
       "symbol": "IRIS",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-6",
-        "source_denom": "uiris"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png"
       },
@@ -1230,9 +1160,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:7"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 7
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1266,11 +1198,6 @@
       "name": "Starname",
       "display": "iov",
       "symbol": "IOV",
-      "ibc": {
-        "source_channel": "channel-2",
-        "dst_channel": "channel-15",
-        "source_denom": "uiov"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
@@ -1279,9 +1206,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:197"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 197
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1315,11 +1244,6 @@
       "name": "e-Money",
       "display": "ngm",
       "symbol": "NGM",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-37",
-        "source_denom": "ungm"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
@@ -1328,9 +1252,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:463"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 463
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1361,11 +1287,6 @@
       "name": "e-Money EUR",
       "display": "eeur",
       "symbol": "EEUR",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-37",
-        "source_denom": "eeur"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
@@ -1374,9 +1295,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:481"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 481
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1410,11 +1333,6 @@
       "name": "LikeCoin",
       "display": "like",
       "symbol": "LIKE",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-53",
-        "source_denom": "nanolike"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
@@ -1423,9 +1341,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:553"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 553
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1459,20 +1379,17 @@
       "name": "IXO",
       "display": "ixo",
       "symbol": "IXO",
-      "ibc": {
-        "source_channel": "channel-4",
-        "dst_channel": "channel-38",
-        "source_denom": "uixo"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
       },
       "coingecko_id": "ixo",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:557"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 557
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1506,11 +1423,6 @@
       "name": "BitCanna",
       "display": "bcna",
       "symbol": "BCNA",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-51",
-        "source_denom": "ubcna"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
@@ -1519,9 +1431,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:571"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 571
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1555,11 +1469,6 @@
       "name": "BitSong",
       "display": "btsg",
       "symbol": "BTSG",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-73",
-        "source_denom": "ubtsg"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
@@ -1568,9 +1477,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:573"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 573
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1604,11 +1515,6 @@
       "name": "Ki",
       "display": "xki",
       "symbol": "XKI",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-77",
-        "source_denom": "uxki"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
@@ -1617,9 +1523,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:577"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 577
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1653,11 +1561,6 @@
       "name": "MediBloc",
       "display": "med",
       "symbol": "MED",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-82",
-        "source_denom": "umed"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
       },
@@ -1665,9 +1568,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:586"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 586
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1697,19 +1602,16 @@
       "name": "Bostrom",
       "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "symbol": "BOOT",
-      "ibc": {
-        "source_channel": "channel-2",
-        "dst_channel": "channel-95",
-        "source_denom": "boot"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
       },
       "coingecko_id": "bostrom",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:597"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 597
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1743,11 +1645,6 @@
       "name": "Comdex",
       "display": "cmdx",
       "symbol": "CMDX",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-87",
-        "source_denom": "ucmdx"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
       },
@@ -1755,9 +1652,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:601"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 601
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1791,11 +1690,6 @@
       "name": "Cheqd",
       "display": "cheq",
       "symbol": "CHEQ",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-108",
-        "source_denom": "ncheq"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
@@ -1804,9 +1698,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:602"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 602
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1840,11 +1736,6 @@
       "name": "Lum",
       "display": "lum",
       "symbol": "LUM",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-115",
-        "source_denom": "ulum"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
       },
@@ -1852,9 +1743,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:608"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 608
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1888,11 +1781,6 @@
       "name": "Vidulum",
       "display": "vdl",
       "symbol": "VDL",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-124",
-        "source_denom": "uvdl"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
@@ -1901,9 +1789,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:613"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 613
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1937,11 +1827,6 @@
       "name": "Desmos",
       "display": "dsm",
       "symbol": "DSM",
-      "ibc": {
-        "source_channel": "channel-2",
-        "dst_channel": "channel-135",
-        "source_denom": "udsm"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
@@ -1950,9 +1835,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:619"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 619
+      },
       "traces": [
         {
           "type": "ibc",
@@ -1986,11 +1873,6 @@
       "name": "Dig Chain",
       "display": "dig",
       "symbol": "DIG",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-128",
-        "source_denom": "udig"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
       },
@@ -1998,9 +1880,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:621"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 621
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2034,11 +1918,6 @@
       "name": "Sommelier",
       "display": "somm",
       "symbol": "SOMM",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-165",
-        "source_denom": "usomm"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
@@ -2047,9 +1926,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:627"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 627
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2083,11 +1964,6 @@
       "name": "Band Protocol",
       "display": "band",
       "symbol": "BAND",
-      "ibc": {
-        "source_channel": "channel-83",
-        "dst_channel": "channel-148",
-        "source_denom": "uband"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
@@ -2096,9 +1972,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:626"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 626
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2132,11 +2010,6 @@
       "name": "Konstellation",
       "display": "darc",
       "symbol": "DARC",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-171",
-        "source_denom": "udarc"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
@@ -2144,9 +2017,11 @@
       "coingecko_id": "darcmatter-coin",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:637"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 637
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2180,11 +2055,6 @@
       "name": "Umee",
       "display": "umee",
       "symbol": "UMEE",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-184",
-        "source_denom": "uumee"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
       },
@@ -2192,9 +2062,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:641"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 641
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2228,11 +2100,6 @@
       "name": "Graviton",
       "display": "graviton",
       "symbol": "GRAV",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-144",
-        "source_denom": "ugraviton"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
@@ -2241,9 +2108,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:625"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 625
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2277,11 +2146,6 @@
       "name": "Decentr",
       "display": "dec",
       "symbol": "DEC",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-181",
-        "source_denom": "udec"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
@@ -2290,9 +2154,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:644"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 644
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2328,11 +2194,6 @@
       "name": "Marble",
       "display": "marble",
       "symbol": "MARBLE",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
@@ -2340,9 +2201,11 @@
       "coingecko_id": "marble",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:649"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 649
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2378,11 +2241,6 @@
       "name": "Carbon",
       "display": "dswth",
       "symbol": "SWTH",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-188",
-        "source_denom": "swth"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
@@ -2391,9 +2249,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:651"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 651
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2427,20 +2287,17 @@
       "name": "Cerberus",
       "display": "crbrus",
       "symbol": "CRBRUS",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-212",
-        "source_denom": "ucrbrus"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
       },
       "coingecko_id": "cerberus-2",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:662"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 662
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2474,11 +2331,6 @@
       "name": "Fetch.ai",
       "display": "fet",
       "symbol": "FET",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-229",
-        "source_denom": "afet"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
@@ -2487,9 +2339,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:681"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 681
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2523,11 +2377,6 @@
       "name": "AssetMantle",
       "display": "mntl",
       "symbol": "MNTL",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-232",
-        "source_denom": "umntl"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
       },
@@ -2535,9 +2384,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:690"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 690
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2574,20 +2425,17 @@
       "name": "Neta",
       "display": "neta",
       "symbol": "NETA",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
       },
       "coingecko_id": "neta",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:631"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 631
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2620,11 +2468,6 @@
       "name": "Injective",
       "display": "inj",
       "symbol": "INJ",
-      "ibc": {
-        "source_channel": "channel-8",
-        "dst_channel": "channel-122",
-        "source_denom": "inj"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
@@ -2632,9 +2475,11 @@
       "coingecko_id": "injective-protocol",
       "keywords": [
         "osmosis-main",
-        "osmosis-frontier",
-        "OSMO:725"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 725
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2671,11 +2516,6 @@
       "name": "TerraClassicKRW",
       "display": "krt",
       "symbol": "KRTC",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-72",
-        "source_denom": "ukrw"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png"
       },
@@ -2713,11 +2553,6 @@
       "name": "Microtick",
       "display": "tick",
       "symbol": "TICK",
-      "ibc": {
-        "source_channel": "channel-16",
-        "dst_channel": "channel-39",
-        "source_denom": "utick"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
@@ -2725,9 +2560,11 @@
       "coingecko_id": "microtick",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "ATOM:547"
+        "osmosis-info"
       ],
+      "pools": {
+        "ATOM": 547
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2758,11 +2595,6 @@
       "name": "Sifchain Rowan",
       "display": "rowan",
       "symbol": "ROWAN",
-      "ibc": {
-        "source_channel": "channel-17",
-        "dst_channel": "channel-47",
-        "source_denom": "rowan"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
@@ -2770,9 +2602,11 @@
       "coingecko_id": "sifchain",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:629"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 629
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2806,11 +2640,6 @@
       "name": "Shentu",
       "display": "ctk",
       "symbol": "CTK",
-      "ibc": {
-        "source_channel": "channel-8",
-        "dst_channel": "channel-146",
-        "source_denom": "uctk"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
       },
@@ -2850,20 +2679,17 @@
       "name": "Hope Galaxy",
       "display": "hope",
       "symbol": "HOPE",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
       },
       "coingecko_id": "hope-galaxy",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:653"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 653
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2901,20 +2727,17 @@
       "name": "Racoon",
       "display": "rac",
       "symbol": "RAC",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
       },
       "coingecko_id": "racoon",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:669"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 669
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -2942,28 +2765,25 @@
           ]
         },
         {
-          "denom": "usdt",
+          "denom": "axlusdt",
           "exponent": 6
         }
       ],
       "base": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "name": "Tether USD",
-      "display": "usdt",
-      "symbol": "USDT",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "uusdt"
-      },
+      "display": "axlusdt",
+      "symbol": "USDT.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uusdt L@3x.png"
       },
       "coingecko_id": "tether",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "USDC.axl:877"
+        "osmosis-info"
       ],
+      "pools": {
+        "USDC.axl": 877
+      },
       "traces": [
         {
           "type": "ibc",
@@ -2989,19 +2809,14 @@
           ]
         },
         {
-          "denom": "frax",
+          "denom": "axlfrax",
           "exponent": 18
         }
       ],
       "base": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
       "name": "Frax",
-      "display": "frax",
-      "symbol": "FRAX",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "frax-wei"
-      },
+      "display": "axlfrax",
+      "symbol": "FRAX.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/frax-wei L@3x.png"
       },
@@ -3039,11 +2854,6 @@
       "name": "Wrapped Bitcoin",
       "display": "gwbtc",
       "symbol": "WBTC.grv",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-144",
-        "source_denom": "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
       },
@@ -3081,20 +2891,17 @@
       "name": "Wrapped Ethereum",
       "display": "gweth",
       "symbol": "WETH.grv",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-144",
-        "source_denom": "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
       },
       "coingecko_id": "weth",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:634"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 634
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3128,20 +2935,17 @@
       "name": "USD Coin",
       "display": "gusdc",
       "symbol": "USDC.grv",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-144",
-        "source_denom": "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.png"
       },
       "coingecko_id": "usd-coin",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:633"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 633
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3175,11 +2979,6 @@
       "name": "Dai Stablecoin",
       "display": "gdai",
       "symbol": "DAI.grv",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-144",
-        "source_denom": "gravity0x6B175474E89094C44Da98b954EedeAC495271d0F"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.png"
       },
@@ -3217,11 +3016,6 @@
       "name": "Tether USD",
       "display": "gusdt",
       "symbol": "USDT.grv",
-      "ibc": {
-        "source_channel": "channel-10",
-        "dst_channel": "channel-144",
-        "source_denom": "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
@@ -3229,9 +3023,11 @@
       "coingecko_id": "tether",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:818"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 818
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3267,19 +3063,16 @@
       "name": "Block",
       "display": "block",
       "symbol": "BLOCK",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
       },
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:691"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 691
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3315,11 +3108,6 @@
       "name": "Provenance",
       "display": "hash",
       "symbol": "HASH",
-      "ibc": {
-        "source_channel": "channel-7",
-        "dst_channel": "channel-222",
-        "source_denom": "nhash"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg"
@@ -3327,9 +3115,11 @@
       "coingecko_id": "provenance-blockchain",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:693"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 693
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3363,19 +3153,16 @@
       "name": "Galaxy",
       "display": "glx",
       "symbol": "GLX",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-236",
-        "source_denom": "uglx"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.svg"
       },
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:697"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 697
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3407,20 +3194,17 @@
       "name": "DHK",
       "display": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
       "symbol": "DHK",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:695"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 695
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3458,19 +3242,16 @@
       "name": "JunoSwap",
       "display": "raw",
       "symbol": "RAW",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png"
       },
       "coingecko_id": "junoswap-raw-dao",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:700"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 700
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3506,20 +3287,17 @@
       "name": "Meme",
       "display": "meme",
       "symbol": "MEME",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-238",
-        "source_denom": "umeme"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:701"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 701
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3555,11 +3333,6 @@
       "name": "Another.Software Validator Token",
       "display": "asvt",
       "symbol": "ASVT",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
       },
@@ -3600,19 +3373,16 @@
       "name": "JoeDAO",
       "display": "joe",
       "symbol": "JOE",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:718"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 718
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -3648,20 +3418,17 @@
       "name": "Luna",
       "display": "luna",
       "symbol": "LUNA",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-251",
-        "source_denom": "uluna"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
       },
       "coingecko_id": "terra-luna-2",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:726"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 726
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3695,11 +3462,6 @@
       "name": "Atolo",
       "display": "atolo",
       "symbol": "ATOLO",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-221",
-        "source_denom": "uatolo"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
@@ -3738,11 +3500,6 @@
       "name": "Hard",
       "display": "HARD",
       "symbol": "HARD",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-143",
-        "source_denom": "hard"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
@@ -3781,11 +3538,6 @@
       "name": "Swap",
       "display": "SWP",
       "symbol": "SWP",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-143",
-        "source_denom": "swp"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
@@ -3816,19 +3568,14 @@
           ]
         },
         {
-          "denom": "link",
+          "denom": "axllink",
           "exponent": 18
         }
       ],
       "base": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
       "name": "Chainlink",
-      "display": "link",
-      "symbol": "LINK",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "link-wei"
-      },
+      "display": "axllink",
+      "symbol": "LINK.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/link-wei L@3x.png"
       },
@@ -3836,9 +3583,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:731"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 731
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3872,20 +3621,17 @@
       "name": "GenesisL1",
       "display": "l1",
       "symbol": "L1",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-253",
-        "source_denom": "el1"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:732"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 732
+      },
       "traces": [
         {
           "type": "ibc",
@@ -3911,19 +3657,14 @@
           ]
         },
         {
-          "denom": "aave",
+          "denom": "axlaave",
           "exponent": 18
         }
       ],
       "base": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
       "name": "Aave",
-      "display": "aave",
-      "symbol": "AAVE",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "aave-wei"
-      },
+      "display": "axlaave",
+      "symbol": "AAVE.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/aave-wei L@3x.png"
       },
@@ -3953,19 +3694,14 @@
           ]
         },
         {
-          "denom": "ape",
+          "denom": "axlape",
           "exponent": 18
         }
       ],
       "base": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
       "name": "ApeCoin",
-      "display": "ape",
-      "symbol": "APE",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "ape-wei"
-      },
+      "display": "axlape",
+      "symbol": "APE.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/ape-wei L@3x.png"
       },
@@ -3995,19 +3731,14 @@
           ]
         },
         {
-          "denom": "axs",
+          "denom": "axlaxs",
           "exponent": 18
         }
       ],
       "base": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
       "name": "Axie Infinity Shard",
-      "display": "axs",
-      "symbol": "AXS",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "axs-wei"
-      },
+      "display": "axlaxs",
+      "symbol": "AXS.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axs-wei L@3x.png"
       },
@@ -4037,28 +3768,25 @@
           ]
         },
         {
-          "denom": "mkr",
+          "denom": "axlmkr",
           "exponent": 18
         }
       ],
       "base": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
       "name": "Maker",
-      "display": "mkr",
-      "symbol": "MKR",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "mkr-wei"
-      },
+      "display": "axlmkr",
+      "symbol": "MKR.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/mkr-wei L@3x.png"
       },
       "coingecko_id": "maker",
       "keywords": [
         "osmosis-main",
-        "osmosis-frontier",
-        "OSMO:733"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 733
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4084,19 +3812,14 @@
           ]
         },
         {
-          "denom": "rai",
+          "denom": "axlrai",
           "exponent": 18
         }
       ],
       "base": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
       "name": "Rai Reflex Index",
-      "display": "rai",
-      "symbol": "RAI",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "rai-wei"
-      },
+      "display": "axlrai",
+      "symbol": "RAI.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/rai-wei L@3x.png"
       },
@@ -4126,19 +3849,14 @@
           ]
         },
         {
-          "denom": "shib",
+          "denom": "axlshib",
           "exponent": 18
         }
       ],
       "base": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
       "name": "Shiba Inu",
-      "display": "shib",
-      "symbol": "SHIB",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "shib-wei"
-      },
+      "display": "axlshib",
+      "symbol": "SHIB.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/shib-wei L@3x.png"
       },
@@ -4168,19 +3886,14 @@
           ]
         },
         {
-          "denom": "uni",
+          "denom": "axluni",
           "exponent": 18
         }
       ],
       "base": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
       "name": "Uniswap",
-      "display": "uni",
-      "symbol": "UNI",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "uni-wei"
-      },
+      "display": "axluni",
+      "symbol": "UNI.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/uni-wei L@3x.png"
       },
@@ -4210,19 +3923,14 @@
           ]
         },
         {
-          "denom": "xcn",
+          "denom": "axlxcn",
           "exponent": 18
         }
       ],
       "base": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
       "name": "Chain",
-      "display": "xcn",
-      "symbol": "XCN",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "xcn-wei"
-      },
+      "display": "axlxcn",
+      "symbol": "XCN.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/xcn-wei L@3x.png"
       },
@@ -4260,11 +3968,6 @@
       "name": "Kuji",
       "display": "kuji",
       "symbol": "KUJI",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-259",
-        "source_denom": "ukuji"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
       },
@@ -4272,9 +3975,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:744"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 744
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4308,11 +4013,6 @@
       "name": "Tgrade",
       "display": "tgd",
       "symbol": "TGD",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-263",
-        "source_denom": "utgd"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
@@ -4320,9 +4020,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:769"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 769
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4356,20 +4058,17 @@
       "name": "Echelon",
       "display": "echelon",
       "symbol": "ECH",
-      "ibc": {
-        "source_channel": "channel-11",
-        "dst_channel": "channel-403",
-        "source_denom": "aechelon"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/logo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
       },
       "coingecko_id": "echelon",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:848"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 848
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4403,11 +4102,6 @@
       "name": "ODIN",
       "display": "odin",
       "symbol": "ODIN",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-258",
-        "source_denom": "loki"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
@@ -4415,9 +4109,11 @@
       "coingecko_id": "odin-protocol",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:777"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 777
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4451,11 +4147,6 @@
       "name": "GEO",
       "display": "geo",
       "symbol": "GEO",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-258",
-        "source_denom": "mGeo"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
@@ -4463,9 +4154,11 @@
       "coingecko_id": "geodb",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:787"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 787
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4499,19 +4192,16 @@
       "name": "O9W",
       "display": "O9W",
       "symbol": "O9W",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-258",
-        "source_denom": "mO9W"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
       },
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:805"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 805
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4548,20 +4238,17 @@
       "name": "Lvn",
       "display": "lvn",
       "symbol": "LVN",
-      "ibc": {
-        "source_channel": "channel-18",
-        "dst_channel": "channel-261",
-        "source_denom": "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
       },
       "coingecko_id": "lvn",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:774"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 774
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4590,19 +4277,14 @@
           ]
         },
         {
-          "denom": "wglmr",
+          "denom": "axlwglmr",
           "exponent": 18
         }
       ],
       "base": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
       "name": "Wrapped GLMR",
-      "display": "wglmr",
-      "symbol": "WGLMR",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "wglmr-wei"
-      },
+      "display": "axlwglmr",
+      "symbol": "WGLMR.axl",
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wdev-wei.png"
       },
@@ -4642,19 +4324,16 @@
       "name": "Gelotto",
       "display": "glto",
       "symbol": "GLTO",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:778"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 778
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4692,19 +4371,16 @@
       "name": "GKey",
       "display": "gkey",
       "symbol": "GKEY",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:790"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 790
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -4740,11 +4416,6 @@
       "name": "Crescent",
       "display": "cre",
       "symbol": "CRE",
-      "ibc": {
-        "source_channel": "channel-9",
-        "dst_channel": "channel-297",
-        "source_denom": "ucre"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
@@ -4752,9 +4423,11 @@
       "coingecko_id": "crescent-network",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:786"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 786
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4788,18 +4461,15 @@
       "name": "LumenX",
       "display": "lumen",
       "symbol": "LUMEN",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-286",
-        "source_denom": "ulumen"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png"
       },
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:788"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 788
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4833,11 +4503,6 @@
       "name": "Oraichain",
       "display": "ORAI",
       "symbol": "ORAI",
-      "ibc": {
-        "source_channel": "channel-13",
-        "dst_channel": "channel-216",
-        "source_denom": "orai"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
@@ -4876,11 +4541,6 @@
       "name": "Cudos",
       "display": "cudos",
       "symbol": "CUDOS",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-298",
-        "source_denom": "acudos"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
@@ -4888,9 +4548,11 @@
       "coingecko_id": "cudos",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:796"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 796
+      },
       "traces": [
         {
           "type": "ibc",
@@ -4924,11 +4586,6 @@
       "name": "USDX",
       "display": "USDX",
       "symbol": "USDX",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-143",
-        "source_denom": "usdx"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png"
       },
@@ -4969,17 +4626,14 @@
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
       },
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-320",
-        "source_denom": "ubld"
-      },
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:795"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 795
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5013,11 +4667,6 @@
       "name": "Inter Stable Token",
       "display": "ist",
       "symbol": "IST",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-320",
-        "source_denom": "uist"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
       },
@@ -5025,9 +4674,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:837"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 837
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5063,11 +4714,6 @@
       "name": "StakeEasy seJUNO",
       "display": "sejuno",
       "symbol": "seJUNO",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
@@ -5075,9 +4721,11 @@
       "coingecko_id": "stakeeasy-juno-derivative",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:793"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 793
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5115,11 +4763,6 @@
       "name": "StakeEasy bJUNO",
       "display": "bjuno",
       "symbol": "bJUNO",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
@@ -5161,11 +4804,6 @@
       "name": "Stride",
       "display": "strd",
       "symbol": "STRD",
-      "ibc": {
-        "source_channel": "channel-5",
-        "dst_channel": "channel-326",
-        "source_denom": "ustrd"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
@@ -5174,9 +4812,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:806"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 806
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5210,11 +4850,6 @@
       "name": "Stride Staked Atom",
       "display": "statom",
       "symbol": "stATOM",
-      "ibc": {
-        "source_channel": "channel-5",
-        "dst_channel": "channel-326",
-        "source_denom": "stuatom"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
@@ -5223,9 +4858,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "ATOM:803"
+        "osmosis-info"
       ],
+      "pools": {
+        "ATOM": 803
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5259,20 +4896,17 @@
       "name": "Stride Staked Stars",
       "display": "ststars",
       "symbol": "stSTARS",
-      "ibc": {
-        "source_channel": "channel-5",
-        "dst_channel": "channel-326",
-        "source_denom": "stustars"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "STARS:810"
+        "osmosis-info"
       ],
+      "pools": {
+        "STARS": 810
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5308,11 +4942,6 @@
       "name": "Solarbank DAO",
       "display": "solar",
       "symbol": "SOLAR",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
@@ -5354,20 +4983,17 @@
       "name": "StakeEasy SEASY",
       "display": "seasy",
       "symbol": "SEASY",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
       },
       "coingecko_id": "seasy",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:808"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 808
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5403,11 +5029,6 @@
       "name": "Axelar",
       "display": "axl",
       "symbol": "AXL",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-208",
-        "source_denom": "uaxl"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
@@ -5416,9 +5037,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:812"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 812
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5452,11 +5075,6 @@
       "name": "Rebuschain",
       "display": "rebus",
       "symbol": "REBUS",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-355",
-        "source_denom": "arebus"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
@@ -5464,9 +5082,11 @@
       "coingecko_id": "rebus",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:813"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 813
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5500,11 +5120,6 @@
       "name": "teritori",
       "display": "tori",
       "symbol": "TORI",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-362",
-        "source_denom": "utori"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/tori.svg"
@@ -5512,9 +5127,11 @@
       "coingecko_id": "teritori",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:816"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 816
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5548,20 +5165,17 @@
       "name": "Stride Juno",
       "display": "stjuno",
       "symbol": "stJUNO",
-      "ibc": {
-        "source_channel": "channel-5",
-        "dst_channel": "channel-326",
-        "source_denom": "stujuno"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "JUNO:817"
+        "osmosis-info"
       ],
+      "pools": {
+        "JUNO": 817
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5595,11 +5209,6 @@
       "name": "Stride Staked osmo",
       "display": "stosmo",
       "symbol": "stOSMO",
-      "ibc": {
-        "source_channel": "channel-5",
-        "dst_channel": "channel-326",
-        "source_denom": "stuosmo"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
@@ -5608,9 +5217,11 @@
       "keywords": [
         "osmosis-main",
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:833"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 833
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5646,11 +5257,6 @@
       "name": "MUSE",
       "display": "muse",
       "symbol": "MUSE",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
       },
@@ -5689,20 +5295,17 @@
       "name": "Lambda",
       "display": "lamb",
       "symbol": "LAMB",
-      "ibc": {
-        "source_channel": "channel-2",
-        "dst_channel": "channel-378",
-        "source_denom": "ulamb"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
       },
       "coingecko_id": "lambda",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:826"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 826
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5736,19 +5339,16 @@
       "name": "USK",
       "display": "USK",
       "symbol": "USK",
-      "ibc": {
-        "source_channel": "channel-3",
-        "dst_channel": "channel-259",
-        "source_denom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
       },
       "coingecko_id": "usk",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:819"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 819
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5782,19 +5382,16 @@
       "name": "Unification",
       "display": "fund",
       "symbol": "FUND",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-382",
-        "source_denom": "nund"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
       },
       "coingecko_id": "unification",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:830"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 830
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5828,11 +5425,6 @@
       "name": "Jackal",
       "display": "jkl",
       "symbol": "JKL",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-412",
-        "source_denom": "ujkl"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
@@ -5840,9 +5432,11 @@
       "coingecko_id": "",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:832"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 832
+      },
       "traces": [
         {
           "type": "ibc",
@@ -5878,11 +5472,6 @@
       "name": "Alter",
       "display": "alter",
       "symbol": "ALTER",
-      "ibc": {
-        "source_channel": "channel-44",
-        "dst_channel": "channel-476",
-        "source_denom": "cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg"
@@ -5890,9 +5479,11 @@
       "coingecko_id": "alter",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:845"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 845
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -5930,11 +5521,6 @@
       "name": "Button",
       "display": "butt",
       "symbol": "BUTT",
-      "ibc": {
-        "source_channel": "channel-44",
-        "dst_channel": "channel-476",
-        "source_denom": "cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
@@ -5977,11 +5563,6 @@
       "name": "Shade",
       "display": "shd",
       "symbol": "SHD",
-      "ibc": {
-        "source_channel": "channel-44",
-        "dst_channel": "channel-476",
-        "source_denom": "cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg"
@@ -5989,9 +5570,11 @@
       "coingecko_id": "shade-protocol",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:846"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 846
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -6029,20 +5612,17 @@
       "name": "SIENNA",
       "display": "sienna",
       "symbol": "SIENNA",
-      "ibc": {
-        "source_channel": "channel-44",
-        "dst_channel": "channel-476",
-        "source_denom": "cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
       },
       "coingecko_id": "sienna",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:853"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 853
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -6080,20 +5660,17 @@
       "name": "SCRT Staking Derivatives",
       "display": "stkd-scrt",
       "symbol": "stkd-SCRT",
-      "ibc": {
-        "source_channel": "channel-44",
-        "dst_channel": "channel-476",
-        "source_denom": "cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg"
       },
       "coingecko_id": "stkd-scrt",
       "keywords": [
-        "osmosis-frontier",
-        "SCRT:854"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "SCRT": 854
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -6129,11 +5706,6 @@
       "name": "BeeZee",
       "display": "bze",
       "symbol": "BZE",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-340",
-        "source_denom": "ubze"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
@@ -6141,9 +5713,11 @@
       "coingecko_id": "bzedge",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:856"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 856
+      },
       "traces": [
         {
           "type": "ibc",
@@ -6179,11 +5753,6 @@
       "name": "Fanfury",
       "display": "fury",
       "symbol": "FURY",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"
       },
@@ -6223,20 +5792,17 @@
       "name": "Acre",
       "display": "acre",
       "symbol": "ACRE",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-490",
-        "source_denom": "aacre"
-      },
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg",
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.png"
       },
       "coingecko_id": "arable-protocol",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:858"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 858
+      },
       "traces": [
         {
           "type": "ibc",
@@ -6270,19 +5836,16 @@
       "name": "CMST",
       "display": "cmst",
       "symbol": "CMST",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-87",
-        "source_denom": "ucmst"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png"
       },
       "coingecko_id": "",
       "keywords": [
-        "osmosis-frontier",
-        "OSMO:857"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "OSMO": 857
+      },
       "traces": [
         {
           "type": "ibc",
@@ -6316,19 +5879,16 @@
       "name": "Imversed",
       "display": "imv",
       "symbol": "IMV",
-      "ibc": {
-        "source_channel": "channel-1",
-        "dst_channel": "channel-517",
-        "source_denom": "aimv"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
       },
       "keywords": [
-        "osmosis-frontier",
-        "USDC.axl:866"
+        "osmosis-frontier"
       ],
+      "pools": {
+        "USDC.axl": 866
+      },
       "traces": [
         {
           "type": "ibc",
@@ -6362,20 +5922,17 @@
       "name": "MedasDigital",
       "display": "medas",
       "symbol": "MEDAS",
-      "ibc": {
-        "source_channel": "channel-0",
-        "dst_channel": "channel-519",
-        "source_denom": "umedas"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.svg"
       },
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "OSMO:859"
+        "osmosis-info"
       ],
+      "pools": {
+        "OSMO": 859
+      },
       "traces": [
         {
           "type": "ibc",
@@ -6411,11 +5968,6 @@
       "name": "Posthuman",
       "display": "phmn",
       "symbol": "PHMN",
-      "ibc": {
-        "source_channel": "channel-47",
-        "dst_channel": "channel-169",
-        "source_denom": "cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg"
@@ -6423,9 +5975,11 @@
       "coingecko_id": "posthuman",
       "keywords": [
         "osmosis-frontier",
-        "osmosis-info",
-        "ATOM:867"
+        "osmosis-info"
       ],
+      "pools": {
+        "ATOM": 867
+      },
       "traces": [
         {
           "type": "ibc-cw20",
@@ -6463,11 +6017,6 @@
       "name": "Amber",
       "display": "amber",
       "symbol": "AMBER",
-      "ibc": {
-        "source_channel": "channel-44",
-        "dst_channel": "channel-476",
-        "source_denom": "cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.svg"
@@ -6510,11 +6059,6 @@
       "name": "PSTAKE staked ATOM",
       "display": "stkatom",
       "symbol": "stkATOM",
-      "ibc": {
-        "source_channel": "channel-6",
-        "dst_channel": "channel-4",
-        "source_denom": "stk/uatom"
-      },
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.svg"


### PR DESCRIPTION
because the less confusing information is now in traces.

was: 
```
      "ibc": {
        "source_channel": "channel-3",
        "dst_channel": "channel-208",
        "source_denom": "uusdc"
      },
```
now:
```
      "traces": [
        {
          "type": "ibc",
          "counterparty": {
            "chain_name": "axelar",
            "base_denom": "uusdc",
            "channel_id": "channel-3"
          },
          "chain": {
            "channel_id": "channel-208"
          }
        }
      ]
```