### PR TITLE
Add Chain Registry as Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "chain-registry"]
+	path = chain-registry
+	url = https://github.com/cosmos/chain-registry


### PR DESCRIPTION
Purpose
-It allows us to remove our assetlist.schema.json (because ours is just an exact copy of Chain Reg's), so we won't need to worry about keeping it up to date--less moving parts is always nice. We simply point the validation to use the submodule's assetlist.schema instead.
-It allows us to very easily automate the generation of assetlists (next step) without needing to request from a web address; we can simply look into the '/chain-registry/' directory that's in the same repo, so using ('../chain-registry/' as the root dir for chain reg data).