### PR TITLE
Add osmo-test-4 zone json

### DIFF
--- a/osmo-test-4/osmosis.zone.json
+++ b/osmo-test-4/osmosis.zone.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "../zone.schema.json",
+  "chain_name": "osmosis",
+  "assets": [
+    {
+      "chain_name": "osmosistestnet",
+      "base_denom": "uosmo",
+      "osmosis_main": true,
+      "osmosis_frontier": true,
+      "osmosis_info": false
+    },
+    {
+      "chain_name": "osmosistestnet",
+      "base_denom": "uion",
+      "osmosis_main": true,
+      "osmosis_frontier": true,
+      "osmosis_info": false
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "uausdc",
+      "osmosis_main": true,
+      "osmosis_frontier": true,
+      "osmosis_info": false,
+      "override_properties": {
+        "symbol": "USDC"
+      }
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "weth-wei",
+      "osmosis_main": true,
+      "osmosis_frontier": true,
+      "osmosis_info": false,
+      "override_properties": {
+        "symbol": "WETH"
+      }
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "wbnb-wei",
+      "osmosis_main": true,
+      "osmosis_frontier": true,
+      "osmosis_info": false,
+      "override_properties": {
+        "symbol": "WBNB"
+      }
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "wmatic-wei",
+      "osmosis_main": true,
+      "osmosis_frontier": true,
+      "osmosis_info": false,
+      "override_properties": {
+        "symbol": "WMATIC"
+      }
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "wglmr-wei",
+      "osmosis_main": false,
+      "osmosis_frontier": true,
+      "osmosis_info": false,
+      "override_properties": {
+        "symbol": "WGLMR"
+      }
+    }
+  ]
+}

--- a/osmo-test-4/osmosis.zone.json
+++ b/osmo-test-4/osmosis.zone.json
@@ -5,22 +5,22 @@
     {
       "chain_name": "osmosistestnet",
       "base_denom": "uosmo",
-      "osmosis_main": true,
-      "osmosis_frontier": true,
+      "osmosis_main": false,
+      "osmosis_frontier": false,
       "osmosis_info": false
     },
     {
       "chain_name": "osmosistestnet",
       "base_denom": "uion",
-      "osmosis_main": true,
-      "osmosis_frontier": true,
+      "osmosis_main": false,
+      "osmosis_frontier": false,
       "osmosis_info": false
     },
     {
       "chain_name": "axelartestnet",
       "base_denom": "uausdc",
-      "osmosis_main": true,
-      "osmosis_frontier": true,
+      "osmosis_main": false,
+      "osmosis_frontier": false,
       "osmosis_info": false,
       "override_properties": {
         "symbol": "aUSDC"
@@ -29,8 +29,8 @@
     {
       "chain_name": "axelartestnet",
       "base_denom": "weth-wei",
-      "osmosis_main": true,
-      "osmosis_frontier": true,
+      "osmosis_main": false,
+      "osmosis_frontier": false,
       "osmosis_info": false,
       "override_properties": {
         "symbol": "WETH"
@@ -39,8 +39,8 @@
     {
       "chain_name": "axelartestnet",
       "base_denom": "wbnb-wei",
-      "osmosis_main": true,
-      "osmosis_frontier": true,
+      "osmosis_main": false,
+      "osmosis_frontier": false,
       "osmosis_info": false,
       "override_properties": {
         "symbol": "WBNB"
@@ -49,8 +49,8 @@
     {
       "chain_name": "axelartestnet",
       "base_denom": "wmatic-wei",
-      "osmosis_main": true,
-      "osmosis_frontier": true,
+      "osmosis_main": false,
+      "osmosis_frontier": false,
       "osmosis_info": false,
       "override_properties": {
         "symbol": "WMATIC"
@@ -60,7 +60,7 @@
       "chain_name": "axelartestnet",
       "base_denom": "wglmr-wei",
       "osmosis_main": false,
-      "osmosis_frontier": true,
+      "osmosis_frontier": false,
       "osmosis_info": false,
       "override_properties": {
         "symbol": "WGLMR"

--- a/osmo-test-4/osmosis.zone.json
+++ b/osmo-test-4/osmosis.zone.json
@@ -23,7 +23,7 @@
       "osmosis_frontier": true,
       "osmosis_info": false,
       "override_properties": {
-        "symbol": "USDC"
+        "symbol": "aUSDC"
       }
     },
     {


### PR DESCRIPTION
Adds osmo-test-4 folder and osmosis.zone.json (same name as the zone file for mainnets, but within the testnet folder). Used to generate testnet assetlist file.