### PR TITLE
Fix wftm source chain name

### DIFF
--- a/osmosis-1/osmosis.zone.json
+++ b/osmosis-1/osmosis.zone.json
@@ -1404,7 +1404,7 @@
       "osmosis_info": true
     },
     {
-      "chain_name": "axelartestnet",
+      "chain_name": "axelar",
       "base_denom": "wftm-wei",
       "pools": {
         "OSMO": 900


### PR DESCRIPTION
Remove 'testnet' from ftm's chain name
was axelartestnet, should be just axelar