### PR TITLE
Add Check for locally defined ics20 assets

### DIFF
--- a/.github/workflows/utility/chain_registry.mjs
+++ b/.github/workflows/utility/chain_registry.mjs
@@ -11,8 +11,7 @@ import * as path from 'path';
 
 export let chainNameToDirectoryMap = new Map();
 
-//export const chainRegistryRoot = "../../../chain-registry";
-export const chainRegistryRoot = "/mnt/e/Documents/GitHub/chain-registry";
+export const chainRegistryRoot = "../../../chain-registry";
 
 const networkTypeToDirectoryNameMap = new Map();
 networkTypeToDirectoryNameMap.set("mainnet", "");

--- a/.github/workflows/utility/chain_registry.mjs
+++ b/.github/workflows/utility/chain_registry.mjs
@@ -11,7 +11,8 @@ import * as path from 'path';
 
 export let chainNameToDirectoryMap = new Map();
 
-export const chainRegistryRoot = "../../../chain-registry";
+//export const chainRegistryRoot = "../../../chain-registry";
+export const chainRegistryRoot = "/mnt/e/Documents/GitHub/chain-registry";
 
 const networkTypeToDirectoryNameMap = new Map();
 networkTypeToDirectoryNameMap.set("mainnet", "");
@@ -55,7 +56,7 @@ const fileNames = {
 };
 
 let paths = {};
-let chains = {};
+let chains = [];
 export const chain__FileName = "chain.json";
 export const assetlist__FileName = "assetlist.json";
 
@@ -110,20 +111,14 @@ export function setDifferenceArray(a, b) {
 // -- CHAIN REGISTRY MODULES --
 
 
-// - network_type:: -
-
-
-
-
-
 export function populateChainDirectories() {
   for (let [networkType, networkTypeDirectoryName] of networkTypeToDirectoryNameMap) {
     for (let [domain, domainDirectoryName] of domainToDirectoryNameMap) {
-      let chainNames = setDifferenceArray(
+      chains = setDifferenceArray(
         getDirectoryContents(path.join(chainRegistryRoot, networkTypeDirectoryName, domainDirectoryName)),
         nonChainDirectories
       );
-      chainNames.forEach((chainName) => {
+      chains.forEach((chainName) => {
         chainNameToDirectoryMap.set(
           chainName,
           path.join(chainRegistryRoot, networkTypeDirectoryName, domainDirectoryName, chainName)
@@ -225,6 +220,28 @@ export function getAssetPointers() {
     assetPointers = assetPointers.concat(getAssetPointersByChain(chainName));
   });
   return assetPointers;
+}
+
+export function getChains() {
+  chains = Array.from(chainNameToDirectoryMap.keys());
+  return chains;
+}
+
+export function filterChainsByFileProperty(chains, file, property, value) {
+  let filtered = [];
+  chains.forEach((chain) => {
+    let propertyValue = getFileProperty(chain, file, property);
+    if(value == "*") {
+      if(propertyValue && propertyValue != "") {
+        filtered.push(pointer);
+      }
+    } else {
+      if(propertyValue == value) {
+        filtered.push(pointer);
+      }
+    }
+  });
+  return filtered;
 }
 
 export function filterAssetPointersByFileProperty(pointers, file, property, value) {

--- a/.github/workflows/utility/generate_assetlist.mjs
+++ b/.github/workflows/utility/generate_assetlist.mjs
@@ -238,7 +238,7 @@ const generateAssets = async (generatedAssetlist, zoneAssetlist) => {
         return;
       });
       
-      //--Use local version if IBC Hash for asset exists in Chain Assetlist--
+      //--Use local version of asset with same IBC Hash--
       localChainAssetBases.forEach((asset) => {
         if(asset == generatedAsset.base) {
           generatedAsset = copyRegisteredAsset(localChainName, generatedAsset.base);

--- a/.github/workflows/utility/generate_assetlist.mjs
+++ b/.github/workflows/utility/generate_assetlist.mjs
@@ -36,6 +36,7 @@ const ibcFolderName = "_IBC";
 const mainnetChainName = "osmosis";
 const testnetChainName = "osmosistestnet";
 let localChainName = "";
+let localChainAssetBases = [];
 const mainnetChainId = "osmosis-1";
 const testnetChainId = "osmo-test-4";
 let localChainId = "";
@@ -124,6 +125,16 @@ function reorderProperties(object, referenceObject) {
   return newObject;
 }
 
+function getLocalChainAssetBases() {
+  try {
+    const chainRegistryChainAssetlist = JSON.parse(fs.readFileSync(path.join(chainRegistryRoot, chainRegistrySubdirectory, localChainName, assetlistFileName)));
+    chainRegistryChainAssetlist.assets.forEach((asset) => {
+      localChainAssetBases.push(asset.base);
+    });
+  } catch (err) {
+    console.log(err);
+  }
+}
 
 const generateAssets = async (generatedAssetlist, zoneAssetlist) => {
   
@@ -226,6 +237,13 @@ const generateAssets = async (generatedAssetlist, zoneAssetlist) => {
         }
         return;
       });
+      
+      //--Use local version if IBC Hash for asset exists in Chain Assetlist--
+      localChainAssetBases.forEach((asset) => {
+        if(asset == generatedAsset.base) {
+          generatedAsset = copyRegisteredAsset(localChainName, generatedAsset.base);
+        }
+      });
 
     }
   
@@ -301,11 +319,13 @@ function selectDomain(domain) {
     assetlistsSubdirectory = assetlistsMainnetsSubdirectory;
     localChainName = mainnetChainName;
     localChainId = mainnetChainId;
+    getLocalChainAssetBases();
   } else if(domain == "testnets") {
     chainRegistrySubdirectory = chainRegistryTestnetsSubdirectory;
     assetlistsSubdirectory = assetlistsTestnetsSubdirectory;
     localChainName = testnetChainName;
     localChainId = testnetChainId;
+    getLocalChainAssetBases();
   } else {
     console.log("Invalid Domain (Mainnets, Testnets, Devnets, etc.)");
   }


### PR DESCRIPTION
-The main reason why replacing a defined asset with a local definition is so we can define the cw20<>ics20 contract via the trace path in Osmosis' assetlist.json, rather than assume the first cw20<>ics20 contract that happens to be defined for a connection in the chain registry. The issue arose when we learned of 2x CW20<>ICS20 contracts for terra2, and they want to add the second contract for terra2<>osmosis as well because the token (ampluna) already uses that second contract (would be confusing to send a coin to a certain contract just for osmosis, while using a different contract for all other chains. But ASTRO uses the first contract.