### PR TITLE
Feat/add osmo test 5

### DIFF
--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -72,7 +72,7 @@
           "exponent": 6
         }
       ],
-      "base": "ibc/7E3DB8DA12B7A7E2056E2449434A6F745E3C29B50217538BE31A50375EF088C6",
+      "base": "ibc/8E2FEFCBD754FA3C97411F0126B9EC76191BAA1B3959CB73CECF396A4037BBF0",
       "name": "Juno Testnet",
       "display": "junox",
       "symbol": "JUNOX",
@@ -82,11 +82,11 @@
           "counterparty": {
             "chain_name": "junotestnet",
             "base_denom": "ujunox",
-            "channel_id": "channel-140"
+            "channel_id": "channel-190"
           },
           "chain": {
-            "channel_id": "channel-3316",
-            "path": "transfer/channel-3316/ujunox"
+            "channel_id": "channel-1",
+            "path": "transfer/channel-1/ujunox"
           }
         }
       ],

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -184,6 +184,49 @@
         "osmosis-price:uosmo:1",
         "osmosis-info_2"
       ]
+    },
+    {
+      "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
+      "denom_units": [
+        {
+          "denom": "ibc/4DAE26570FD24ABA40E2BE4137E39D946C78B00B248D3F78B0919567C4371156",
+          "exponent": 0,
+          "aliases": [
+            "uakt"
+          ]
+        },
+        {
+          "denom": "akt",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/4DAE26570FD24ABA40E2BE4137E39D946C78B00B248D3F78B0919567C4371156",
+      "name": "Akash Testnet",
+      "display": "akt",
+      "symbol": "AKT",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "sandbox",
+            "base_denom": "uakt",
+            "channel_id": "channel-2"
+          },
+          "chain": {
+            "channel_id": "channel-4",
+            "path": "transfer/channel-1/uakt"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
+      },
+      "coingecko_id": "akash-network",
+      "keywords": [
+        "osmosis-price:uosmo:3",
+        "osmosis-info_2"
+      ]
     }
   ]
 }

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -244,9 +244,9 @@
         }
       ],
       "base": "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
-      "name": "Noble Testnet",
+      "name": "USD Coin",
       "display": "usdc",
-      "symbol": "USDC",
+      "symbol": "nUSDC",
       "traces": [
         {
           "type": "ibc",
@@ -266,6 +266,56 @@
         "svg": ""
       },
       "coingecko_id": "noble-network",
+      "keywords": [
+        "osmosis-info_2"
+      ]
+    },
+    {
+      "description": "Circle's stablecoin on Axelar",
+      "denom_units": [
+        {
+          "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE",
+          "exponent": 0,
+          "aliases": [
+            "uausdc"
+          ]
+        },
+        {
+          "denom": "ausdc",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE",
+      "name": "USD Coin",
+      "display": "ausdc",
+      "symbol": "aUSDC",
+      "traces": [
+        {
+          "type": "bridge",
+          "counterparty": {
+            "chain_name": "ethereumtestnet",
+            "base_denom": "0x254d06f33bDc5b8ee05b2ea472107E300226659A"
+          },
+          "provider": "Axelar"
+        },
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "axelar-testnet-lisbon-3",
+            "base_denom": "uausdc",
+            "channel_id": "channel-227"
+          },
+          "chain": {
+            "channel_id": "channel-3",
+            "path": "transfer/channel-3/uausdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
+      },
+      "coingecko_id": "usd-coin",
       "keywords": [
         "osmosis-info_2"
       ]

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -80,7 +80,7 @@
         {
           "type": "ibc",
           "counterparty": {
-            "chain_name": "junotestnet",
+            "chain_name": "uni-6",
             "base_denom": "ujunox",
             "channel_id": "channel-190"
           },
@@ -116,14 +116,14 @@
         }
       ],
       "base": "ibc/0973EE75F04F14E896733FD6B6F00342E7CD7867785EE8596D3E74767BC19FC9",
-      "name": "Mars",
+      "name": "Mars Testnet",
       "display": "mars",
       "symbol": "MARS",
       "traces": [
         {
           "type": "ibc",
           "counterparty": {
-            "chain_name": "marstestnet",
+            "chain_name": "ares-1",
             "base_denom": "umars",
             "channel_id": "channel-12"
           },
@@ -139,6 +139,49 @@
       "keywords": [
         "OSMO:768",
         "osmosis-price:uosmo:768",
+        "osmosis-info_2"
+      ]
+    },
+    {
+      "description": "The native staking and governance token of the Cosmos Hub.",
+      "denom_units": [
+        {
+          "denom": "ibc/A8C2D23A1E6F95DA4E48BA349667E322BD7A6C996D8A4AAE8BA72E190F3D1477",
+          "exponent": 0,
+          "aliases": [
+            "uatom"
+          ]
+        },
+        {
+          "denom": "atom",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/A8C2D23A1E6F95DA4E48BA349667E322BD7A6C996D8A4AAE8BA72E190F3D1477",
+      "name": "Cosmos Hub Atom Testnet",
+      "display": "atom",
+      "symbol": "ATOM",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "thetha-testnet-001",
+            "base_denom": "uatom",
+            "channel_id": "channel-2500"
+          },
+          "chain": {
+            "channel_id": "channel-12",
+            "path": "transfer/channel-12/uatom"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+      },
+      "coingecko_id": "cosmos",
+      "keywords": [
+        "osmosis-price:uosmo:1",
         "osmosis-info_2"
       ]
     }

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -1,0 +1,104 @@
+{
+  "chain_name": "osmo-test-5",
+  "assets": [
+    {
+      "description": "The native token of Osmosis",
+      "denom_units": [
+        {
+          "denom": "uosmo",
+          "exponent": 0,
+          "aliases": []
+        },
+        {
+          "denom": "osmo",
+          "exponent": 6,
+          "aliases": []
+        }
+      ],
+      "base": "uosmo",
+      "name": "Osmosis",
+      "display": "osmo",
+      "symbol": "OSMO",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+      },
+      "coingecko_id": "osmosis",
+      "keywords": [
+        "dex",
+        "staking",
+        "osmosis-price:ibc/FF3065989E34457F342D4EFB8692406D49D4E2B5C70F725F127862E22CE6BDCD:766",
+        "osmosis-info_2"
+      ]
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "uion",
+          "exponent": 0
+        },
+        {
+          "denom": "ion",
+          "exponent": 6
+        }
+      ],
+      "base": "uion",
+      "name": "Ion",
+      "display": "ion",
+      "symbol": "ION",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+      },
+      "coingecko_id": "ion",
+      "keywords": [
+        "memecoin",
+        "osmosis-price:uosmo:2",
+        "osmosis-info_2"
+      ]
+    },
+    {
+      "description": "The native token of JUNO Chain",
+      "denom_units": [
+        {
+          "denom": "ibc/7E3DB8DA12B7A7E2056E2449434A6F745E3C29B50217538BE31A50375EF088C6",
+          "exponent": 0,
+          "aliases": [
+            "ujunox"
+          ]
+        },
+        {
+          "denom": "junox",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/7E3DB8DA12B7A7E2056E2449434A6F745E3C29B50217538BE31A50375EF088C6",
+      "name": "Juno Testnet",
+      "display": "junox",
+      "symbol": "JUNOX",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "junotestnet",
+            "base_denom": "ujunox",
+            "channel_id": "channel-140"
+          },
+          "chain": {
+            "channel_id": "channel-3316",
+            "path": "transfer/channel-3316/ujunox"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/junotestnet/images/juno.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/junotestnet/images/juno.svg"
+      },
+      "coingecko_id": "juno-network",
+      "keywords": [
+        "osmosis-price:uosmo:789",
+        "osmosis-info_2"
+      ]
+    }
+  ]
+}

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -99,6 +99,48 @@
         "osmosis-price:uosmo:789",
         "osmosis-info_2"
       ]
+    },
+    {
+      "description": "The native token of Mars Protocol",
+      "denom_units": [
+        {
+          "denom": "ibc/ACA4C8A815A053CC027DB90D15915ADA31939FA331CE745862CDD00A2904FA17",
+          "exponent": 0,
+          "aliases": [
+            "umars"
+          ]
+        },
+        {
+          "denom": "mars",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/0973EE75F04F14E896733FD6B6F00342E7CD7867785EE8596D3E74767BC19FC9",
+      "name": "Mars",
+      "display": "mars",
+      "symbol": "MARS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "marstestnet",
+            "base_denom": "umars",
+            "channel_id": "channel-12"
+          },
+          "chain": {
+            "channel_id": "channel-2",
+            "path": "transfer/channel-2/umars"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/marstestnet/images/mars.svg"
+      },
+      "keywords": [
+        "OSMO:768",
+        "osmosis-price:uosmo:768",
+        "osmosis-info_2"
+      ]
     }
   ]
 }

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -214,7 +214,7 @@
           },
           "chain": {
             "channel_id": "channel-4",
-            "path": "transfer/channel-1/uakt"
+            "path": "transfer/channel-4/uakt"
           }
         }
       ],
@@ -225,6 +225,48 @@
       "coingecko_id": "akash-network",
       "keywords": [
         "osmosis-price:uosmo:3",
+        "osmosis-info_2"
+      ]
+    },
+    {
+      "description": "Circle's stablecoin on Noble",
+      "denom_units": [
+        {
+          "denom": "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
+          "exponent": 0,
+          "aliases": [
+            "usdc"
+          ]
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "base": "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
+      "name": "Noble Testnet",
+      "display": "usdc",
+      "symbol": "USDC",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "grand-1",
+            "base_denom": "usdc",
+            "channel_id": "channel-6"
+          },
+          "chain": {
+            "channel_id": "channel-6",
+            "path": "transfer/channel-6/uusdc"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "",
+        "svg": ""
+      },
+      "coingecko_id": "noble-network",
+      "keywords": [
         "osmosis-info_2"
       ]
     }

--- a/osmo-test-5/osmosis.zone.json
+++ b/osmo-test-5/osmosis.zone.json
@@ -11,18 +11,18 @@
       "base_denom": "uion"
     },
     {
-      "chain_name": "axelartestnet",
+      "chain_name": "axelar-testnet-lisbon-3",
       "base_denom": "uausdc",
       "override_properties": {
         "symbol": "aUSDC"
       }
     },
     {
-      "chain_name": "junotestnet",
+      "chain_name": "uni-6",
       "base_denom": "ujunox"
     },
     {
-      "chain_name": "marstestnet",
+      "chain_name": "ares-1",
       "base_denom": "umars"
     }
   ]

--- a/osmo-test-5/osmosis.zone.json
+++ b/osmo-test-5/osmosis.zone.json
@@ -20,6 +20,10 @@
     {
       "chain_name": "junotestnet",
       "base_denom": "ujunox"
+    },
+    {
+      "chain_name": "marstestnet",
+      "base_denom": "umars"
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone.json
+++ b/osmo-test-5/osmosis.zone.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../zone.schema.json",
+  "chain_name": "osmosis",
+  "assets": [
+    {
+      "chain_name": "osmo-test-5",
+      "base_denom": "uosmo"
+    },
+    {
+      "chain_name": "osmo-test-5",
+      "base_denom": "uion"
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "uausdc",
+      "override_properties": {
+        "symbol": "aUSDC"
+      }
+    },
+    {
+      "chain_name": "junotestnet",
+      "base_denom": "ujunox"
+    }
+  ]
+}

--- a/osmo-test-5/osmosis.zone.json
+++ b/osmo-test-5/osmosis.zone.json
@@ -24,6 +24,10 @@
     {
       "chain_name": "ares-1",
       "base_denom": "umars"
+    },
+    {
+      "chain_name": "sandbox",
+      "base_denom": "uakt"
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone.json
+++ b/osmo-test-5/osmosis.zone.json
@@ -28,6 +28,13 @@
     {
       "chain_name": "sandbox",
       "base_denom": "uakt"
+    },
+    {
+      "chain_name": "grand-1",
+      "base_denom": "uusdc",
+      "override_properties": {
+        "symbol": "nUSDC"
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds the assetlists for `osmo-test-5`. 

Docs to verify: https://github.com/osmosis-labs/testnets/blob/main/testnets/osmo-test-5/IBC.md 

Some notes:

- I'm not sure about the use of the `keywords` sections
- The nobleUSDC it's missing the `logo_URIs`
- I've only added `aUSDC` for axelar for now. I wasn't sure about the rest
- I have used the `chain-id`s of the testnet networks as `chain_name`, not sure if it's correct