### PR TITLE
Fix LIGHT token

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -8683,7 +8683,7 @@
         },
         {
           "denom": "light",
-          "exponent": 6
+          "exponent": 9
         }
       ],
       "type_asset": "cw20",
@@ -8713,8 +8713,8 @@
       },
       "keywords": [
         "osmosis-frontier",
-        "OSMO:995",
-        "osmosis-price:ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7:995",
+        "OSMO:1009",
+        "osmosis-price:uosmo:1009",
         "osmosis-info_2"
       ]
     },


### PR DESCRIPTION
After the token listing on the frontend we got some issues: -1#Light is not showing correct number quantity. (2.000.000 = 2.000) Maybe getting price from new pool 1009 fix this? -2# When trying to trade light for any other token in Swap front page it takes a lot of RAM memory and crash the browser. What may be causing this?