### PR TITLE
add ampOSMO

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -10178,6 +10178,31 @@
         "osmosis-info",
         "osmosis-price:uosmo:1065"
       ]
+    },
+    {
+      "description": "ERIS liquid staked OSMO",
+      "denom_units": [
+        {
+          "denom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+          "exponent": 0
+        },
+        {
+          "denom": "ampOSMO",
+          "exponent": 6
+        }
+      ],
+      "address": "osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9",
+      "base": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+      "name": "ERIS Amplified OSMO",
+      "display": "ampOSMO",
+      "symbol": "ampOSMO",
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/amp.osmo.png"
+      },
+      "keywords": [
+        "osmosis-frontier",
+        "osmosis-info"
+      ]
     }
   ]
 }

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -10200,6 +10200,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/amp.osmo.png"
       },
       "keywords": [
+        "osmosis-main",
         "osmosis-frontier",
         "osmosis-info"
       ]

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1570,7 +1570,7 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
-      "osmosis_main": false,
+      "osmosis_main": true,
       "osmosis_frontier": true
     }
   ]

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1566,6 +1566,12 @@
       "path": "transfer/channel-1411/umpwr",
       "osmosis_main": false,
       "osmosis_frontier": true
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+      "osmosis_main": false,
+      "osmosis_frontier": true
     }
   ]
 }


### PR DESCRIPTION
This PR adds ampOSMO to Osmosis frontier

There is a PR still open for the chain-registry: https://github.com/cosmos/chain-registry/pull/2508



## Description

ampOSMO is a liquid staked OSMO token launched on osmosis.

## Checklist

### Adding Assets

If adding a new asset, please ensure the following:
- [x] Add to bottom of zone_assets.json
- [x] `osmosis_main` defaults to `false` (or else cite the listing rule that justifies enlisting to the Main app)
- [x] The IBC channel referenced in `path` has been registered to the Chain Registry.

### Validation Testing

If adding a new asset, the **Deposit** and **Withdraw** functions (and the link to the transaction on the foreign chain's block explorer) for the asset must be validated before listing. Please specify whether the Osmosis assetlists repo maintainers [x]or the submitting team shall validate: (choose one)

- [x] Osmosis assetlists repo maintainers to validate--testers will need a small amount of tokens to validate. In which case:
  - [ ] Validaters can buy a small amount of this asset from Pool ID: {PROVIDE POOL ID}.
  - [x] Validators can get assets here: https://www.erisprotocol.com/osmosis/amplifier

### On-chain liquidity

If adding a new asset, please provide the plan for on-chain liquidity of the asset: (choose one)
- [x] The submitting team will ensure a pool will be created soon. Please hold off until further communication, which will notify of the Pool ID.

