### PR TITLE
remove wrapped from a bunch of names

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -33,6 +33,7 @@
       "osmosis_verified": true,
       "override_properties": {
         "symbol": "ETH",
+        "name": "Ether",
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
         }
@@ -97,7 +98,8 @@
       "path": "transfer/channel-208/wbnb-wei",
       "osmosis_verified": true,
       "override_properties": {
-        "symbol": "BNB"
+        "symbol": "BNB",
+        "name": "Binance Coin"
       }
     },
     {
@@ -107,6 +109,7 @@
       "osmosis_verified": true,
       "override_properties": {
         "symbol": "MATIC",
+        "name": "Polygon",
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png"
         }
@@ -119,6 +122,7 @@
       "osmosis_verified": true,
       "override_properties": {
         "symbol": "AVAX",
+        "name": "Avalanche",
         "logo_URIs": {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
         }
@@ -143,6 +147,7 @@
       "osmosis_verified": true,
       "override_properties": {
         "symbol": "DOT.axl",
+        "name": "Polkadot",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dot.axl.svg"
         }
@@ -712,7 +717,8 @@
       "path": "transfer/channel-208/wglmr-wei",
       "osmosis_verified": false,
       "override_properties": {
-        "symbol": "GLMR"
+        "symbol": "GLMR",
+        "name": "Moonbeam"
       }
     },
     {
@@ -991,7 +997,8 @@
       "path": "transfer/channel-208/wftm-wei",
       "osmosis_verified": true,
       "override_properties": {
-        "symbol": "FTM"
+        "symbol": "FTM",
+        "name": "Fantom"
       }
     },
     {
@@ -1240,7 +1247,11 @@
       "chain_name": "axelar",
       "base_denom": "wfil-wei",
       "path": "transfer/channel-208/wfil-wei",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "override_properties": {
+        "symbol": "FIL",
+        "name": "Filecoin"
+      }
     },
     {
       "chain_name": "juno",


### PR DESCRIPTION
## Description

Adds a name override to a bunch of Axelar bridged native assets, to remove the "Wrapped" from their token names.

