### PR TITLE
Update the USD Stablecoin Canon References

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1564,7 +1564,11 @@
       "base_denom": "erc20/tether/usdt",
       "path": "transfer/channel-143/erc20/tether/usdt",
       "peg_mechanism": "collateralized",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "canonical": {
+        "chain_name": "ethereum",
+        "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      }
     },
     {
       "chain_name": "osmosis",
@@ -1698,6 +1702,10 @@
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
         }
+      },
+      "canonical": {
+        "chain_name": "ethereum",
+        "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
       }
     },
     {


### PR DESCRIPTION
## Description

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->

Update the USD Stablecoin Canon References so that Kava USDT and Noble USDC are now canonical representations of USDT and USDC from Ethereum, respectively