### PR TITLE
fix: osmosis and cosmos hub explorer URLs

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -5,7 +5,7 @@
       "chain_name": "osmosis",
       "rpc": "https://rpc-osmosis.keplr.app",
       "rest": "https://lcd-osmosis.keplr.app",
-      "explorer_tx_url": "https://www.mintscan.io/cosmos/txs/${txHash}",
+      "explorer_tx_url": "https://www.mintscan.io/osmosis/txs/${txHash}",
       "keplr_features": [
         "ibc-go",
         "ibc-transfer",
@@ -18,7 +18,7 @@
       "chain_name": "cosmoshub",
       "rpc": "https://rpc-cosmoshub.keplr.app",
       "rest": "https://lcd-cosmoshub.keplr.app",
-      "explorer_tx_url": "https://www.mintscan.io/osmosis/txs/${txHash}",
+      "explorer_tx_url": "https://www.mintscan.io/cosmos/txs/${txHash}",
       "keplr_features": [
         "ibc-go",
         "ibc-transfer"


### PR DESCRIPTION
## Description

fix osmosis and cosmos hub explorer URLs because they were reverted before
<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->
