### PR TITLE
Replace Asset Name w/ Chain Name if Staking Token

### DIFF
--- a/.github/workflows/utility/generate_assetlist.mjs
+++ b/.github/workflows/utility/generate_assetlist.mjs
@@ -114,6 +114,16 @@ const generateAssets = async (chainName, assets, zone_assets) => {
       } else {
         assetPropertyValue = chain_reg.getAssetProperty(zone_asset.chain_name, zone_asset.base_denom, assetProperty);
       }
+
+      // Use Chain's Name instead of Asset Name when it's the staking token
+      if (assetProperty == "name") {
+        let staking_denom = chain_reg.getFileProperty(reference_asset.chain_name, "chain", "staking")?.staking_tokens[0]?.denom;
+        if(reference_asset.base_denom == staking_denom) {
+           let chainPretty = chain_reg.getFileProperty(reference_asset.chain_name, "chain", "pretty_name");
+           assetPropertyValue = chainPretty ? chainPretty : defaultValue;
+        }
+      }
+
       if (assetPropertyValue) {
         if (assetProperty == "logo_URIs") {
           generatedAsset[assetProperty] = {};

--- a/osmo-test-5/osmo-test-5.assetlist.json
+++ b/osmo-test-5/osmo-test-5.assetlist.json
@@ -16,7 +16,7 @@
         }
       ],
       "base": "uosmo",
-      "name": "Osmosis",
+      "name": "Osmosis Testnet",
       "display": "osmo",
       "symbol": "OSMO",
       "traces": [],
@@ -76,7 +76,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/9FF2B7A5F55038A7EE61F4FD6749D9A648B48E89830F2682B67B5DC158E2753C",
-      "name": "Cosmos",
+      "name": "Cosmos Hub Public Testnet",
       "display": "atom",
       "symbol": "ATOM",
       "traces": [
@@ -267,7 +267,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/18401C07347459EE2413C0AFDE3ACDB66AC9FD363B3E56A6FC1DFF1B69341FC3",
-      "name": "Mars",
+      "name": "Mars Hub Testnet",
       "display": "mars",
       "symbol": "MARS",
       "traces": [
@@ -373,7 +373,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/AD59D59CFB0E628E73C798415F823AB5B6257C2FE4BF67DBB5D6A677B2686E82",
-      "name": "Akash Network",
+      "name": "Sandbox",
       "display": "akt",
       "symbol": "AKT",
       "traces": [
@@ -412,7 +412,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/AB8AF05799E299FB5C5C80781DA35887F53E029745D20E5641233DB4E6B28515",
-      "name": "KYVE",
+      "name": "KYVE Kaon",
       "display": "kyve",
       "symbol": "KYVE",
       "traces": [
@@ -454,7 +454,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F37CF69589DE12342758382F8770C0852CD8D2E4519F55166EBDAF472AD667C9",
-      "name": "Quicksilver",
+      "name": "Quicksilver Testnet",
       "display": "qck",
       "symbol": "QCK",
       "traces": [
@@ -497,7 +497,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/E3D323CB6F427C49E56F913C853A416F6B71BAA9B0164625AD0203266F92B3ED",
-      "name": "Chain4Energy",
+      "name": "Chain4Energy Testnet",
       "display": "c4e",
       "symbol": "C4E",
       "traces": [
@@ -539,7 +539,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/754C8533F8A418B03AD5F2C6AA19D4703CF78BBAB9E2E4DDD6212AAC2E502CA6",
-      "name": "Persistence",
+      "name": "Persistence Testnet",
       "display": "xprt",
       "symbol": "XPRT",
       "traces": [
@@ -594,7 +594,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/13F66070C572362C27DCE01404E18888E7C53CF65202C03237DB3F4FB7169722",
-      "name": "xion",
+      "name": "Xion Testnet",
       "display": "XION",
       "symbol": "XION",
       "traces": [

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -465,7 +465,7 @@
       "keywords": [
         "osmosis-main",
         "osmosis-info",
-        "osmosis-price:uosmo:1265"
+        "osmosis-price:uosmo:1135"
       ]
     },
     {
@@ -485,7 +485,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
-      "name": "Cronos",
+      "name": "Cronos POS Chain",
       "display": "cro",
       "symbol": "CRO",
       "traces": [
@@ -724,7 +724,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-      "name": "Luna Classic",
+      "name": "Terra Classic",
       "display": "luna",
       "symbol": "LUNC",
       "traces": [
@@ -1276,7 +1276,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-      "name": "Akash Network",
+      "name": "Akash",
       "display": "akt",
       "symbol": "AKT",
       "traces": [
@@ -1321,7 +1321,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-      "name": "Regen Network",
+      "name": "Regen",
       "display": "regen",
       "symbol": "REGEN",
       "traces": [
@@ -1635,7 +1635,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
-      "name": "IXO",
+      "name": "ixo",
       "display": "ixo",
       "symbol": "IXO",
       "traces": [
@@ -1815,7 +1815,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
-      "name": "MediBloc",
+      "name": "Medibloc",
       "display": "med",
       "symbol": "MED",
       "traces": [
@@ -1857,7 +1857,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-      "name": "Bostrom",
+      "name": "bostrom",
       "display": "boot",
       "symbol": "BOOT",
       "traces": [
@@ -1947,7 +1947,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
-      "name": "cheqd",
+      "name": "Cheqd",
       "display": "cheq",
       "symbol": "CHEQ",
       "traces": [
@@ -1992,7 +1992,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
-      "name": "Lum",
+      "name": "Lum Network",
       "display": "lum",
       "symbol": "LUM",
       "traces": [
@@ -2270,7 +2270,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
-      "name": "DARC",
+      "name": "Konstellation",
       "display": "darc",
       "symbol": "DARC",
       "traces": [
@@ -2360,7 +2360,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
-      "name": "Graviton",
+      "name": "Gravity Bridge",
       "display": "graviton",
       "symbol": "GRAV",
       "traces": [
@@ -2589,7 +2589,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-      "name": "fetch-ai",
+      "name": "Fetch.ai",
       "display": "fet",
       "symbol": "FET",
       "traces": [
@@ -3454,7 +3454,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
-      "name": "Hash",
+      "name": "Provenance",
       "display": "hash",
       "symbol": "HASH",
       "traces": [
@@ -3764,7 +3764,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
-      "name": "Luna",
+      "name": "Terra",
       "display": "luna",
       "symbol": "LUNA",
       "traces": [
@@ -3809,7 +3809,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
-      "name": "Rizon Chain",
+      "name": "Rizon",
       "display": "atolo",
       "symbol": "ATOLO",
       "traces": [
@@ -4551,7 +4551,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
-      "name": "ODIN",
+      "name": "Odin Protocol",
       "display": "odin",
       "symbol": "ODIN",
       "traces": [
@@ -4923,7 +4923,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
-      "name": "LUMEN",
+      "name": "LumenX",
       "display": "lumen",
       "symbol": "LUMEN",
       "traces": [
@@ -5885,7 +5885,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
-      "name": "Unification Network",
+      "name": "Unification",
       "display": "FUND",
       "symbol": "FUND",
       "traces": [
@@ -6287,7 +6287,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
-      "name": "Acre",
+      "name": "Acrechain",
       "display": "acre",
       "symbol": "ACRE",
       "traces": [
@@ -6377,7 +6377,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
-      "name": "IMV",
+      "name": "Imversed",
       "display": "imv",
       "symbol": "IMV",
       "traces": [
@@ -6420,7 +6420,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-      "name": "Medas Digital",
+      "name": "Medas Digital Network",
       "display": "medas",
       "symbol": "MEDAS",
       "traces": [
@@ -6556,7 +6556,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
-      "name": "Nom",
+      "name": "Onomy",
       "display": "nom",
       "symbol": "NOM",
       "traces": [
@@ -6649,7 +6649,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
-      "name": "Dys",
+      "name": "Dyson Protocol",
       "display": "dys",
       "symbol": "DYS",
       "traces": [
@@ -7171,7 +7171,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-      "name": "Mars",
+      "name": "Mars Hub",
       "display": "mars",
       "symbol": "MARS",
       "traces": [
@@ -7688,7 +7688,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/0F91EE8B98AAE3CF393D94CD7F89A10F8D7758C5EC707E721899DFE65C164C28",
-      "name": "Arkh",
+      "name": "Arkhadian",
       "display": "ARKH",
       "symbol": "ARKH",
       "traces": [
@@ -7829,7 +7829,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
-      "name": "Whale",
+      "name": "Migaloo",
       "display": "whale",
       "symbol": "WHALE",
       "traces": [
@@ -8406,7 +8406,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-      "name": "Flix",
+      "name": "OmniFlix",
       "display": "flix",
       "symbol": "FLIX",
       "traces": [
@@ -9352,7 +9352,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
-      "name": "LORE",
+      "name": "Gitopia",
       "display": "LORE",
       "symbol": "LORE",
       "traces": [
@@ -9743,7 +9743,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
-      "name": "Pica",
+      "name": "Composable",
       "display": "pica",
       "symbol": "PICA",
       "traces": [
@@ -10031,7 +10031,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
-      "name": "MPWR",
+      "name": "EmpowerChain",
       "display": "mpwr",
       "symbol": "MPWR",
       "traces": [
@@ -11032,7 +11032,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/95C9B5870F95E21A242E6AF9ADCB1F212EE4A8855087226C36FBE43FC41A77B8",
-      "name": "Xpla",
+      "name": "XPLA",
       "display": "xpla",
       "symbol": "XPLA",
       "traces": [
@@ -11302,7 +11302,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/01D2F0C4739C871BFBEE7E786709E6904A55559DC1483DD92ED392EF12247862",
-      "name": "FIS",
+      "name": "StaFi Hub",
       "display": "fis",
       "symbol": "FIS",
       "traces": [
@@ -11578,7 +11578,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
-      "name": "dYdX",
+      "name": "dYdX Protocol",
       "display": "dydx",
       "symbol": "DYDX",
       "traces": [
@@ -11622,7 +11622,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/2B30802A0B03F91E4E16D6175C9B70F2911377C1CAE9E50FF011C821465463F9",
-      "name": "Function X",
+      "name": "f(x)Core",
       "display": "WFX",
       "symbol": "FX",
       "traces": [
@@ -11992,7 +11992,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/09FAF1E04435E14C68DE7AB0D03C521C92975C792DB12B2EA390BAA2E06B3F3D",
-      "name": "Qwoyn Blockchain",
+      "name": "Qwoyn",
       "display": "qwoyn",
       "symbol": "QWOYN",
       "traces": [


### PR DESCRIPTION
## Description

Update to use Chain Pretty Name as the asset name when it's the staking asset

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->

See some of the Examples:

FIS -> StaFi Hub (way better, IMO),
LORE -> Gitopia (way better, IMO),
Fetch-ai -> Fetch.ai (looks better, IMO),
LUMEN -> LumnenX (better)

The majority of the dozens of changes provide a more understandable experience to the user.

Although a couple examples might be a bit worse...
Cronos -> Cronos POS Chain (Bulky and long for an asset name. Although its perhaps a worse name for the token itself, it's a valuable descriptor because there are two CRO-native chains, so also a good thing)

Luna -> Terra (I don't love this change... but willing to go with it),
Luna Classic -> Terra Classic (Technically, the name 'Terra' when used to describe assets, broadly describes the stablecoins, NOT $LUNA itself, and I suppose defaults TerraSDR if no fiat suffix is given (like with Terra USD). However, note that the names for USTC and KRTC, etc, always include the Fiat suffix, like: 'Terra USD' and 'Terra KRT', and never just 'Terra' nor just 'Terra Classic', so it shouldn't be ambiguous.
By the time a user encounters LUNA, they will probably understand that the names accompanying assets are just showing the Chain's name whenever it's the staking token.
