### PR TITLE
Remove SEASY coingecko id

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -5497,7 +5497,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
       },
-      "coingecko_id": "seasy",
       "keywords": [
         "osmosis-price:uosmo:808"
       ]


### PR DESCRIPTION
## Description

It seems that [SEASY token price from Coingecko is wrong](https://api.coingecko.com/api/v3/simple/price?ids=seasy&vs_currencies=usd). It's not even listed in Coingecko. so I suggest to remove SEASY coingecko id here.
<img width="235" alt="Screenshot 2023-11-30 at 4 34 23 PM" src="https://github.com/osmosis-labs/assetlists/assets/32129022/ba150b79-31b6-4087-a037-a88964d55d9f">
