### PR TITLE
Add impacthub to Osmo-test-5 assets and chains

### DIFF
--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -77,6 +77,11 @@
       "chain_name": "sagatestnet",
       "base_denom": "utsaga",
       "path": "transfer/channel-4374/utsaga"
+    },
+    {
+      "chain_name": "impacthubtestnet",
+      "base_denom": "uixo",
+      "path": "transfer/channel-1637/uixo"
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone_chains.json
+++ b/osmo-test-5/osmosis.zone_chains.json
@@ -115,7 +115,7 @@
         "ibc-transfer",
         "ibc-go"
       ]
-     },
+    },
     {
       "chain_name": "persistencetestnet2",
       "rpc": "https://rpc.testnet2.persistence.one",
@@ -141,6 +141,16 @@
       "rpc": "https://testnet-ssc.sagarpc.io/",
       "rest": "https://testnet-ssc-lcd.sagarpc.io/",
       "explorer_tx_url": "https://www.mintscan.io/saga-testnet/tx/${txHash}",
+      "keplr_features": [
+        "ibc-transfer",
+        "ibc-go"
+      ]
+    },
+    {
+      "chain_name": "impacthubtestnet",
+      "rpc": "https://rpc.testnet.ixo.earth",
+      "rest": "https://testnet.ixo.earth/rest",
+      "explorer_tx_url": "https://blockscan-pandora.ixo.earth/transactions/${txHash}",
       "keplr_features": [
         "ibc-transfer",
         "ibc-go"


### PR DESCRIPTION
Add Impacthub (Ixo) to Osmo-test-5/osmosis.zone_assets and Osmo-test-5/osmosis.zone_chains

Description
Adding chain: impacthubtestnet (Ixo)
Adding token: uxio from chain Ixo

Adding Chains
Adding ImpacthubTestnet to chain registry is in pr(https://github.com/cosmos/chain-registry/pull/2854), opening this pr so long to make sure everything is okay.

Adding Assets
Asset is already on chain registry, made a pr to add tesnet ibc channel in pr(https://github.com/cosmos/chain-registry/pull/2854)

On-chain liquidity
If adding a new asset, please provide the plan for on-chain liquidity of the asset:

[ *] The submitting team will ensure a pool will be created soon. Please hold off until further communication, which will notify of the Pool ID.
I can provide a lot of uixo ibc tokens for the pool, just not sure how to get 1000osmo tokens on tesnet to create the pool?