### PR TITLE
Update FURY.legacy token

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -6231,7 +6231,7 @@
       ]
     },
     {
-      "description": "The native token cw20 for Fanfury on Juno Chain",
+      "description": "The legacy cw20 token for Fanfury on Juno Chain",
       "denom_units": [
         {
           "denom": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
@@ -6249,8 +6249,8 @@
       "address": "juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
       "base": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
       "name": "Fanfury",
-      "display": "fury",
-      "symbol": "FURY",
+      "display": "fury.legacy",
+      "symbol": "FURY.legacy",
       "traces": [
         {
           "type": "ibc-cw20",


### PR DESCRIPTION
The cw20 version of the FURY token has been labelled as FURY.legacy as there now a new Native version of the FURY token on Furya chain.
