### PR TITLE
Fix Picasso IBC transfer URL overrides

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1724,8 +1724,8 @@
         {
           "name": "Composable Trustless Zone",
           "type": "external_interface",
-          "deposit_url": "https://app.trustless.zone/multihop?from=PICASSO&to=OSMOSIS",
-          "withdraw_url": "https://app.trustless.zone/multihop?from=OSMOSIS&to=PICASSO"
+          "deposit_url": "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
+          "withdraw_url": "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO"
         }
       ]
     },
@@ -1742,8 +1742,8 @@
         {
           "name": "Composable Trustless Zone",
           "type": "external_interface",
-          "deposit_url": "https://app.trustless.zone/multihop?from=PICASSO&to=OSMOSIS",
-          "withdraw_url": "https://app.trustless.zone/multihop?from=OSMOSIS&to=PICASSO"
+          "deposit_url": "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
+          "withdraw_url": "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO"
         }
       ]
     },
@@ -1760,8 +1760,8 @@
         {
           "name": "Composable Trustless Zone",
           "type": "external_interface",
-          "deposit_url": "https://app.trustless.zone/multihop?from=PICASSO&to=OSMOSIS",
-          "withdraw_url": "https://app.trustless.zone/multihop?from=OSMOSIS&to=PICASSO"
+          "deposit_url": "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
+          "withdraw_url": "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO"
         }
       ]
     },


### PR DESCRIPTION
## Description

Fix Picasso IBC transfer URL overrides, since the old URL now results in 404