### PR TITLE
Update Zone Asset Config

### DIFF
--- a/.github/workflows/utility/generate_zone_config.mjs
+++ b/.github/workflows/utility/generate_zone_config.mjs
@@ -77,7 +77,7 @@ const generateAssets = async (chainName, assets, zone_assets) => {
     
     generatedAsset.chain_name = zone_asset.chain_name;
     generatedAsset.base_denom = zone_asset.base_denom;
-    generatedAsset.symbol = zone_asset.symbol;
+    
 
     
     let reference_asset = {};
@@ -87,7 +87,19 @@ const generateAssets = async (chainName, assets, zone_assets) => {
       reference_asset = zone_asset;
     }
     generatedAsset.coingecko_id = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "coingecko_id");
-    
+    generatedAsset.symbol = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "symbol");
+    generatedAsset.images = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "images");
+
+
+    //Get Decimals
+    let denom_units = chain_reg.getAssetProperty(zone_asset.chain_name, zone_asset.base_denom, "denom_units");
+    let display = chain_reg.getAssetProperty(zone_asset.chain_name, zone_asset.base_denom, "display");
+    denom_units.forEach((unit) => {
+      if(unit.denom === display) {
+        generateAsset.decimals = unit.exponent;
+      }
+    });
+
 
   
     //--Overrides Properties when Specified--

--- a/.github/workflows/utility/generate_zone_config.mjs
+++ b/.github/workflows/utility/generate_zone_config.mjs
@@ -15,7 +15,9 @@ const chainNameToChainIdMap = new Map([
 ]);
 
 const assetlistsRoot = "../../..";
+const generatedFolderName = "generated";
 const assetlistFileName = "assetlist.json";
+const zoneAssetConfigFileName = "zone_asset_config.json";
 const zoneAssetlistFileName = "osmosis.zone_assets.json";
 const zoneChainlistFileName = "osmosis.zone_chains.json";
 
@@ -37,7 +39,8 @@ function writeToFile(assetlist, chainName) {
     fs.writeFile(path.join(
       assetlistsRoot,
       chainNameToChainIdMap.get(chainName),
-      chainNameToChainIdMap.get(chainName) +'.zone_config.json'
+      generatedFolderName,
+      zoneAssetConfigFileName
     ), JSON.stringify(assetlist,null,2), (err) => {
       if (err) throw err;
     });
@@ -72,9 +75,9 @@ const generateAssets = async (chainName, assets, zone_assets) => {
     let generatedAsset = {};
     
     
-    
-    generatedAsset.base_denom = zone_asset.base_denom;
     generatedAsset.chain_name = zone_asset.chain_name;
+    generatedAsset.base_denom = zone_asset.base_denom;
+    generatedAsset.symbol = zone_asset.symbol;
 
     
     let reference_asset = {};
@@ -91,6 +94,9 @@ const generateAssets = async (chainName, assets, zone_assets) => {
     if(zone_asset.override_properties) {
       if(zone_asset.override_properties.coingecko_id) {
         generatedAsset.coingecko_id = zone_asset.override_properties.coingecko_id;
+      }
+      if(zone_asset.override_properties.symbol) {
+        generatedAsset.symbol = zone_asset.override_properties.symbol;
       }
     }
     

--- a/.github/workflows/utility/generate_zone_config.mjs
+++ b/.github/workflows/utility/generate_zone_config.mjs
@@ -86,9 +86,7 @@ const generateAssets = async (chainName, assets, zone_assets) => {
     } else {
       reference_asset = zone_asset;
     }
-    generatedAsset.coingecko_id = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "coingecko_id");
     generatedAsset.symbol = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "symbol");
-    generatedAsset.images = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "images");
 
 
     //Get Decimals
@@ -96,10 +94,13 @@ const generateAssets = async (chainName, assets, zone_assets) => {
     let display = chain_reg.getAssetProperty(zone_asset.chain_name, zone_asset.base_denom, "display");
     denom_units.forEach((unit) => {
       if(unit.denom === display) {
-        generateAsset.decimals = unit.exponent;
+        generatedAsset.decimals = unit.exponent;
       }
     });
 
+
+    generatedAsset.images = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "images");
+    generatedAsset.coingecko_id = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "coingecko_id");
 
   
     //--Overrides Properties when Specified--

--- a/osmo-test-5/generated/zone_asset_config.json
+++ b/osmo-test-5/generated/zone_asset_config.json
@@ -1,0 +1,274 @@
+{
+  "chain_name": "osmosistestnet",
+  "assets": [
+    {
+      "chain_name": "osmosistestnet",
+      "base_denom": "uosmo",
+      "coingecko_id": "osmosis",
+      "symbol": "OSMO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+        }
+      ],
+      "decimals": 6,
+      "api_include": true,
+      "price": {
+        "pool": "5",
+        "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE"
+      }
+    },
+    {
+      "chain_name": "osmosistestnet",
+      "base_denom": "uion",
+      "coingecko_id": "ion",
+      "symbol": "ION",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+        }
+      ],
+      "decimals": 6,
+      "api_include": true,
+      "price": {
+        "pool": "1",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "cosmoshubtestnet",
+      "base_denom": "uatom",
+      "symbol": "ATOM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9FF2B7A5F55038A7EE61F4FD6749D9A648B48E89830F2682B67B5DC158E2753C",
+      "api_include": true,
+      "price": {
+        "pool": "308",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "uausdc",
+      "symbol": "aUSDC",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereumtestnet",
+            "base_denom": "0x254d06f33bDc5b8ee05b2ea472107E300226659A"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/2164BDB48DE5501430E71286448D87C6D2240EC0E078CF113CAB85E21A352BB0"
+    },
+    {
+      "chain_name": "axelartestnet",
+      "base_denom": "eth-wei",
+      "symbol": "ETH",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereumtestnet",
+            "base_denom": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/weth.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/1F42AC9631DBE03009219ECCFE151786F53A038DE9F7A07C709158514F1D5942"
+    },
+    {
+      "chain_name": "junotestnet",
+      "base_denom": "ujunox",
+      "coingecko_id": "juno-network",
+      "symbol": "JUNOX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/junotestnet/images/juno.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/junotestnet/images/juno.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/315940955C3051051C55B195EE30F7265D5BE3D3A7CC48D74E5D9871DCED8B26"
+    },
+    {
+      "chain_name": "marstestnet",
+      "base_denom": "umars",
+      "symbol": "MARS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/18401C07347459EE2413C0AFDE3ACDB66AC9FD363B3E56A6FC1DFF1B69341FC3"
+    },
+    {
+      "chain_name": "nobletestnet",
+      "base_denom": "uusdc",
+      "symbol": "USDC",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
+      "api_include": true,
+      "price": {
+        "pool": "313",
+        "denom": "ibc/1587E7B54FC9EFDA2350DC690EC2F9B9ECEB6FC31CF11884F9C0C5207ABE3921"
+      }
+    },
+    {
+      "chain_name": "akashtestnet",
+      "base_denom": "uakt",
+      "symbol": "AKT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/AD59D59CFB0E628E73C798415F823AB5B6257C2FE4BF67DBB5D6A677B2686E82"
+    },
+    {
+      "chain_name": "kyvetestnet",
+      "base_denom": "tkyve",
+      "symbol": "KYVE",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/kyvetestnet/images/kyve.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/AB8AF05799E299FB5C5C80781DA35887F53E029745D20E5641233DB4E6B28515",
+      "price": {
+        "pool": "4",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quicksilvertestnet",
+      "base_denom": "uqck",
+      "coingecko_id": "quicksilver",
+      "symbol": "QCK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F37CF69589DE12342758382F8770C0852CD8D2E4519F55166EBDAF472AD667C9",
+      "api_include": true,
+      "price": {
+        "pool": "34",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "chain4energytestnet",
+      "base_denom": "uc4e",
+      "coingecko_id": "",
+      "symbol": "C4E",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/chain4energytestnet/images/c4e.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/E3D323CB6F427C49E56F913C853A416F6B71BAA9B0164625AD0203266F92B3ED",
+      "api_include": true,
+      "price": {
+        "pool": "40",
+        "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE"
+      }
+    },
+    {
+      "chain_name": "persistencetestnet2",
+      "base_denom": "uxprt",
+      "coingecko_id": "persistence",
+      "symbol": "XPRT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/754C8533F8A418B03AD5F2C6AA19D4703CF78BBAB9E2E4DDD6212AAC2E502CA6",
+      "api_include": true,
+      "price": {
+        "pool": "85",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "xiontestnet",
+      "base_denom": "uxion",
+      "symbol": "XION",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/3642669AD14386D3E38F43F30CFCA859B3E8A05BF6BD6A23DEBD2115AD1325E9",
+      "api_include": true,
+      "price": {
+        "pool": "333",
+        "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58"
+      }
+    },
+    {
+      "chain_name": "sagatestnet",
+      "base_denom": "utsaga",
+      "symbol": "TSAGA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/6477A305C6127DE72C5BC8AAE85F318DF571DC8D590228CB191C952C304125F3",
+      "price": {
+        "pool": "317",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "impacthubtestnet",
+      "base_denom": "uixo",
+      "symbol": "IXO",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "impacthub",
+            "base_denom": "uixo"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/88C815D69587CF0F05E96E5E2731EA56194D73C9A02A500095294D3A5DE68F16",
+      "price": {
+        "pool": "254",
+        "denom": "uosmo"
+      }
+    }
+  ]
+}

--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -4,26 +4,31 @@
   "assets": [
     {
       "chain_name": "osmosistestnet",
-      "base_denom": "uosmo"
+      "base_denom": "uosmo",
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosistestnet",
-      "base_denom": "uion"
+      "base_denom": "uion",
+      "osmosis_validated": true
     },
     {
       "chain_name": "cosmoshubtestnet",
       "base_denom": "uatom",
-      "path": "transfer/channel-4156/uatom"
+      "path": "transfer/channel-4156/uatom",
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelartestnet",
       "base_denom": "uausdc",
-      "path": "transfer/channel-4170/uausdc"
+      "path": "transfer/channel-4170/uausdc",
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelartestnet",
       "base_denom": "eth-wei",
       "path": "transfer/channel-4170/eth-wei",
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "ETH"
       }
@@ -31,57 +36,68 @@
     {
       "chain_name": "junotestnet",
       "base_denom": "ujunox",
-      "path": "transfer/channel-4167/ujunox"
+      "path": "transfer/channel-4167/ujunox",
+      "osmosis_validated": true
     },
     {
       "chain_name": "marstestnet",
       "base_denom": "umars",
-      "path": "transfer/channel-4168/umars"
+      "path": "transfer/channel-4168/umars",
+      "osmosis_validated": true
     },
     {
       "chain_name": "nobletestnet",
       "base_denom": "uusdc",
-      "path": "transfer/channel-4280/uusdc"
+      "path": "transfer/channel-4280/uusdc",
+      "osmosis_validated": true
     },
     {
       "chain_name": "akashtestnet",
       "base_denom": "uakt",
-      "path": "transfer/channel-4171/uakt"
+      "path": "transfer/channel-4171/uakt",
+      "osmosis_validated": true
     },
     {
       "chain_name": "kyvetestnet",
       "base_denom": "tkyve",
-      "path": "transfer/channel-10/tkyve"
+      "path": "transfer/channel-10/tkyve",
+      "osmosis_validated": true
     },
     {
       "chain_name": "quicksilvertestnet",
       "base_denom": "uqck",
-      "path": "transfer/channel-13/uqck"
+      "path": "transfer/channel-13/uqck",
+      "osmosis_validated": true
     },
     {
       "chain_name": "chain4energytestnet",
       "base_denom": "uc4e",
-      "path": "transfer/channel-111/uc4e"
+      "path": "transfer/channel-111/uc4e",
+      "osmosis_validated": true
     },
     {
       "chain_name": "persistencetestnet2",
       "base_denom": "uxprt",
-      "path": "transfer/channel-1037/uxprt"
+      "path": "transfer/channel-1037/uxprt",
+      "osmosis_validated": true
     },
     {
       "chain_name": "xiontestnet",
       "base_denom": "uxion",
-      "path": "transfer/channel-4410/uxion"
+      "path": "transfer/channel-4410/uxion",
+      "osmosis_validated": true
     },
     {
       "chain_name": "sagatestnet",
       "base_denom": "utsaga",
-      "path": "transfer/channel-4374/utsaga"
+      "path": "transfer/channel-4374/utsaga",
+      "osmosis_validated": true
     },
     {
       "chain_name": "impacthubtestnet",
       "base_denom": "uixo",
-      "path": "transfer/channel-1637/uixo"
+      "path": "transfer/channel-1637/uixo",
+      "osmosis_validated": true
     }
   ]
 }

--- a/osmosis-1/generated/zone_asset_config.json
+++ b/osmosis-1/generated/zone_asset_config.json
@@ -1,1 +1,5241 @@
-
+{
+  "chain_name": "osmosis",
+  "assets": [
+    {
+      "chain_name": "osmosis",
+      "base_denom": "uosmo",
+      "coingecko_id": "osmosis",
+      "symbol": "OSMO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1221",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "uion",
+      "coingecko_id": "ion",
+      "symbol": "ION",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1100",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "uusdc",
+      "coingecko_id": "axlusdc",
+      "symbol": "USDC.axl",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+      "verified": true,
+      "api_include": true,
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "weth-wei",
+      "coingecko_id": "ethereum",
+      "symbol": "ETH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1134",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wbtc-satoshi",
+      "coingecko_id": "wrapped-bitcoin",
+      "symbol": "WBTC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1090",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "uusdt",
+      "symbol": "USDT.axl",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1150",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "dai-wei",
+      "coingecko_id": "dai",
+      "symbol": "DAI",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/dai.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1260",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "busd-wei",
+      "coingecko_id": "binance-usd",
+      "symbol": "BUSD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "877",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "cosmoshub",
+      "base_denom": "uatom",
+      "coingecko_id": "cosmos",
+      "symbol": "ATOM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1135",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "cryptoorgchain",
+      "base_denom": "basecro",
+      "coingecko_id": "crypto-com-chain",
+      "symbol": "CRO",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cro.svg"
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "9",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wbnb-wei",
+      "coingecko_id": "binancecoin",
+      "symbol": "BNB",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "840",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wmatic-wei",
+      "coingecko_id": "matic-network",
+      "symbol": "MATIC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "789",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wavax-wei",
+      "coingecko_id": "avalanche-2",
+      "symbol": "AVAX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "899",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "terra",
+      "base_denom": "uluna",
+      "coingecko_id": "terra-luna",
+      "symbol": "LUNC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1162",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "ujuno",
+      "coingecko_id": "juno-network",
+      "symbol": "JUNO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1097",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "dot-planck",
+      "symbol": "DOT.axl",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
+        }
+      ],
+      "decimals": 10,
+      "ibc_denom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "773",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "evmos",
+      "base_denom": "aevmos",
+      "coingecko_id": "evmos",
+      "symbol": "EVMOS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "722",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kava",
+      "base_denom": "ukava",
+      "coingecko_id": "kava",
+      "symbol": "KAVA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1105",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "uscrt",
+      "coingecko_id": "secret",
+      "symbol": "SCRT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "584",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "terra",
+      "base_denom": "uusd",
+      "coingecko_id": "terrausd",
+      "symbol": "USTC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "560",
+        "denom": "uosmo"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "algorithmic"
+    },
+    {
+      "chain_name": "stargaze",
+      "base_denom": "ustars",
+      "coingecko_id": "stargaze",
+      "symbol": "STARS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1096",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "chihuahua",
+      "base_denom": "uhuahua",
+      "coingecko_id": "chihuahua-token",
+      "symbol": "HUAHUA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "605",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "persistence",
+      "base_denom": "uxprt",
+      "coingecko_id": "persistence",
+      "symbol": "XPRT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1101",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "persistence",
+      "base_denom": "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444",
+      "coingecko_id": "pstake-finance",
+      "symbol": "PSTAKE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "648",
+        "denom": "uosmo"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "akash",
+      "base_denom": "uakt",
+      "coingecko_id": "akash-network",
+      "symbol": "AKT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1093",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "regen",
+      "base_denom": "uregen",
+      "coingecko_id": "regen",
+      "symbol": "REGEN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "42",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "sentinel",
+      "base_denom": "udvpn",
+      "coingecko_id": "sentinel",
+      "symbol": "DVPN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "6",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "irisnet",
+      "base_denom": "uiris",
+      "coingecko_id": "iris-network",
+      "symbol": "IRIS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1106",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "starname",
+      "base_denom": "uiov",
+      "coingecko_id": "starname",
+      "symbol": "IOV",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "197",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "emoney",
+      "base_denom": "ungm",
+      "coingecko_id": "e-money",
+      "symbol": "NGM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "463",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "emoney",
+      "base_denom": "eeur",
+      "coingecko_id": "e-money-eur",
+      "symbol": "EEUR",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "481",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "likecoin",
+      "base_denom": "nanolike",
+      "coingecko_id": "likecoin",
+      "symbol": "LIKE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
+        }
+      ],
+      "decimals": 9,
+      "ibc_denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "553",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "impacthub",
+      "base_denom": "uixo",
+      "coingecko_id": "ixo",
+      "symbol": "IXO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "558",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "bitcanna",
+      "base_denom": "ubcna",
+      "coingecko_id": "bitcanna",
+      "symbol": "BCNA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "571",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "bitsong",
+      "base_denom": "ubtsg",
+      "coingecko_id": "bitsong",
+      "symbol": "BTSG",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1109",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kichain",
+      "base_denom": "uxki",
+      "coingecko_id": "ki",
+      "symbol": "XKI",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "577",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "panacea",
+      "base_denom": "umed",
+      "coingecko_id": "medibloc",
+      "symbol": "MED",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "586",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "bostrom",
+      "base_denom": "boot",
+      "coingecko_id": "bostrom",
+      "symbol": "BOOT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.svg"
+        }
+      ],
+      "decimals": 0,
+      "ibc_denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1326",
+        "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20"
+      }
+    },
+    {
+      "chain_name": "comdex",
+      "base_denom": "ucmdx",
+      "coingecko_id": "comdex",
+      "symbol": "CMDX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "601",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "cheqd",
+      "base_denom": "ncheq",
+      "coingecko_id": "cheqd-network",
+      "symbol": "CHEQ",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
+        }
+      ],
+      "decimals": 9,
+      "ibc_denom": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1273",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "lumnetwork",
+      "base_denom": "ulum",
+      "coingecko_id": "lum-network",
+      "symbol": "LUM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "608",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "vidulum",
+      "base_denom": "uvdl",
+      "coingecko_id": "vidulum",
+      "symbol": "VDL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "613",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "desmos",
+      "base_denom": "udsm",
+      "coingecko_id": "desmos",
+      "symbol": "DSM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "619",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "dig",
+      "base_denom": "udig",
+      "coingecko_id": "dig-chain",
+      "symbol": "DIG",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "621",
+        "denom": "uosmo"
+      },
+      "unstable": true
+    },
+    {
+      "chain_name": "sommelier",
+      "base_denom": "usomm",
+      "coingecko_id": "sommelier",
+      "symbol": "SOMM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1103",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "bandchain",
+      "base_denom": "uband",
+      "coingecko_id": "band-protocol",
+      "symbol": "BAND",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "626",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "konstellation",
+      "base_denom": "udarc",
+      "coingecko_id": "darcmatter-coin",
+      "symbol": "DARC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "637",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "umee",
+      "base_denom": "uumee",
+      "coingecko_id": "umee",
+      "symbol": "UMEE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1110",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "ugraviton",
+      "coingecko_id": "graviton",
+      "symbol": "GRAV",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "625",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "decentr",
+      "base_denom": "udec",
+      "coingecko_id": "decentr",
+      "symbol": "DEC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "644",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
+      "coingecko_id": "marble",
+      "symbol": "MARBLE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
+        }
+      ],
+      "decimals": 3,
+      "ibc_denom": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "649",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "carbon",
+      "base_denom": "swth",
+      "coingecko_id": "switcheo",
+      "symbol": "SWTH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "651",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "cerberus",
+      "base_denom": "ucrbrus",
+      "coingecko_id": "cerberus-2",
+      "symbol": "CRBRUS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "662",
+        "denom": "uosmo"
+      },
+      "unstable": true
+    },
+    {
+      "chain_name": "fetchhub",
+      "base_denom": "afet",
+      "coingecko_id": "fetch-ai",
+      "symbol": "FET",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "681",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "assetmantle",
+      "base_denom": "umntl",
+      "coingecko_id": "assetmantle",
+      "symbol": "MNTL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "686",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
+      "coingecko_id": "neta",
+      "symbol": "NETA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "631",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "injective",
+      "base_denom": "inj",
+      "coingecko_id": "injective-protocol",
+      "symbol": "INJ",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "725",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "terra",
+      "base_denom": "ukrw",
+      "coingecko_id": "terrakrw",
+      "symbol": "KRTC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+      "verified": false,
+      "price": {
+        "pool": "581",
+        "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "algorithmic"
+    },
+    {
+      "chain_name": "microtick",
+      "base_denom": "utick",
+      "symbol": "TICK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "547",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      },
+      "unstable": true
+    },
+    {
+      "chain_name": "sifchain",
+      "base_denom": "rowan",
+      "coingecko_id": "sifchain",
+      "symbol": "ROWAN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "629",
+        "denom": "uosmo"
+      },
+      "unstable": true
+    },
+    {
+      "chain_name": "shentu",
+      "base_denom": "uctk",
+      "coingecko_id": "certik",
+      "symbol": "CTK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1020",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
+      "coingecko_id": "hope-galaxy",
+      "symbol": "HOPE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+      "verified": false,
+      "price": {
+        "pool": "653",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
+      "coingecko_id": "racoon",
+      "symbol": "RAC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "669",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "frax-wei",
+      "coingecko_id": "frax",
+      "symbol": "FRAX",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/frax.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "679",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "hybrid"
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+      "symbol": "WBTC.grv",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+      "verified": false,
+      "price": {
+        "pool": "694",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "symbol": "WETH.grv",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/weth.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1297",
+        "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+      }
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "symbol": "USDC.grv",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "633",
+        "denom": "uosmo"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "gravity0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      "symbol": "DAI.grv",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/dai.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+      "verified": false,
+      "price": {
+        "pool": "702",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "symbol": "USDT.grv",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "818",
+        "denom": "uosmo"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+      "symbol": "BLOCK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+      "verified": false,
+      "price": {
+        "pool": "691",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "provenance",
+      "base_denom": "nhash",
+      "coingecko_id": "provenance-blockchain",
+      "symbol": "HASH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.svg"
+        }
+      ],
+      "decimals": 9,
+      "ibc_denom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "693",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "galaxy",
+      "base_denom": "uglx",
+      "symbol": "GLX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/glx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/glx.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+      "verified": false,
+      "price": {
+        "pool": "697",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49",
+      "symbol": "DHK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
+        }
+      ],
+      "ibc_denom": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "695",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+      "coingecko_id": "junoswap-raw-dao",
+      "symbol": "RAW",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+      "verified": true,
+      "price": {
+        "pool": "700",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "meme",
+      "base_denom": "umeme",
+      "coingecko_id": "meme-network",
+      "symbol": "MEME",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "701",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w",
+      "symbol": "ASVT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
+      "verified": false,
+      "price": {
+        "pool": "771",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
+      "symbol": "JOE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "718",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "terra2",
+      "base_denom": "uluna",
+      "coingecko_id": "terra-luna-2",
+      "symbol": "LUNA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1163",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "rizon",
+      "base_denom": "uatolo",
+      "coingecko_id": "rizon",
+      "symbol": "ATOLO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+      "verified": false,
+      "price": {
+        "pool": "729",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kava",
+      "base_denom": "hard",
+      "coingecko_id": "kava-lend",
+      "symbol": "HARD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D6C28E07F7343360AC41E15DDD44D79701DDCA2E0C2C41279739C8D4AE5264BC",
+      "verified": false
+    },
+    {
+      "chain_name": "kava",
+      "base_denom": "swp",
+      "coingecko_id": "kava-swap",
+      "symbol": "SWP",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
+      "verified": false
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "link-wei",
+      "coingecko_id": "chainlink",
+      "symbol": "LINK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "731",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "genesisl1",
+      "base_denom": "el1",
+      "symbol": "L1",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "732",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "aave-wei",
+      "coingecko_id": "aave",
+      "symbol": "AAVE",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+      "verified": false
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "ape-wei",
+      "coingecko_id": "apecoin",
+      "symbol": "APE",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
+      "verified": false
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "axs-wei",
+      "coingecko_id": "axie-infinity",
+      "symbol": "AXS",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
+      "verified": false
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "mkr-wei",
+      "coingecko_id": "maker",
+      "symbol": "MKR",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/mkr.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+      "verified": true,
+      "price": {
+        "pool": "734",
+        "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "rai-wei",
+      "coingecko_id": "rai",
+      "symbol": "RAI",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
+      "verified": false
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "shib-wei",
+      "coingecko_id": "shiba-inu",
+      "symbol": "SHIB",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+      "verified": false,
+      "price": {
+        "pool": "880",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "uni-wei",
+      "coingecko_id": "uniswap",
+      "symbol": "UNI",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
+      "verified": false
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "xcn-wei",
+      "coingecko_id": "chain-2",
+      "symbol": "XCN",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
+      "verified": false
+    },
+    {
+      "chain_name": "kujira",
+      "base_denom": "ukuji",
+      "coingecko_id": "kujira",
+      "symbol": "KUJI",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1161",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "tgrade",
+      "base_denom": "utgd",
+      "coingecko_id": "tgrade",
+      "symbol": "TGD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "769",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "echelon",
+      "base_denom": "aechelon",
+      "coingecko_id": "echelon",
+      "symbol": "ECH",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/ech.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+      "verified": false,
+      "price": {
+        "pool": "848",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "odin",
+      "base_denom": "loki",
+      "coingecko_id": "odin-protocol",
+      "symbol": "ODIN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "777",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "odin",
+      "base_denom": "mGeo",
+      "symbol": "GEO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "787",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "odin",
+      "base_denom": "mO9W",
+      "symbol": "O9W",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "805",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kichain",
+      "base_denom": "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
+      "coingecko_id": "lvn",
+      "symbol": "kichain.LVN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "772",
+        "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wglmr-wei",
+      "coingecko_id": "moonbeam",
+      "symbol": "GLMR",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+      "verified": false,
+      "price": {
+        "pool": "825",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
+      "symbol": "GLTO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "778",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
+      "symbol": "GKEY",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "790",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "crescent",
+      "base_denom": "ucre",
+      "coingecko_id": "crescent-network",
+      "symbol": "CRE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "786",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "lumenx",
+      "base_denom": "ulumen",
+      "symbol": "LUMEN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+      "verified": false,
+      "price": {
+        "pool": "788",
+        "denom": "uosmo"
+      },
+      "unstable": true
+    },
+    {
+      "chain_name": "oraichain",
+      "base_denom": "orai",
+      "coingecko_id": "oraichain-token",
+      "symbol": "ORAI",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "799",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "cudos",
+      "base_denom": "acudos",
+      "coingecko_id": "cudos",
+      "symbol": "CUDOS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "796",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kava",
+      "base_denom": "usdx",
+      "coingecko_id": "usdx",
+      "symbol": "USDX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+      "verified": false,
+      "price": {
+        "pool": "792",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "agoric",
+      "base_denom": "ubld",
+      "coingecko_id": "agoric",
+      "symbol": "BLD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1104",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "agoric",
+      "base_denom": "uist",
+      "symbol": "IST",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1224",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "coingecko_id": "stakeeasy-juno-derivative",
+      "symbol": "SEJUNO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "807",
+        "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "coingecko_id": "stakeeasy-bjuno",
+      "symbol": "BJUNO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3"
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "ustrd",
+      "coingecko_id": "stride",
+      "symbol": "STRD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1098",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stuatom",
+      "coingecko_id": "stride-staked-atom",
+      "symbol": "stATOM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1283",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stustars",
+      "symbol": "stSTARS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "810",
+        "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse",
+      "symbol": "SOLAR",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "941",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+      "symbol": "SEASY",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+      "verified": false,
+      "price": {
+        "pool": "808",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "uaxl",
+      "coingecko_id": "axelar",
+      "symbol": "AXL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "812",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "rebus",
+      "base_denom": "arebus",
+      "coingecko_id": "rebus",
+      "symbol": "REBUS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "813",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "teritori",
+      "base_denom": "utori",
+      "coingecko_id": "teritori",
+      "symbol": "TORI",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "teritori",
+            "base_denom": "utori"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "816",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stujuno",
+      "symbol": "stJUNO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "817",
+        "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stuosmo",
+      "symbol": "stOSMO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1252",
+        "denom": "uosmo"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
+      "symbol": "MUSE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
+      "verified": false
+    },
+    {
+      "chain_name": "lambda",
+      "base_denom": "ulamb",
+      "coingecko_id": "lambda",
+      "symbol": "LAMB",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "826",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kujira",
+      "base_denom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
+      "coingecko_id": "usk",
+      "symbol": "USK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+      "verified": true,
+      "price": {
+        "pool": "827",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "unification",
+      "base_denom": "nund",
+      "coingecko_id": "unification",
+      "symbol": "FUND",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
+        }
+      ],
+      "decimals": 9,
+      "ibc_denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1240",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "jackal",
+      "base_denom": "ujkl",
+      "coingecko_id": "jackal-protocol",
+      "symbol": "JKL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "832",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej",
+      "coingecko_id": "alter",
+      "symbol": "ALTER",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
+      "verified": false,
+      "price": {
+        "pool": "845",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt",
+      "coingecko_id": "buttcoin-2",
+      "symbol": "BUTT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
+      "verified": false,
+      "price": {
+        "pool": "985",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d",
+      "symbol": "SHD(old)",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shdold.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
+      "verified": false,
+      "price": {
+        "pool": "846",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4",
+      "coingecko_id": "sienna",
+      "symbol": "SIENNA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
+      "verified": false,
+      "price": {
+        "pool": "853",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4",
+      "coingecko_id": "stkd-scrt",
+      "symbol": "stkd-SCRT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
+      "verified": false,
+      "price": {
+        "pool": "854",
+        "denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A"
+      }
+    },
+    {
+      "chain_name": "beezee",
+      "base_denom": "ubze",
+      "coingecko_id": "bzedge",
+      "symbol": "BZE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "856",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
+      "coingecko_id": "fanfury",
+      "symbol": "FURY",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
+      "verified": false
+    },
+    {
+      "chain_name": "acrechain",
+      "base_denom": "aacre",
+      "coingecko_id": "arable-protocol",
+      "symbol": "ACRE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "858",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "comdex",
+      "base_denom": "ucmst",
+      "coingecko_id": "composite",
+      "symbol": "CMST",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1258",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "imversed",
+      "base_denom": "aimv",
+      "coingecko_id": "imv",
+      "symbol": "IMV",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+      "verified": false,
+      "price": {
+        "pool": "866",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "medasdigital",
+      "base_denom": "umedas",
+      "symbol": "MEDAS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1329",
+        "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
+      "coingecko_id": "posthuman",
+      "symbol": "PHMN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1255",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852",
+      "symbol": "AMBER",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
+      "verified": false,
+      "price": {
+        "pool": "984",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "onomy",
+      "base_denom": "anom",
+      "coingecko_id": "onomy-protocol",
+      "symbol": "NOM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "882",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "persistence",
+      "base_denom": "stk/uatom",
+      "coingecko_id": "stkatom",
+      "symbol": "stkATOM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "886",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "dyson",
+      "base_denom": "dys",
+      "coingecko_id": "",
+      "symbol": "DYS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.svg"
+        }
+      ],
+      "decimals": 0,
+      "ibc_denom": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "950",
+        "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n",
+      "coingecko_id": "hopers-io ",
+      "symbol": "HOPERS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
+      "verified": false,
+      "price": {
+        "pool": "894",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "acrechain",
+      "base_denom": "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c",
+      "coingecko_id": "arable-usd",
+      "symbol": "arUSD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
+      "verified": false,
+      "price": {
+        "pool": "895",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "planq",
+      "base_denom": "aplanq",
+      "coingecko_id": "planq",
+      "symbol": "PLQ",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "898",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wftm-wei",
+      "coingecko_id": "fantom",
+      "symbol": "FTM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "900",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "canto",
+      "base_denom": "acanto",
+      "coingecko_id": "canto",
+      "symbol": "CANTO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
+      "verified": true,
+      "price": {
+        "pool": "901",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqstars",
+      "symbol": "qSTARS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "903",
+        "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "symbol": "WYND",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "902",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "polygon-uusdc",
+      "coingecko_id": "usd-coin",
+      "symbol": "polygon.USDC",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "938",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "avalanche-uusdc",
+      "coingecko_id": "usd-coin",
+      "symbol": "avalanche.USDC",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "938",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "mars",
+      "base_denom": "umars",
+      "coingecko_id": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
+      "symbol": "MARS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1099",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "acrechain",
+      "base_denom": "erc20/0xAE6D3334989a22A65228732446731438672418F2",
+      "symbol": "CNTO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/cnto.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/cnto.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "909",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stuluna",
+      "symbol": "stLUNA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stluna.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372",
+      "verified": true,
+      "price": {
+        "pool": "913",
+        "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "staevmos",
+      "symbol": "stEVMOS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stevmos.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/C5579A9595790017C600DD726276D978B9BF314CF82406CE342720A9C7911A01",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "922",
+        "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq",
+      "symbol": "NRIDE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "924",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "8ball",
+      "base_denom": "uebl",
+      "coingecko_id": "",
+      "symbol": "EBL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/8ball/images/8ball.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/8ball/images/8ball.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/8BE73A810E22F80E5E850531A688600D63AE7392E7C2770AE758CAA4FD921B7F",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "935",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqatom",
+      "symbol": "qATOM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qatom.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qatom.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/FA602364BEC305A696CBDF987058E99D8B479F0318E47314C49173E8838C5BAC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "944",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "comdex",
+      "base_denom": "uharbor",
+      "coingecko_id": "",
+      "symbol": "HARBOR",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/harbor.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/AD4DEA52408EA07C0C9E19444EC8DA84A274A70AD2687A710EFDDEB28BB2986A",
+      "verified": false,
+      "price": {
+        "pool": "967",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqregen",
+      "symbol": "qREGEN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qregen.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qregen.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "948",
+        "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x",
+      "symbol": "FOX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fox.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/4F24D904BAB5FFBD3524F2DE3EC3C7A9E687A2408D9A985E57B356D9FA9201C6",
+      "verified": false,
+      "price": {
+        "pool": "949",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqck",
+      "coingecko_id": "quicksilver",
+      "symbol": "QCK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "952",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "arkh",
+      "base_denom": "arkh",
+      "symbol": "ARKH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/arkh/images/arkh.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/arkh/images/arkh.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/0F91EE8B98AAE3CF393D94CD7F89A10F8D7758C5EC707E721899DFE65C164C28",
+      "verified": false,
+      "price": {
+        "pool": "954",
+        "denom": "uosmo"
+      },
+      "unstable": true
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqosmo",
+      "symbol": "qOSMO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "956",
+        "denom": "uosmo"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "noble",
+      "base_denom": "ufrienzies",
+      "symbol": "FRNZ",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/frnz.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/frnz.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/7FA7EC64490E3BDE5A1A28CBE73CC0AD22522794957BC891C46321E3A6074DB9",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1012",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "migaloo",
+      "base_denom": "uwhale",
+      "coingecko_id": "white-whale",
+      "symbol": "WHALE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1318",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma",
+      "symbol": "GRDN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/guardian.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/BAC9C6998F1F5C316D3353622EAEDAF8BD00FAABEB374FECDF8C9BC475172CFA",
+      "verified": false,
+      "price": {
+        "pool": "959",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my",
+      "symbol": "MNPU",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/mnpu.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/mnpu.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/DC0D3303BBE739E073224D0314385B88B247F56D71D726A91414CCA244FFFE7E",
+      "verified": false,
+      "price": {
+        "pool": "961",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z",
+      "symbol": "SHIBAC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/shibacosmos.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/447A0DCE83691056289503DDAB8EB08E52E167A73629F2ACC59F056B92F51CE8",
+      "verified": false,
+      "price": {
+        "pool": "962",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp",
+      "symbol": "SKOJ",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sikoba.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sikoba.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/71066B030D8FC6479E638580E1BA9C44925E8C1F6E45036669D22017CFDC8C5E",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "964",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "regen",
+      "base_denom": "eco.uC.NCT",
+      "coingecko_id": "toucan-protocol-nature-carbon-tonne",
+      "symbol": "NCT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "972",
+        "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg",
+      "symbol": "CLST",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/celestims.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/0E4FA664327BD40B32803EE84A77F145834C0281B7F82B65521333B3669FA0BA",
+      "verified": false,
+      "price": {
+        "pool": "974",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je",
+      "symbol": "OSDOGE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/osdoge.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/8AEEA9B9304392070F72611076C0E328CE3F2DECA1E18557E36F9DB4F09C0156",
+      "verified": false,
+      "price": {
+        "pool": "975",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06",
+      "symbol": "APEMOS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/apemos.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1EB03F13F29FEA73444586FC4E88A8C14ACE9291501E9658E3BEF951EA4AC85D",
+      "verified": false,
+      "price": {
+        "pool": "977",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8",
+      "symbol": "INVDRS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/invdrs.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/3DB1721541C94AD19D7735FECED74C227E13F925BDB814392980B40A19C1ED54",
+      "verified": false,
+      "price": {
+        "pool": "969",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d",
+      "symbol": "DOGA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/doga.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/04BE4E9C825ED781F9684A1226114BB49607500CAD855F1E3FEEC18532297250",
+      "verified": false,
+      "price": {
+        "pool": "978",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488",
+      "symbol": "CATMOS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/catmos.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F4A07138CAEF0BFB4889E03C44C57956A48631061F1C8AB80421C1F229C1B835",
+      "verified": false,
+      "price": {
+        "pool": "981",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
+      "symbol": "SUMMIT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/summit.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/56B988C4D934FB7503F5EA9B440C75D489C8AD5D193715B477BEC4F84B8BBA2A",
+      "verified": false,
+      "price": {
+        "pool": "982",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "omniflixhub",
+      "base_denom": "uflix",
+      "coingecko_id": "omniflix-network",
+      "symbol": "FLIX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "992",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg",
+      "symbol": "SPACER",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/spacer.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/7A496DB7C2277D4B74EC4428DDB5AC8A62816FBD0DEBE1CFE094935D746BE19C",
+      "verified": false,
+      "price": {
+        "pool": "993",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l",
+      "symbol": "LIGHT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/light.png"
+        }
+      ],
+      "decimals": 9,
+      "ibc_denom": "ibc/3DC08BDF2689978DBCEE28C7ADC2932AA658B2F64B372760FBC5A0058669AD29",
+      "verified": false,
+      "price": {
+        "pool": "1009",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd",
+      "symbol": "SILK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/silk.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/silk.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1146",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d",
+      "symbol": "MILE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/mille.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/912275A63A565BFD80734AEDFFB540132C51E446EAC41483B26EDE8A557C71CF",
+      "verified": false,
+      "price": {
+        "pool": "1000",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq",
+      "symbol": "MANNA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/manna.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/980A2748F37C938AD129B92A51E2ABA8CFFC6862ADD61EC1B291125535DBE30B",
+      "verified": false,
+      "price": {
+        "pool": "997",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wfil-wei",
+      "coingecko_id": "filecoin",
+      "symbol": "FIL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/filecoin/images/fil.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/filecoin/images/fil.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
+      "verified": true,
+      "price": {
+        "pool": "1006",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8",
+      "symbol": "VOID",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/void.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/593F820ECE676A3E0890C734EC4F3A8DE16EC10A54EEDFA8BDFEB40EEA903960",
+      "verified": false,
+      "price": {
+        "pool": "1003",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "secretnetwork",
+      "base_denom": "cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
+      "coingecko_id": "shade-protocol",
+      "symbol": "SHD",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/0B3D528E74E3DEAADF8A68F393887AC7E06028904D02173561B0D27F6E751D0A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1170",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "bluzelle",
+      "base_denom": "ubnt",
+      "coingecko_id": "bluzelle",
+      "symbol": "BLZ",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bluzelle/images/bluzelle.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bluzelle/images/bluzelle.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/63CDD51098FD99E04E5F5610A3882CBE7614C441607BA6FCD7F3A3C1CD5325F8",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1007",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "arb-wei",
+      "coingecko_id": "arbitrum",
+      "symbol": "ARB",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1011",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux",
+      "symbol": "SLCA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/silica.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/5164ECF584AD7DC27DA9E6A89E75DAB0F7C4FCB0A624B69215B8BC6A2C40CD07",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1023",
+        "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k",
+      "symbol": "PEPEC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/pepec.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/C00B17F74C94449A62935B4C886E6F0F643249A270DEF269D53CE6741ECCDB93",
+      "verified": false,
+      "price": {
+        "pool": "1016",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "pepe-wei",
+      "coingecko_id": "pepe",
+      "symbol": "PEPE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
+      "verified": true,
+      "price": {
+        "pool": "1018",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
+      "coingecko_id": "ibc-index",
+      "symbol": "IBCX",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibcx.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1254",
+        "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "cbeth-wei",
+      "coingecko_id": "coinbase-wrapped-staked-eth",
+      "symbol": "cbETH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/cbeth.png"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/4D7A6F2A7744B1534C984A21F9EDFFF8809FC71A9E9243FFB702073E7FCA513A",
+      "verified": true,
+      "price": {
+        "pool": "1030",
+        "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "reth-wei",
+      "coingecko_id": "rocket-pool-eth",
+      "symbol": "rETH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/reth.png"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/E610B83FD5544E00A8A1967A2EB3BEF25F1A8CFE8650FE247A8BD4ECA9DC9222",
+      "verified": true,
+      "price": {
+        "pool": "1030",
+        "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "sfrxeth-wei",
+      "coingecko_id": "staked-frax-ether",
+      "symbol": "sfrxETH",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/sfrxeth.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/81F578C39006EB4B27FFFA9460954527910D73390991B379C03B18934D272F46",
+      "verified": true,
+      "price": {
+        "pool": "1030",
+        "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "wsteth-wei",
+      "symbol": "wstETH.axl",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereum",
+            "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wsteth.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C",
+      "verified": true,
+      "price": {
+        "pool": "1024",
+        "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+      }
+    },
+    {
+      "chain_name": "gitopia",
+      "base_denom": "ulore",
+      "coingecko_id": "gitopia",
+      "symbol": "LORE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/lore.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/lore.svg"
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/gitopia.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1036",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "terra2",
+      "base_denom": "cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
+      "symbol": "ROAR",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/roar.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/98BCD43F190C6960D0005BC46BB765C827403A361C9C03C2FF694150A30284B0",
+      "verified": true,
+      "price": {
+        "pool": "1043",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stuumee",
+      "symbol": "stUMEE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stumee.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stumee.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/02F196DA6FD0917DD5FEA249EE61880F4D941EE9059E7964C5C9B50AF103800F",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1035",
+        "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
+      "symbol": "stIBCX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1107",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "nolus",
+      "base_denom": "unls",
+      "coingecko_id": "nolus",
+      "symbol": "NLS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D9AFCECDD361D38302AA66EB3BAC23B95234832C51D12489DC451FA2B7C72782",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1041",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "terra2",
+      "base_denom": "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
+      "symbol": "CUB",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/cub.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/6F18EFEBF1688AA77F7EAC17065609494DC1BA12AFC78E9AEC832AF70A11BEF3",
+      "verified": false,
+      "price": {
+        "pool": "1072",
+        "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
+      }
+    },
+    {
+      "chain_name": "terra2",
+      "base_denom": "cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
+      "symbol": "BLUE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/blue.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/DA961FE314B009C38595FFE3AF41225D8894D663B8C3F6650DCB5B6F8435592E",
+      "verified": false,
+      "price": {
+        "pool": "1073",
+        "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
+      }
+    },
+    {
+      "chain_name": "neutron",
+      "base_denom": "untrn",
+      "coingecko_id": "neutron-3",
+      "symbol": "NTRN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1324",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss",
+      "symbol": "CASA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/casa.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/2F5C084037D951B24D100F15CC013A131DF786DCE1B1DBDC48F018A9B9A138DE",
+      "verified": false,
+      "price": {
+        "pool": "1028",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "composable",
+      "base_denom": "ppica",
+      "coingecko_id": "picasso",
+      "symbol": "PICA",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "picasso",
+            "base_denom": "ppica"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/pica.svg"
+        }
+      ],
+      "decimals": 12,
+      "ibc_denom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1057",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "composable",
+      "base_denom": "ibc/EE9046745AEC0E8302CB7ED9D5AD67F528FB3B7AE044B247FB0FB293DBDA35E9",
+      "coingecko_id": "kusama",
+      "symbol": "KSM",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/kusama/images/ksm.svg"
+        }
+      ],
+      "decimals": 12,
+      "ibc_denom": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1151",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "composable",
+      "base_denom": "ibc/3CC19CEC7E5A3E90E78A5A9ECC5A0E2F8F826A375CF1E096F4515CF09DA3E366",
+      "coingecko_id": "polkadot",
+      "symbol": "DOT",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
+        }
+      ],
+      "decimals": 10,
+      "ibc_denom": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1145",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quasar",
+      "base_denom": "uqsr",
+      "coingecko_id": "quasar-2",
+      "symbol": "QSR",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quasar/images/quasar.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1314",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "archway",
+      "base_denom": "aarch",
+      "coingecko_id": "archway",
+      "symbol": "ARCH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/archway.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1061",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "empowerchain",
+      "base_denom": "umpwr",
+      "symbol": "MPWR",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/empowerchain/images/mpwr.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1065",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "cw20:juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw",
+      "symbol": "WATR",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/watr.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/AABCB14ACAFD53A5C455BAC01EA0CA5AE18714895846681A52BFF1E3B960B44E",
+      "verified": false,
+      "price": {
+        "pool": "1071",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kyve",
+      "base_denom": "ukyve",
+      "coingecko_id": "kyve-network",
+      "symbol": "KYVE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1075",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kava",
+      "base_denom": "erc20/tether/usdt",
+      "coingecko_id": "tether",
+      "symbol": "USDT",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1220",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      },
+      "categories": [
+        "stablecoin"
+      ],
+      "peg_mechanism": "collateralized"
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+      "symbol": "ampOSMO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/amposmo.png"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "price": {
+        "pool": "1067",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "sei",
+      "base_denom": "usei",
+      "coingecko_id": "sei-network",
+      "symbol": "SEI",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1114",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqsomm",
+      "symbol": "qSOMM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/EAF76AD1EEF7B16D167D87711FB26ABE881AC7D9F7E6D0CF313D5FA530417208",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1087",
+        "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "passage",
+      "base_denom": "upasg",
+      "coingecko_id": "passage",
+      "symbol": "PASG",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/passage/images/pasg.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1137",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "stride",
+      "base_denom": "stusomm",
+      "symbol": "stSOMM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/5A0060579D24FBE5268BEA74C3281E7FE533D361C41A99307B4998FEC611E46B",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1120",
+        "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA",
+      "coingecko_id": "solana",
+      "symbol": "SOL",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1294",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
+      "coingecko_id": "bonk",
+      "symbol": "BONK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/bonk.png"
+        }
+      ],
+      "decimals": 5,
+      "ibc_denom": "ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1129",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
+      "symbol": "USDT.wh",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereum",
+            "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1131",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh",
+      "coingecko_id": "sui",
+      "symbol": "SUI",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/sui/images/sui.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
+      "verified": true,
+      "price": {
+        "pool": "1127",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r",
+      "coingecko_id": "aptos",
+      "symbol": "APT",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/aptos.svg"
+        },
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/apt-dm.svg",
+          "theme": {
+            "dark_mode": true
+          }
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/A4D176906C1646949574B48C1928D475F2DF56DE0AC04E1C99B08F90BC21ABDE",
+      "verified": true,
+      "price": {
+        "pool": "1125",
+        "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
+      }
+    },
+    {
+      "chain_name": "kujira",
+      "base_denom": "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta",
+      "coingecko_id": "mantadao",
+      "symbol": "MNTA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/51D893F870B7675E507E91DA8DB0B22EA66333207E4F5C0708757F08EE059B0B",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1215",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "juno",
+      "base_denom": "factory/juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e/DGL",
+      "symbol": "DGL",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dgl.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D69F6D787EC649F4E998161A9F0646F4C2DCC64748A2AB982F14CAFBA7CC0EC9",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1143",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
+      "symbol": "USDC.wh",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "ethereum",
+            "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/6B99DB46AA9FF47162148C1726866919E44A6A5E0274B90912FD17E19A337695",
+      "verified": true
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
+      "symbol": "wETH.wh",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/62F82550D0B96522361C89B0DA1119DE262FBDFB25E5502BC5101B5C0D0DBAAC",
+      "verified": true,
+      "price": {
+        "pool": "1214",
+        "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+      }
+    },
+    {
+      "chain_name": "noble",
+      "base_denom": "uusdc",
+      "coingecko_id": "usd-coin",
+      "symbol": "USDC",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1223",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "yieldeth-wei",
+      "symbol": "YieldETH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/yieldeth.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/yieldeth.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/FBB3FEF80ED2344D821D4F95C31DBFD33E4E31D5324CAD94EF756E67B749F668",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1213",
+        "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+      }
+    },
+    {
+      "chain_name": "xpla",
+      "base_denom": "axpla",
+      "coingecko_id": "xpla",
+      "symbol": "XPLA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/95C9B5870F95E21A242E6AF9ADCB1F212EE4A8855087226C36FBE43FC41A77B8",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1173",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "sei",
+      "base_denom": "factory/sei1thgp6wamxwqt7rthfkeehktmq0ujh5kspluw6w/OIN",
+      "coingecko_id": "",
+      "symbol": "OIN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/oin.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/98B3DBF1FA79C4C14CC5F08F62ACD5498560FCB515F677526FD200D54EA048B6",
+      "verified": false,
+      "price": {
+        "pool": "1210",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "evmos",
+      "base_denom": "erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9",
+      "symbol": "NEOK",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/neok.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/neok.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/DEE262653B9DE39BCEF0493D47E0DFC4FE62F7F046CF38B9FDEFEBE98D149A71",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1121",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "realio",
+      "base_denom": "ario",
+      "coingecko_id": "realio-network",
+      "symbol": "RIO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/realio/images/rio.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/realio/images/rio.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/1CDF9C7D073DD59ED06F15DB08CC0901F2A24759BE70463570E8896F9A444ADF",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1180",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
+      "coingecko_id": "collateralized-debt-token",
+      "symbol": "CDT",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CDT.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1268",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
+      "coingecko_id": "membrane",
+      "symbol": "MBRN",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/MBRN.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1225",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "sge",
+      "base_denom": "usge",
+      "coingecko_id": "six-sigma",
+      "symbol": "SGE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sge/images/sge.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sge/images/sge.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/A1830DECC0B742F0B2044FF74BE727B5CF92C9A28A9235C3BACE4D24A23504FA",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1233",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "stafihub",
+      "base_denom": "ufis",
+      "coingecko_id": "stafi",
+      "symbol": "FIS",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stafihub/images/fis.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/01D2F0C4739C871BFBEE7E786709E6904A55559DC1483DD92ED392EF12247862",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1230",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "stafihub",
+      "base_denom": "uratom",
+      "coingecko_id": "",
+      "symbol": "rATOM",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stafihub/images/ratom.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/B66CE615C600ED0A8B5AF425ECFE0D57BE2377587F66C45934A76886F34DC9B7",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1227",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "stargaze",
+      "base_denom": "factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/dust",
+      "coingecko_id": "",
+      "symbol": "STRDST",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/dust.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/dust.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1234",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "doravota",
+      "base_denom": "peaka",
+      "symbol": "DORA",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/doravota/images/dora.svg"
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/doravota/images/doravota.png"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/672406ADE4EDFD8C5EA7A0D0DD0C37E431DA7BD8393A15CD2CFDE3364917EB2A",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1239",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "coreum",
+      "base_denom": "ucore",
+      "coingecko_id": "coreum",
+      "symbol": "COREUM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/coreum.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/F3166F4D31D6BA1EC6C9F5536F5DDDD4CC93DBA430F7419E7CDC41C497944A65",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1244",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "celestia",
+      "base_denom": "utia",
+      "coingecko_id": "celestia",
+      "symbol": "TIA",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1248",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "dydx",
+      "base_denom": "adydx",
+      "coingecko_id": "dydx",
+      "symbol": "DYDX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.svg"
+        },
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx-circle.svg",
+          "theme": {
+            "circle": true
+          }
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1246",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "fxcore",
+      "base_denom": "FX",
+      "coingecko_id": "fx-coin",
+      "symbol": "FX",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fxcore/images/fx.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fxcore/images/fx.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/2B30802A0B03F91E4E16D6175C9B70F2911377C1CAE9E50FF011C821465463F9",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1241",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "nomic",
+      "base_denom": "usat",
+      "symbol": "nBTC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nbtc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nbtc.svg"
+        }
+      ],
+      "decimals": 14,
+      "ibc_denom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1284",
+        "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
+      }
+    },
+    {
+      "chain_name": "nois",
+      "base_denom": "unois",
+      "symbol": "NOIS",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nois/images/nois.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nois/images/nois.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/6928AFA9EA721938FED13B051F9DBF1272B16393D20C49EA5E4901BB76D94A90",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1305",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
+      "symbol": "sqOSMO",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqosmo.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1267",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "kujira",
+      "base_denom": "factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk",
+      "symbol": "NSTK",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/nstk.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/690EB0A0CA0DA2DC1E9CF62FB23C935AE5C7E9F57919CF89690521D5D70948A7",
+      "verified": false
+    },
+    {
+      "chain_name": "stargaze",
+      "base_denom": "factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/uBRNCH",
+      "coingecko_id": "",
+      "symbol": "BRNCH",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/brnch.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/brnch.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/71DAA4CAFA4FE2F9803ABA0696BA5FC0EFC14305A2EA8B4E01880DB851B1EC02",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1288",
+        "denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B"
+      }
+    },
+    {
+      "chain_name": "neutron",
+      "base_denom": "factory/neutron1ug740qrkquxzrk2hh29qrlx3sktkfml3je7juusc2te7xmvsscns0n2wry/wstETH",
+      "coingecko_id": "wrapped-steth",
+      "symbol": "wstETH",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wsteth.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/2F21E6D4271DE3F561F20A02CD541DAF7405B1E9CB3B9B07E3C2AC7D8A4338A5",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1292",
+        "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqatom",
+      "symbol": "sqATOM",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqatom.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1299",
+        "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqbtc",
+      "symbol": "sqBTC",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqbtc.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "unlisted": true
+    },
+    {
+      "chain_name": "qwoyn",
+      "base_denom": "uqwoyn",
+      "symbol": "QWOYN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qwoyn/images/qwoyn.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/09FAF1E04435E14C68DE7AB0D03C521C92975C792DB12B2EA390BAA2E06B3F3D",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1295",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "bostrom",
+      "base_denom": "hydrogen",
+      "symbol": "HYDROGEN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/hydrogen.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/hydrogen.svg"
+        }
+      ],
+      "decimals": 0,
+      "ibc_denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1302",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "bostrom",
+      "base_denom": "tocyb",
+      "symbol": "TOCYB",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/tocyb.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/tocyb.svg"
+        }
+      ],
+      "decimals": 0,
+      "ibc_denom": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
+      "verified": false,
+      "price": {
+        "pool": "1310",
+        "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20"
+      }
+    },
+    {
+      "chain_name": "bostrom",
+      "base_denom": "millivolt",
+      "symbol": "V",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/volt.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/volt.svg"
+        }
+      ],
+      "decimals": 3,
+      "ibc_denom": "ibc/D3A1900B2B520E45608B5671ADA461E1109628E89B4289099557C6D3996F7DAA",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1304",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "bostrom",
+      "base_denom": "milliampere",
+      "symbol": "A",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/ampere.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/ampere.svg"
+        }
+      ],
+      "decimals": 3,
+      "ibc_denom": "ibc/020F5162B7BC40656FC5432622647091F00D53E82EE8D21757B43D3282F25424",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1303",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "source",
+      "base_denom": "usource",
+      "coingecko_id": "source",
+      "symbol": "SOURCE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/source/images/source.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/source/images/source.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1311",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      }
+    },
+    {
+      "chain_name": "gateway",
+      "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/B8ohBnfisop27exk2gtNABJyYjLwQA7ogrp5uNzvZCoy",
+      "coingecko_id": "pyth-network",
+      "symbol": "PYTH",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/pyth.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/E42006ED917C769EDE1B474650EEA6BFE3F97958912B9206DD7010A28D01D9D5",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1315",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+      }
+    },
+    {
+      "chain_name": "persistence",
+      "base_denom": "stk/uosmo",
+      "symbol": "stkOSMO",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkosmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkosmo.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/ECBE78BF7677320A93E7BA1761D144BCBF0CBC247C290C049655E106FE5DC68E",
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1323",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
+      "symbol": "LVN",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.svg"
+        },
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.png"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1325",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "chihuahua",
+      "base_denom": "cw20:chihuahua1yl8z39ugle8s02fpwkhh293509q5xcpalmdzc4amvchz8nkexrmsy95gef",
+      "symbol": "PUPPY",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/puppyhuahua_logo.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1332",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "neutron",
+      "base_denom": "factory/neutron1p8d89wvxyjcnawmgw72klknr3lg9gwwl6ypxda/newt",
+      "symbol": "NEWT",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/newt.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1334",
+        "denom": "uosmo"
+      }
+    },
+    {
+      "chain_name": "osmosis",
+      "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
+      "symbol": "milkTIA",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/milktia.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/milktia.svg"
+        }
+      ],
+      "decimals": 6,
+      "verified": true,
+      "api_include": true,
+      "price": {
+        "pool": "1335",
+        "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"
+      },
+      "categories": [
+        "liquid_staking"
+      ]
+    },
+    {
+      "chain_name": "migaloo",
+      "base_denom": "factory/migaloo1erul6xyq0gk6ws98ncj7lnq9l4jn4gnnu9we73gdz78yyl2lr7qqrvcgup/ash",
+      "symbol": "ASH",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/ash.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/4976049456D261659D0EC499CC9C2391D3C7D1128A0B9FB0BBF2842D1B2BC7BC",
+      "verified": false
+    },
+    {
+      "chain_name": "migaloo",
+      "base_denom": "factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/urac",
+      "symbol": "migaloo.RAC",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rac.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rac.svg"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/DDF1CD4CDC14AE2D6A3060193624605FF12DEE71CF1F8C19EEF35E9447653493",
+      "verified": false
+    },
+    {
+      "chain_name": "migaloo",
+      "base_denom": "factory/migaloo1etlu2h30tjvv8rfa4fwdc43c92f6ul5w9acxzk/uguppy",
+      "symbol": "GUPPY",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/guppy.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/42A9553A7770F3D7B62F3A82AF04E7719B4FD6EAF31BE5645092AAC4A6C2201D",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1342",
+        "denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963"
+      }
+    },
+    {
+      "chain_name": "haqq",
+      "base_denom": "aISLM",
+      "coingecko_id": "islamic-coin",
+      "symbol": "ISLM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/haqq/images/islm.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/haqq/images/islm.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
+      "verified": false,
+      "price": {
+        "pool": "1343",
+        "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+      },
+      "unlisted": true
+    },
+    {
+      "chain_name": "injective",
+      "base_denom": "factory/inj14lf8xm6fcvlggpa7guxzjqwjmtr24gnvf56hvz/autism",
+      "symbol": "AUTISM",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/autism.png"
+        }
+      ],
+      "decimals": 6,
+      "ibc_denom": "ibc/9DDF52A334F92BC57A9E0D59DFF9984EAC61D2A14E5162605DF601AA58FDFC6D",
+      "verified": false
+    },
+    {
+      "chain_name": "gravitybridge",
+      "base_denom": "gravity0x60e683C6514Edd5F758A55b6f393BeBBAfaA8d5e",
+      "symbol": "PAGE",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/page.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/page.svg"
+        }
+      ],
+      "decimals": 8,
+      "ibc_denom": "ibc/23A62409E4AD8133116C249B1FA38EED30E500A115D7B153109462CD82C1CD99",
+      "verified": false,
+      "api_include": true,
+      "price": {
+        "pool": "1344",
+        "denom": "uosmo"
+      },
+      "unlisted": true
+    },
+    {
+      "chain_name": "pundix",
+      "base_denom": "bsc0x29a63F4B209C29B4DC47f06FFA896F32667DAD2C",
+      "symbol": "PURSE",
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "binancesmartchain",
+            "base_denom": "0x29a63F4B209C29B4DC47f06FFA896F32667DAD2C"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pundix/images/purse-token-logo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pundix/images/purse-token-logo.svg"
+        }
+      ],
+      "decimals": 18,
+      "ibc_denom": "ibc/6FD2938076A4C1BB3A324A676E76B0150A4443DAE0E002FB62AC0E6B604B1519",
+      "verified": false,
+      "unlisted": true
+    }
+  ]
+}

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5,12 +5,14 @@
     {
       "chain_name": "osmosis",
       "base_denom": "uosmo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "uion",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
@@ -18,6 +20,7 @@
       "path": "transfer/channel-208/uusdc",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "USDC.axl",
         "logo_URIs": {
@@ -31,6 +34,7 @@
       "base_denom": "weth-wei",
       "path": "transfer/channel-208/weth-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "ETH",
         "name": "Ether",
@@ -48,6 +52,7 @@
       "base_denom": "wbtc-satoshi",
       "path": "transfer/channel-208/wbtc-satoshi",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "WBTC"
       },
@@ -62,6 +67,7 @@
       "path": "transfer/channel-208/uusdt",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "USDT.axl",
         "logo_URIs": {
@@ -75,6 +81,7 @@
       "path": "transfer/channel-208/dai-wei",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "DAI"
       },
@@ -88,6 +95,7 @@
       "base_denom": "busd-wei",
       "path": "transfer/channel-208/busd-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "BUSD"
       },
@@ -101,6 +109,7 @@
       "base_denom": "uatom",
       "path": "transfer/channel-0/uatom",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Cosmos Hub"
       }
@@ -109,13 +118,15 @@
       "chain_name": "cryptoorgchain",
       "base_denom": "basecro",
       "path": "transfer/channel-5/basecro",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "wbnb-wei",
       "path": "transfer/channel-208/wbnb-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "BNB",
         "name": "Binance Coin"
@@ -130,6 +141,7 @@
       "base_denom": "wmatic-wei",
       "path": "transfer/channel-208/wmatic-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "MATIC",
         "name": "Polygon",
@@ -147,6 +159,7 @@
       "base_denom": "wavax-wei",
       "path": "transfer/channel-208/wavax-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "AVAX",
         "name": "Avalanche",
@@ -164,10 +177,11 @@
       "base_denom": "uluna",
       "path": "transfer/channel-72/uluna",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Luna Classic"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Terra Bridge",
           "type": "external_interface",
@@ -180,13 +194,15 @@
       "chain_name": "juno",
       "base_denom": "ujuno",
       "path": "transfer/channel-42/ujuno",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "dot-planck",
       "path": "transfer/channel-208/dot-planck",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "DOT.axl",
         "logo_URIs": {
@@ -199,7 +215,8 @@
       "base_denom": "aevmos",
       "path": "transfer/channel-204/aevmos",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Evmos App",
           "type": "external_interface",
@@ -212,44 +229,51 @@
       "chain_name": "kava",
       "base_denom": "ukava",
       "path": "transfer/channel-143/ukava",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "secretnetwork",
       "base_denom": "uscrt",
       "path": "transfer/channel-88/uscrt",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "terra",
       "base_denom": "uusd",
       "path": "transfer/channel-72/uusd",
       "peg_mechanism": "algorithmic",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stargaze",
       "base_denom": "ustars",
       "path": "transfer/channel-75/ustars",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "chihuahua",
       "base_denom": "uhuahua",
       "path": "transfer/channel-113/uhuahua",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "persistence",
       "base_denom": "uxprt",
       "path": "transfer/channel-4/uxprt",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "persistence",
       "base_denom": "ibc/A6E3AF63B3C906416A9AF7A556C59EA4BD50E617EFFE6299B99700CCB780E444",
       "path": "transfer/channel-4/transfer/channel-38/gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006"
@@ -259,171 +283,199 @@
       "chain_name": "akash",
       "base_denom": "uakt",
       "path": "transfer/channel-1/uakt",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "regen",
       "base_denom": "uregen",
       "path": "transfer/channel-8/uregen",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "sentinel",
       "base_denom": "udvpn",
       "path": "transfer/channel-2/udvpn",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "irisnet",
       "base_denom": "uiris",
       "path": "transfer/channel-6/uiris",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "starname",
       "base_denom": "uiov",
       "path": "transfer/channel-15/uiov",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "emoney",
       "base_denom": "ungm",
       "path": "transfer/channel-37/ungm",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "emoney",
       "base_denom": "eeur",
       "path": "transfer/channel-37/eeur",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "likecoin",
       "base_denom": "nanolike",
       "path": "transfer/channel-53/nanolike",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "impacthub",
       "base_denom": "uixo",
       "path": "transfer/channel-38/uixo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bitcanna",
       "base_denom": "ubcna",
       "path": "transfer/channel-51/ubcna",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bitsong",
       "base_denom": "ubtsg",
       "path": "transfer/channel-73/ubtsg",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kichain",
       "base_denom": "uxki",
       "path": "transfer/channel-77/uxki",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "panacea",
       "base_denom": "umed",
       "path": "transfer/channel-82/umed",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bostrom",
       "base_denom": "boot",
       "path": "transfer/channel-95/boot",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "comdex",
       "base_denom": "ucmdx",
       "path": "transfer/channel-87/ucmdx",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "cheqd",
       "base_denom": "ncheq",
       "path": "transfer/channel-108/ncheq",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "lumnetwork",
       "base_denom": "ulum",
       "path": "transfer/channel-115/ulum",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "vidulum",
       "base_denom": "uvdl",
       "path": "transfer/channel-124/uvdl",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "desmos",
       "base_denom": "udsm",
       "path": "transfer/channel-135/udsm",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "dig",
       "base_denom": "udig",
       "path": "transfer/channel-128/udig",
       "osmosis_verified": true,
-      "osmosis_unstable": true
+      "osmosis_unstable": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "sommelier",
       "base_denom": "usomm",
       "path": "transfer/channel-165/usomm",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bandchain",
       "base_denom": "uband",
       "path": "transfer/channel-148/uband",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "konstellation",
       "base_denom": "udarc",
       "path": "transfer/channel-171/udarc",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "umee",
       "base_denom": "uumee",
       "path": "transfer/channel-184/uumee",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "gravitybridge",
       "base_denom": "ugraviton",
       "path": "transfer/channel-144/ugraviton",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "decentr",
       "base_denom": "udec",
       "path": "transfer/channel-181/udec",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
       "path": "transfer/channel-169/cw20:juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "carbon",
       "base_denom": "swth",
       "path": "transfer/channel-188/swth",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Carbon Demex",
           "type": "external_interface",
@@ -437,32 +489,37 @@
       "base_denom": "ucrbrus",
       "path": "transfer/channel-212/ucrbrus",
       "osmosis_verified": false,
-      "osmosis_unstable": true
+      "osmosis_unstable": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "fetchhub",
       "base_denom": "afet",
       "path": "transfer/channel-229/afet",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "assetmantle",
       "base_denom": "umntl",
       "path": "transfer/channel-232/umntl",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
       "path": "transfer/channel-169/cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "injective",
       "base_denom": "inj",
       "path": "transfer/channel-122/inj",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Injective Hub",
           "type": "external_interface",
@@ -476,14 +533,16 @@
       "base_denom": "ukrw",
       "path": "transfer/channel-72/ukrw",
       "peg_mechanism": "algorithmic",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "microtick",
       "base_denom": "utick",
       "path": "transfer/channel-39/utick",
       "osmosis_verified": false,
-      "osmosis_unstable": true
+      "osmosis_unstable": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "sifchain",
@@ -491,6 +550,7 @@
       "path": "transfer/channel-47/rowan",
       "osmosis_verified": false,
       "osmosis_unstable": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Sifchain"
       }
@@ -499,19 +559,22 @@
       "chain_name": "shentu",
       "base_denom": "uctk",
       "path": "transfer/channel-146/uctk",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
       "path": "transfer/channel-169/cw20:juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
       "path": "transfer/channel-169/cw20:juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
@@ -519,6 +582,7 @@
       "path": "transfer/channel-208/frax-wei",
       "peg_mechanism": "hybrid",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "FRAX"
       },
@@ -532,6 +596,7 @@
       "base_denom": "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "path": "transfer/channel-144/gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Wrapped Bitcoin (Gravity Bridge)",
         "symbol": "WBTC.grv",
@@ -539,7 +604,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.grv.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Gravity Bridge",
           "type": "external_interface",
@@ -553,6 +618,7 @@
       "base_denom": "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "path": "transfer/channel-144/gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Ether (Gravity Bridge)",
         "symbol": "WETH.grv",
@@ -560,7 +626,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.grv.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Gravity Bridge",
           "type": "external_interface",
@@ -575,6 +641,7 @@
       "path": "transfer/channel-144/gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "USD Coin (Gravity Bridge)",
         "symbol": "USDC.grv",
@@ -582,7 +649,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.grv.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Gravity Bridge",
           "type": "external_interface",
@@ -597,6 +664,7 @@
       "path": "transfer/channel-144/gravity0x6B175474E89094C44Da98b954EedeAC495271d0F",
       "peg_mechanism": "collateralized",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "DAI Stablecoin (Gravity Bridge)",
         "symbol": "DAI.grv",
@@ -604,7 +672,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dai.grv.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Gravity Bridge",
           "type": "external_interface",
@@ -619,6 +687,7 @@
       "path": "transfer/channel-144/gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Tether USD (Gravity Bridge)",
         "symbol": "USDT.grv",
@@ -626,7 +695,7 @@
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.grv.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Gravity Bridge",
           "type": "external_interface",
@@ -639,55 +708,64 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "path": "transfer/channel-169/cw20:juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "provenance",
       "base_denom": "nhash",
       "path": "transfer/channel-222/nhash",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "galaxy",
       "base_denom": "uglx",
       "path": "transfer/channel-236/uglx",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49",
       "path": "transfer/channel-169/cw20:juno1tdjwrqmnztn2j3sj2ln9xnyps5hs48q3ddwjrz7jpv6mskappjys5czd49",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
       "path": "transfer/channel-169/cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "meme",
       "base_denom": "umeme",
       "path": "transfer/channel-238/umeme",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w",
       "path": "transfer/channel-169/cw20:juno17wzaxtfdw5em7lc94yed4ylgjme63eh73lm3lutp2rhcxttyvpwsypjm4w",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
       "path": "transfer/channel-169/cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "terra2",
       "base_denom": "uluna",
       "path": "transfer/channel-251/uluna",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "Luna"
       }
@@ -696,25 +774,29 @@
       "chain_name": "rizon",
       "base_denom": "uatolo",
       "path": "transfer/channel-221/uatolo",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kava",
       "base_denom": "hard",
       "path": "transfer/channel-143/hard",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kava",
       "base_denom": "swp",
       "path": "transfer/channel-143/swp",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "link-wei",
       "path": "transfer/channel-208/link-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "LINK"
       },
@@ -727,13 +809,15 @@
       "chain_name": "genesisl1",
       "base_denom": "el1",
       "path": "transfer/channel-253/el1",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "aave-wei",
       "path": "transfer/channel-208/aave-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "AAVE"
       },
@@ -747,6 +831,7 @@
       "base_denom": "ape-wei",
       "path": "transfer/channel-208/ape-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "APE"
       },
@@ -760,6 +845,7 @@
       "base_denom": "axs-wei",
       "path": "transfer/channel-208/axs-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "AXS"
       },
@@ -773,6 +859,7 @@
       "base_denom": "mkr-wei",
       "path": "transfer/channel-208/mkr-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "MKR"
       },
@@ -786,6 +873,7 @@
       "base_denom": "rai-wei",
       "path": "transfer/channel-208/rai-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "RAI"
       },
@@ -799,6 +887,7 @@
       "base_denom": "shib-wei",
       "path": "transfer/channel-208/shib-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "SHIB"
       },
@@ -812,6 +901,7 @@
       "base_denom": "uni-wei",
       "path": "transfer/channel-208/uni-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "UNI"
       },
@@ -825,6 +915,7 @@
       "base_denom": "xcn-wei",
       "path": "transfer/channel-208/xcn-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "XCN"
       },
@@ -838,7 +929,8 @@
       "base_denom": "ukuji",
       "path": "transfer/channel-259/ukuji",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Kujira Blue",
           "type": "external_interface",
@@ -850,14 +942,16 @@
       "chain_name": "tgrade",
       "base_denom": "utgd",
       "path": "transfer/channel-263/utgd",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "echelon",
       "base_denom": "aechelon",
       "path": "transfer/channel-403/aechelon",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Echelon Network",
           "type": "external_interface",
@@ -870,25 +964,29 @@
       "chain_name": "odin",
       "base_denom": "loki",
       "path": "transfer/channel-258/loki",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "odin",
       "base_denom": "mGeo",
       "path": "transfer/channel-258/mGeo",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "odin",
       "base_denom": "mO9W",
       "path": "transfer/channel-258/mO9W",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kichain",
       "base_denom": "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
       "path": "transfer/channel-261/cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "kichain.LVN"
       }
@@ -898,6 +996,7 @@
       "base_denom": "wglmr-wei",
       "path": "transfer/channel-208/wglmr-wei",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "GLMR",
         "name": "Moonbeam"
@@ -911,146 +1010,170 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
       "path": "transfer/channel-169/cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
       "path": "transfer/channel-169/cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "crescent",
       "base_denom": "ucre",
       "path": "transfer/channel-297/ucre",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "lumenx",
       "base_denom": "ulumen",
       "path": "transfer/channel-286/ulumen",
       "osmosis_verified": false,
-      "osmosis_unstable": true
+      "osmosis_unstable": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "oraichain",
       "base_denom": "orai",
       "path": "transfer/channel-216/orai",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "cudos",
       "base_denom": "acudos",
       "path": "transfer/channel-298/acudos",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kava",
       "base_denom": "usdx",
       "path": "transfer/channel-143/usdx",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "agoric",
       "base_denom": "ubld",
       "path": "transfer/channel-320/ubld",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "agoric",
       "base_denom": "uist",
       "path": "transfer/channel-320/uist",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "path": "transfer/channel-169/cw20:juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
-      "path": "transfer/channel-169/cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
+      "path": "transfer/channel-169/cw20:juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "ustrd",
       "path": "transfer/channel-326/ustrd",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "stuatom",
       "path": "transfer/channel-326/stuatom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "stustars",
       "path": "transfer/channel-326/stustars",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse",
       "path": "transfer/channel-169/cw20:juno159q8t5g02744lxq8lfmcn6f78qqulq9wn3y9w7lxjgkz4e0a6kvsfvapse",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
       "path": "transfer/channel-169/cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "uaxl",
       "path": "transfer/channel-208/uaxl",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "rebus",
       "base_denom": "arebus",
       "path": "transfer/channel-355/arebus",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "teritori",
       "base_denom": "utori",
       "path": "transfer/channel-362/utori",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "stujuno",
       "path": "transfer/channel-326/stujuno",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "stuosmo",
       "path": "transfer/channel-326/stuosmo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
       "path": "transfer/channel-169/cw20:juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "lambda",
       "base_denom": "ulamb",
       "path": "transfer/channel-378/ulamb",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kujira",
       "base_denom": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
       "path": "transfer/channel-259/factory:kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7:uusk",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Kujira Blue",
           "type": "external_interface",
@@ -1062,20 +1185,23 @@
       "chain_name": "unification",
       "base_denom": "nund",
       "path": "transfer/channel-382/nund",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "jackal",
       "base_denom": "ujkl",
       "path": "transfer/channel-412/ujkl",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "secretnetwork",
       "base_denom": "cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej",
       "path": "transfer/channel-476/cw20:secret12rcvz0umvk875kd6a803txhtlu7y0pnd73kcej",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1088,7 +1214,8 @@
       "base_denom": "cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt",
       "path": "transfer/channel-476/cw20:secret1yxcexylwyxlq58umhgsjgstgcg2a0ytfy4d9lt",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1101,7 +1228,8 @@
       "base_denom": "cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d",
       "path": "transfer/channel-476/cw20:secret1qfql357amn448duf5gvp9gr48sxx9tsnhupu3d",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1114,7 +1242,8 @@
       "base_denom": "cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4",
       "path": "transfer/channel-476/cw20:secret1rgm2m5t530tdzyd99775n6vzumxa5luxcllml4",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1127,7 +1256,8 @@
       "base_denom": "cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4",
       "path": "transfer/channel-476/cw20:secret1k6u0cy4feepm6pehnz804zmwakuwdapm69tuc4",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1139,51 +1269,59 @@
       "chain_name": "beezee",
       "base_denom": "ubze",
       "path": "transfer/channel-340/ubze",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
       "path": "transfer/channel-169/cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "acrechain",
       "base_denom": "aacre",
       "path": "transfer/channel-490/aacre",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "comdex",
       "base_denom": "ucmst",
       "path": "transfer/channel-87/ucmst",
       "peg_mechanism": "collateralized",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "imversed",
       "base_denom": "aimv",
       "path": "transfer/channel-517/aimv",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "medasdigital",
       "base_denom": "umedas",
       "path": "transfer/channel-519/umedas",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
       "path": "transfer/channel-169/cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "secretnetwork",
       "base_denom": "cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852",
       "path": "transfer/channel-476/cw20:secret1s09x2xvfd2lp2skgzm29w2xtena7s8fq98v852",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1195,32 +1333,37 @@
       "chain_name": "onomy",
       "base_denom": "anom",
       "path": "transfer/channel-525/anom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "persistence",
       "base_denom": "stk/uatom",
       "path": "transfer/channel-4/stk/uatom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "dyson",
       "base_denom": "dys",
       "path": "transfer/channel-526/dys",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n",
       "path": "transfer/channel-169/cw20:juno1u45shlp0q4gcckvsj06ss4xuvsu0z24a0d0vr9ce6r24pht4e5xq7q995n",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "acrechain",
       "base_denom": "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c",
       "path": "transfer/channel-490/erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Arable Finance",
           "type": "external_interface",
@@ -1234,7 +1377,8 @@
       "base_denom": "aplanq",
       "path": "transfer/channel-492/aplanq",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "TFM IBC Transfer",
           "type": "external_interface",
@@ -1247,6 +1391,7 @@
       "base_denom": "wftm-wei",
       "path": "transfer/channel-208/wftm-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "FTM",
         "name": "Fantom"
@@ -1260,19 +1405,22 @@
       "chain_name": "canto",
       "base_denom": "acanto",
       "path": "transfer/channel-550/acanto",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "quicksilver",
       "base_denom": "uqstars",
       "path": "transfer/channel-522/uqstars",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "path": "transfer/channel-169/cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
@@ -1280,6 +1428,7 @@
       "path": "transfer/channel-208/polygon-uusdc",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "USD Coin (Polygon)",
         "symbol": "polygon.USDC",
@@ -1298,6 +1447,7 @@
       "path": "transfer/channel-208/avalanche-uusdc",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "name": "USD Coin (Avalanche)",
         "symbol": "avalanche.USDC",
@@ -1314,14 +1464,16 @@
       "chain_name": "mars",
       "base_denom": "umars",
       "path": "transfer/channel-557/umars",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "acrechain",
       "base_denom": "erc20/0xAE6D3334989a22A65228732446731438672418F2",
       "path": "transfer/channel-490/erc20/0xAE6D3334989a22A65228732446731438672418F2",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Arable Finance",
           "type": "external_interface",
@@ -1334,177 +1486,206 @@
       "chain_name": "stride",
       "base_denom": "stuluna",
       "path": "transfer/channel-326/stuluna",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "staevmos",
       "path": "transfer/channel-326/staevmos",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq",
       "path": "transfer/channel-169/cw20:juno1qmlchtmjpvu0cr7u0tad2pq8838h6farrrjzp39eqa9xswg7teussrswlq",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "8ball",
       "base_denom": "uebl",
       "path": "transfer/channel-641/uebl",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "quicksilver",
       "base_denom": "uqatom",
       "path": "transfer/channel-522/uqatom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "comdex",
       "base_denom": "uharbor",
       "path": "transfer/channel-87/uharbor",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "quicksilver",
       "base_denom": "uqregen",
       "path": "transfer/channel-522/uqregen",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x",
       "path": "transfer/channel-169/cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "quicksilver",
       "base_denom": "uqck",
       "path": "transfer/channel-522/uqck",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "arkh",
       "base_denom": "arkh",
       "path": "transfer/channel-648/arkh",
       "osmosis_verified": false,
-      "osmosis_unstable": true
+      "osmosis_unstable": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "quicksilver",
       "base_denom": "uqosmo",
       "path": "transfer/channel-522/uqosmo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "noble",
       "base_denom": "ufrienzies",
       "path": "transfer/channel-750/ufrienzies",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "migaloo",
       "base_denom": "uwhale",
       "path": "transfer/channel-642/uwhale",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma",
       "path": "transfer/channel-169/cw20:juno1xekkh27punj0uxruv3gvuydyt856fax0nu750xns99t2qcxp7xmsqwhfma",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my",
       "path": "transfer/channel-169/cw20:juno166heaxlyntd33a5euh4rrz26svhean4klzw594esmd02l4atan6sazy2my",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z",
       "path": "transfer/channel-169/cw20:juno1x5qt47rw84c4k6xvvywtrd40p8gxjt8wnmlahlqg07qevah3f8lqwxfs7z",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp",
       "path": "transfer/channel-169/cw20:juno1qqwf3lkfjhp77yja7gmg3y95pda0e5xctqrdhf3wvwdd79flagvqfgrgxp",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "regen",
       "base_denom": "eco.uC.NCT",
       "path": "transfer/channel-8/eco.uC.NCT",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg",
       "path": "transfer/channel-169/cw20:juno1ngww7zxak55fql42wmyqrr4rhzpne24hhs4p3w4cwhcdgqgr3hxsmzl9zg",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je",
       "path": "transfer/channel-169/cw20:juno1ytymtllllsp3hfmndvcp802p2xmy5s8m59ufel8xv9ahyxyfs4hs4kd4je",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06",
       "path": "transfer/channel-169/cw20:juno1jrr0tuuzxrrwcg6hgeqhw5wqpck2y55734e7zcrp745aardlp0qqg8jz06",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8",
       "path": "transfer/channel-169/cw20:juno1jwdy7v4egw36pd84aeks3ww6n8k7zhsumd4ac8q5lts83ppxueus4626e8",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d",
       "path": "transfer/channel-169/cw20:juno1k2ruzzvvwwtwny6gq6kcwyfhkzahaunp685wmz4hafplduekj98q9hgs6d",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488",
       "path": "transfer/channel-169/cw20:juno1f5datjdse3mdgrapwuzs3prl7pvxxht48ns6calnn0t77v2s9l8s0qu488",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
       "path": "transfer/channel-169/cw20:juno1j4ux0f6gt7e82z7jdpm25v4g2gts880ap64rdwa49989wzhd0dfqed6vqm",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "omniflixhub",
       "base_denom": "uflix",
       "path": "transfer/channel-199/uflix",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg",
       "path": "transfer/channel-169/cw20:juno1dyyf7pxeassxvftf570krv7fdf5r8e4r04mp99h0mllsqzp3rs4q7y8yqg",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l",
       "path": "transfer/channel-169/cw20:juno1dpany8c0lj526lsa02sldv7shzvnw5dt5ues72rk35hd69rrydxqeraz8l",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "secretnetwork",
       "base_denom": "cw20:secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd",
       "path": "transfer/channel-476/cw20:secret1fl449muk5yq8dlad7a22nje4p5d2pnsgymhjfd",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Secret Network IBC Transfer",
           "type": "external_interface",
@@ -1516,19 +1697,22 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d",
       "path": "transfer/channel-169/cw20:juno1llg7q2d5dqlrqzh5dxv8c7kzzjszld34s5vktqmlmaaxqjssz43sxyhq0d",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq",
       "path": "transfer/channel-169/cw20:juno13ca2g36ng6etcfhr9qxx352uw2n5e92np54thfkm3w3nzlhsgvwsjaqlyq",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "wfil-wei",
       "path": "transfer/channel-208/wfil-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "FIL",
         "name": "Filecoin"
@@ -1542,25 +1726,29 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8",
       "path": "transfer/channel-169/cw20:juno1lpvx3mv2a6ddzfjc7zzz2v2cm5gqgqf0hx67hc5p5qwn7hz4cdjsnznhu8",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "secretnetwork",
       "base_denom": "cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
       "path": "transfer/channel-476/cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bluzelle",
       "base_denom": "ubnt",
       "path": "transfer/channel-763/ubnt",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "arb-wei",
       "path": "transfer/channel-208/arb-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "arbitrum",
         "base_denom": "0x912CE59144191C1204E64559FE8253a0e49E6548"
@@ -1570,13 +1758,15 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux",
       "path": "transfer/channel-169/cw20:juno10vgf2u03ufcf25tspgn05l7j3tfg0j63ljgpffy98t697m5r5hmqaw95ux",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k",
       "path": "transfer/channel-169/cw20:juno1epxnvge53c4hkcmqzlxryw5fp7eae2utyk6ehjcfpwajwp48km3sgxsh9k",
       "osmosis_verified": false,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "PEPEC"
       }
@@ -1586,6 +1776,7 @@
       "base_denom": "pepe-wei",
       "path": "transfer/channel-208/pepe-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
@@ -1594,13 +1785,15 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "axelar",
       "base_denom": "cbeth-wei",
       "path": "transfer/channel-208/cbeth-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xbe9895146f7af43049ca1c1ae358b0541ea49704"
@@ -1611,6 +1804,7 @@
       "base_denom": "reth-wei",
       "path": "transfer/channel-208/reth-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xae78736cd615f374d3085123a210448e74fc6393"
@@ -1621,6 +1815,7 @@
       "base_denom": "sfrxeth-wei",
       "path": "transfer/channel-208/sfrxeth-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xac3e018457b222d93114458476f3e3416abbe38f"
@@ -1631,6 +1826,7 @@
       "base_denom": "wsteth-wei",
       "path": "transfer/channel-208/wsteth-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "wstETH.axl",
         "logo_URIs": {
@@ -1642,14 +1838,16 @@
       "chain_name": "gitopia",
       "base_denom": "ulore",
       "path": "transfer/channel-781/ulore",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "terra2",
       "base_denom": "cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
       "path": "transfer/channel-341/cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "TFM IBC Transfer",
           "type": "external_interface",
@@ -1662,25 +1860,29 @@
       "chain_name": "stride",
       "base_denom": "stuumee",
       "path": "transfer/channel-326/stuumee",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "nolus",
       "base_denom": "unls",
       "path": "transfer/channel-783/unls",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "terra2",
       "base_denom": "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
       "path": "transfer/channel-341/cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "TFM IBC Transfer",
           "type": "external_interface",
@@ -1694,7 +1896,8 @@
       "base_denom": "cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
       "path": "transfer/channel-341/cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "TFM IBC Transfer",
           "type": "external_interface",
@@ -1707,20 +1910,23 @@
       "chain_name": "neutron",
       "base_denom": "untrn",
       "path": "transfer/channel-874/untrn",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss",
       "path": "transfer/channel-169/cw20:juno1ju8k8sqwsqu5k6umrypmtyqu2wqcpnrkf4w4mntvl0javt4nma7s8lzgss",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "composable",
       "base_denom": "ppica",
       "path": "transfer/channel-1279/ppica",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Composable Trustless Zone",
           "type": "external_interface",
@@ -1734,11 +1940,12 @@
       "base_denom": "ibc/EE9046745AEC0E8302CB7ED9D5AD67F528FB3B7AE044B247FB0FB293DBDA35E9",
       "path": "transfer/channel-1279/transfer/channel-2/4",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "kusama",
         "base_denom": "Planck"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Composable Trustless Zone",
           "type": "external_interface",
@@ -1752,11 +1959,12 @@
       "base_denom": "ibc/3CC19CEC7E5A3E90E78A5A9ECC5A0E2F8F826A375CF1E096F4515CF09DA3E366",
       "path": "transfer/channel-1279/transfer/channel-2/transfer/channel-15/79228162514264337593543950342",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "polkadot",
         "base_denom": "Planck"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Composable Trustless Zone",
           "type": "external_interface",
@@ -1769,20 +1977,23 @@
       "chain_name": "quasar",
       "base_denom": "uqsr",
       "path": "transfer/channel-688/uqsr",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "archway",
       "base_denom": "aarch",
       "path": "transfer/channel-1429/aarch",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "empowerchain",
       "base_denom": "umpwr",
       "path": "transfer/channel-1411/umpwr",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "TFM IBC Transfer",
           "type": "external_interface",
@@ -1794,13 +2005,15 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw",
       "path": "transfer/channel-169/cw20:juno1m4h8q4p305wgy7vkux0w6e5ylhqll3s6pmadhxkhqtuwd5wlxhxs8xklsw",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kyve",
       "base_denom": "ukyve",
       "path": "transfer/channel-767/ukyve",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kava",
@@ -1808,6 +2021,7 @@
       "path": "transfer/channel-143/erc20/tether/usdt",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xdac17f958d2ee523a2206206994597c13d831ec7"
@@ -1816,14 +2030,16 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "sei",
       "base_denom": "usei",
       "path": "transfer/channel-782/usei",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "TFM IBC Transfer",
           "type": "external_interface",
@@ -1841,24 +2057,27 @@
       "chain_name": "passage",
       "base_denom": "upasg",
       "path": "transfer/channel-2494/upasg",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stride",
       "base_denom": "stusomm",
       "path": "transfer/channel-326/stusomm",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "gateway",
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8sYgCzLRJC3J7qPn2bNbx6PiGcarhyx8rBhVaNnfvHCA",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "solana",
         "base_denom": "Lamport"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -1872,11 +2091,12 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "solana",
         "base_denom": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -1890,13 +2110,14 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "USDT.wh",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.hole.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -1910,11 +2131,12 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "sui",
         "base_denom": "0x2::sui::SUI"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -1928,6 +2150,7 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5wS2fGojbL9RhGEAeQBdkHPUAciYDxjDTMYvdf9aDn2r",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/apt-dm.svg"
@@ -1937,7 +2160,7 @@
         "chain_name": "aptos",
         "base_denom": "0x1::aptos_coin::AptosCoin"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -1951,7 +2174,8 @@
       "base_denom": "factory/kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7/umnta",
       "path": "transfer/channel-259/factory:kujira1643jxg8wasy5cfcn7xm8rd742yeazcksqlg4d7:umnta",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Kujira Blue",
           "type": "external_interface",
@@ -1963,20 +2187,22 @@
       "chain_name": "juno",
       "base_denom": "factory/juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e/DGL",
       "path": "transfer/channel-42/factory/juno1u805lv20qc6jy7c3ttre7nct6uyl20pfky5r7e/DGL",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "gateway",
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "USDC.wh",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -1990,13 +2216,14 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "wETH.wh",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.hole.svg"
         }
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -2010,6 +2237,7 @@
       "base_denom": "uusdc",
       "path": "transfer/channel-750/uusdc",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "symbol": "USDC",
         "logo_URIs": {
@@ -2026,6 +2254,7 @@
       "base_denom": "yieldeth-wei",
       "path": "transfer/channel-208/yieldeth-wei",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec"
@@ -2036,7 +2265,8 @@
       "base_denom": "axpla",
       "path": "transfer/channel-1634/axpla",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "XPLA",
           "type": "external_interface",
@@ -2048,14 +2278,16 @@
       "chain_name": "sei",
       "base_denom": "factory/sei1thgp6wamxwqt7rthfkeehktmq0ujh5kspluw6w/OIN",
       "path": "transfer/channel-782/factory/sei1thgp6wamxwqt7rthfkeehktmq0ujh5kspluw6w/OIN",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "evmos",
       "base_denom": "erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9",
       "path": "transfer/channel-204/erc20/0x655ecB57432CC1370f65e5dc2309588b71b473A9",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Evmos App",
           "type": "external_interface",
@@ -2068,7 +2300,8 @@
       "base_denom": "ario",
       "path": "transfer/channel-1424/ario",
       "osmosis_verified": false,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Realio Network",
           "type": "external_interface",
@@ -2079,60 +2312,70 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "sge",
       "base_denom": "usge",
       "path": "transfer/channel-5485/usge",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stafihub",
       "base_denom": "ufis",
       "path": "transfer/channel-5413/ufis",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stafihub",
       "base_denom": "uratom",
       "path": "transfer/channel-5413/uratom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stargaze",
       "base_denom": "factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/dust",
       "path": "transfer/channel-75/factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/dust",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "doravota",
       "base_denom": "peaka",
       "path": "transfer/channel-2694/peaka",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "coreum",
       "base_denom": "ucore",
       "path": "transfer/channel-2188/ucore",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "celestia",
       "base_denom": "utia",
       "path": "transfer/channel-6994/utia",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "dydx",
       "base_denom": "adydx",
       "path": "transfer/channel-6787/adydx",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx-circle.svg"
@@ -2144,7 +2387,8 @@
       "base_denom": "FX",
       "path": "transfer/channel-2716/FX",
       "osmosis_verified": true,
-      "additional_transfer": [
+      "osmosis_validated": true,
+      "transfer_methods": [
         {
           "name": "Starscan",
           "type": "external_interface",
@@ -2156,36 +2400,42 @@
       "chain_name": "nomic",
       "base_denom": "usat",
       "path": "transfer/channel-6897/usat",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "nois",
       "base_denom": "unois",
       "path": "transfer/channel-8277/unois",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "kujira",
       "base_denom": "factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk",
       "path": "transfer/channel-259/factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "stargaze",
       "base_denom": "factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/uBRNCH",
       "path": "transfer/channel-75/factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/uBRNCH",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "neutron",
       "base_denom": "factory/neutron1ug740qrkquxzrk2hh29qrlx3sktkfml3je7juusc2te7xmvsscns0n2wry/wstETH",
       "path": "transfer/channel-874/factory/neutron1ug740qrkquxzrk2hh29qrlx3sktkfml3je7juusc2te7xmvsscns0n2wry/wstETH",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
@@ -2194,7 +2444,8 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqatom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
@@ -2206,48 +2457,55 @@
       "chain_name": "qwoyn",
       "base_denom": "uqwoyn",
       "path": "transfer/channel-880/uqwoyn",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bostrom",
       "base_denom": "hydrogen",
       "path": "transfer/channel-95/hydrogen",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bostrom",
       "base_denom": "tocyb",
       "path": "transfer/channel-95/tocyb",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bostrom",
       "base_denom": "millivolt",
       "path": "transfer/channel-95/millivolt",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "bostrom",
       "base_denom": "milliampere",
       "path": "transfer/channel-95/milliampere",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "source",
       "base_denom": "usource",
       "path": "transfer/channel-8945/usource",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "gateway",
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/B8ohBnfisop27exk2gtNABJyYjLwQA7ogrp5uNzvZCoy",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/B8ohBnfisop27exk2gtNABJyYjLwQA7ogrp5uNzvZCoy",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "canonical": {
         "chain_name": "solana",
         "base_denom": "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Wormhole Portal Bridge",
           "type": "external_interface",
@@ -2260,29 +2518,34 @@
       "chain_name": "persistence",
       "base_denom": "stk/uosmo",
       "path": "transfer/channel-4/stk/uosmo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "osmosis_validated": true
     },
     {
       "chain_name": "chihuahua",
       "base_denom": "cw20:chihuahua1yl8z39ugle8s02fpwkhh293509q5xcpalmdzc4amvchz8nkexrmsy95gef",
       "path": "transfer/channel-11348/cw20:chihuahua1yl8z39ugle8s02fpwkhh293509q5xcpalmdzc4amvchz8nkexrmsy95gef",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "neutron",
       "base_denom": "factory/neutron1p8d89wvxyjcnawmgw72klknr3lg9gwwl6ypxda/newt",
       "path": "transfer/channel-874/factory/neutron1p8d89wvxyjcnawmgw72klknr3lg9gwwl6ypxda/newt",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
       "osmosis_verified": true,
+      "osmosis_validated": true,
       "override_properties": {
         "traces": []
       }
@@ -2291,7 +2554,8 @@
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1erul6xyq0gk6ws98ncj7lnq9l4jn4gnnu9we73gdz78yyl2lr7qqrvcgup/ash",
       "path": "transfer/channel-642/factory/migaloo1erul6xyq0gk6ws98ncj7lnq9l4jn4gnnu9we73gdz78yyl2lr7qqrvcgup/ash",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "migaloo",
@@ -2300,13 +2564,15 @@
       "override_properties": {
         "symbol": "migaloo.RAC"
       },
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1etlu2h30tjvv8rfa4fwdc43c92f6ul5w9acxzk/uguppy",
       "path": "transfer/channel-642/factory/migaloo1etlu2h30tjvv8rfa4fwdc43c92f6ul5w9acxzk/uguppy",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "haqq",
@@ -2319,7 +2585,8 @@
       "chain_name": "injective",
       "base_denom": "factory/inj14lf8xm6fcvlggpa7guxzjqwjmtr24gnvf56hvz/autism",
       "path": "transfer/channel-122/factory/inj14lf8xm6fcvlggpa7guxzjqwjmtr24gnvf56hvz/autism",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "osmosis_validated": true
     },
     {
       "chain_name": "gravitybridge",
@@ -2333,7 +2600,7 @@
         "chain_name": "ethereum",
         "base_denom": "0x60e683C6514Edd5F758A55b6f393BeBBAfaA8d5e"
       },
-      "additional_transfer": [
+      "transfer_methods": [
         {
           "name": "Gravity Bridge",
           "type": "external_interface",

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -56,6 +56,10 @@
           "type": "boolean",
           "description": "Whether the asset should be temporarily unlisted on the Osmosis Zone app."
         },
+        "osmosis_validated": {
+          "type": "boolean",
+          "description": "Whether the asset has been confrimed by a human to display and function correctly on Osmosis Zone."
+        },
         "canonical": {
           "type": "object",
           "required": [
@@ -74,7 +78,7 @@
             }
           }
         },
-        "additional_transfer": {
+        "transfer_methods": {
           "type": "array",
           "items": {
             "type": "object",
@@ -93,6 +97,10 @@
                   "integrated_bridge",
                   "fiat_onramp"
                 ]
+              },
+              "osmosis_validated": {
+                "type": "boolean",
+                "description": "Whether the transfer method has been tested by a human and confirm to be working correctly."
               }
             },
             "oneOf": [


### PR DESCRIPTION
## Description

Adds a zone_asset_config.json file into each environment's /generated/ folder.
zone_asset_config now has decimals and images (but NOT logo_URIs)
Renamed additional_transfer to transfer_methods. This allows for manually specifying the integrated ibc transfer method, but is also sort of a given when no other options are presented for foreign assets.
Added 'osmosis_validated' to zone_assets.json. This allows new asset listings to omit this property, and omit the osmosis_unlisted property, and the script will assume that it should start unlisted. Only assets that explicitly have this property and set it to true will lose the 'unlisted' marker in the generated file. This makes the process of adding new assets less awkward since the default allows for it's omission.

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->
