### PR TITLE
Update Bridge and Provider Data

### DIFF
--- a/.github/workflows/utility/generate_zone_config.mjs
+++ b/.github/workflows/utility/generate_zone_config.mjs
@@ -358,6 +358,29 @@ const generateAssets = async (chainName, assets, zone_assets, zoneConfig) => {
 
 
 
+    //--Sorting--
+    //how to sort tokens if they don't have cgid
+    if(!generatedAsset.coingecko_id && !zone_asset.canonical){
+      traces?.forEach((trace) => {
+        if(trace.provider) {
+          let providers = zoneConfig?.provider_primary_token;
+          if(providers) {
+            providers.forEach((provider) => {
+              if(provider.provider == trace.provider) {
+                generatedAsset.sort_with = {
+                  chain_name: provider.token.chain_name,
+                  base_denom: provider.token.base_denom
+                }
+                return;
+              }
+            });
+          }
+        }
+      });
+    }
+
+
+
     //--Overrides Properties when Specified--
     if(zone_asset.override_properties) {
       if(zone_asset.override_properties.coingecko_id) {

--- a/.github/workflows/utility/generate_zone_config.mjs
+++ b/.github/workflows/utility/generate_zone_config.mjs
@@ -172,6 +172,9 @@ const generateAssets = async (chainName, assets, zone_assets) => {
     generatedAsset.transfer_methods = zone_asset.transfer_methods;
     
 
+    let bridge_provider = "";
+
+
     if(zone_asset.chain_name != chainName) {
 
       //--Set Up Trace for IBC Transfer--
@@ -267,24 +270,50 @@ const generateAssets = async (chainName, assets, zone_assets) => {
 
       generatedAsset.transfer_methods.push(trace);
 
+
+
+      //--Get Bridge Provider--
+      if(!zone_asset.canonical) {
+        traces?.forEach((trace) => {
+          if(trace.type == "bridge") {
+            bridge_provider = trace.provider;
+            return;
+          }
+        });
+      }
+
+
+
     }
 
 
-    generatedAsset.unstable = zone_asset.osmosis_unstable;
-    
-    generatedAsset.unlisted = zone_asset.osmosis_unlisted;
     
 
-    //--Add Name--
+
+    //--Staking token?--
     let is_staking_token = false;
     if(zone_asset.base_denom == chain_reg.getFileProperty(reference_asset.chain_name, "chain", "staking")?.staking_tokens[0]?.denom) {
       is_staking_token = true;
     }
 
+
+    //--Add Name--
+
     let name = chain_reg.getAssetProperty(reference_asset.chain_name, reference_asset.base_denom, "name");
+
+    //use chain name if staking token
     if(is_staking_token) {
       name = chain_reg.getFileProperty(reference_asset.chain_name, "chain", "pretty_name");
     }
+
+    //append bridge provider if not already there
+    if(bridge_provider) {
+      if(!name.includes(bridge_provider)) {
+        name = name + " " + "(" + bridge_provider + ")"
+      }
+    }
+
+    //submit name
     generatedAsset.name = name;
 
 
@@ -323,6 +352,10 @@ const generateAssets = async (chainName, assets, zone_assets) => {
       }
     }
 
+
+    generatedAsset.unstable = zone_asset.osmosis_unstable;
+    
+    generatedAsset.unlisted = zone_asset.osmosis_unlisted;
 
     
     //--Append Asset to Assetlist--

--- a/osmo-test-5/generated/zone_asset_config.json
+++ b/osmo-test-5/generated/zone_asset_config.json
@@ -133,7 +133,7 @@
           "validated": true
         }
       ],
-      "name": "USD Coin",
+      "name": "USD Coin (Axelar)",
       "description": "Circle's stablecoin on Axelar"
     },
     {
@@ -173,7 +173,7 @@
           "validated": true
         }
       ],
-      "name": "Wrapped Ether",
+      "name": "Wrapped Ether (Axelar)",
       "description": "Wrapped Ether on Axelar"
     },
     {

--- a/osmo-test-5/generated/zone_asset_config.json
+++ b/osmo-test-5/generated/zone_asset_config.json
@@ -100,7 +100,7 @@
       "chain_name": "axelartestnet",
       "base_denom": "uausdc",
       "minimal_denom": "ibc/2164BDB48DE5501430E71286448D87C6D2240EC0E078CF113CAB85E21A352BB0",
-      "symbol": "aUSDC",
+      "symbol": "aUSDC.axl",
       "decimals": 6,
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"

--- a/osmo-test-5/osmosis.zone_config.json
+++ b/osmo-test-5/osmosis.zone_config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../zone.schema.json",
+  "chain_name": "osmosis",
+  "config": {
+    "interoperability": {
+      "suffixes": [
+        {
+          "provider": "Axelar",
+          "suffix": ".axl"
+        },
+        {
+          "provider": "Gravity Bridge",
+          "suffix": ".grv"
+        },
+        {
+          "provider": "Wormhole",
+          "suffix": ".wh"
+        },
+        {
+          "provider": "Composable",
+          "suffix": ".comp"
+        }
+      ]
+    }
+  }
+}

--- a/osmosis-1/generated/zone_asset_config.json
+++ b/osmosis-1/generated/zone_asset_config.json
@@ -22,7 +22,7 @@
       "validated": true,
       "api_include": true,
       "price": {
-        "pool": "1263",
+        "pool": "1221",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "name": "Osmosis",
@@ -4948,7 +4948,7 @@
       "validated": true,
       "api_include": true,
       "price": {
-        "pool": "1283",
+        "pool": "1136",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [

--- a/osmosis-1/generated/zone_asset_config.json
+++ b/osmosis-1/generated/zone_asset_config.json
@@ -22,7 +22,7 @@
       "validated": true,
       "api_include": true,
       "price": {
-        "pool": "1221",
+        "pool": "1263",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "name": "Osmosis",
@@ -97,7 +97,7 @@
           "validated": true
         }
       ],
-      "name": "USD Coin",
+      "name": "USD Coin (Axelar)",
       "description": "Circle's stablecoin on Axelar"
     },
     {
@@ -233,7 +233,7 @@
           "validated": true
         }
       ],
-      "name": "Tether USD",
+      "name": "Tether USD (Axelar)",
       "description": "Tether's USD stablecoin on Axelar"
     },
     {
@@ -349,7 +349,7 @@
       "validated": true,
       "api_include": true,
       "price": {
-        "pool": "1265",
+        "pool": "1135",
         "denom": "uosmo"
       },
       "transfer_methods": [
@@ -687,7 +687,7 @@
           "validated": true
         }
       ],
-      "name": "Wrapped Polkadot",
+      "name": "Wrapped Polkadot (Axelar)",
       "description": "Wrapped Polkadot on Axelar"
     },
     {
@@ -1957,9 +1957,9 @@
           "validated": true
         }
       ],
-      "unstable": true,
       "name": "Dig Chain",
-      "description": "Native token of Dig Chain"
+      "description": "Native token of Dig Chain",
+      "unstable": true
     },
     {
       "chain_name": "sommelier",
@@ -2368,9 +2368,9 @@
           "validated": true
         }
       ],
-      "unstable": true,
       "name": "Cerberus",
-      "description": "The native token of Cerberus Chain"
+      "description": "The native token of Cerberus Chain",
+      "unstable": true
     },
     {
       "chain_name": "fetchhub",
@@ -2646,9 +2646,9 @@
           "validated": true
         }
       ],
-      "unstable": true,
       "name": "Microtick",
-      "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App"
+      "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",
+      "unstable": true
     },
     {
       "chain_name": "sifchain",
@@ -2692,9 +2692,9 @@
           "validated": true
         }
       ],
-      "unstable": true,
       "name": "Sifchain",
-      "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value."
+      "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
+      "unstable": true
     },
     {
       "chain_name": "shentu",
@@ -4571,9 +4571,9 @@
           "validated": true
         }
       ],
-      "unstable": true,
       "name": "LumenX",
-      "description": "The native token of LumenX Network"
+      "description": "The native token of LumenX Network",
+      "unstable": true
     },
     {
       "chain_name": "oraichain",
@@ -4948,7 +4948,7 @@
       "validated": true,
       "api_include": true,
       "price": {
-        "pool": "1136",
+        "pool": "1283",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -7245,9 +7245,9 @@
           "validated": true
         }
       ],
-      "unstable": true,
       "name": "Arkhadian",
-      "description": "The native token of Arkhadian"
+      "description": "The native token of Arkhadian",
+      "unstable": true
     },
     {
       "chain_name": "quicksilver",
@@ -8683,7 +8683,7 @@
           "validated": true
         }
       ],
-      "name": "Wrapped Lido Staked Ether",
+      "name": "Wrapped Lido Staked Ether (Axelar)",
       "description": ""
     },
     {
@@ -11145,9 +11145,9 @@
         }
       ],
       "verified": true,
-      "unlisted": true,
       "name": "BTC Squared",
-      "description": "Margined Power Token sqBTC"
+      "description": "Margined Power Token sqBTC",
+      "unlisted": true
     },
     {
       "chain_name": "qwoyn",
@@ -11889,9 +11889,9 @@
           }
         }
       ],
-      "unlisted": true,
       "name": "Page",
-      "description": "The PAGE token is used for actions in the PageDAO NFT literary ecosystem and for DAO governance."
+      "description": "The PAGE token is used for actions in the PageDAO NFT literary ecosystem and for DAO governance.",
+      "unlisted": true
     },
     {
       "chain_name": "pundix",
@@ -11932,9 +11932,9 @@
           "validated": true
         }
       ],
-      "unlisted": true,
-      "name": "PURSE Token",
-      "description": "PURSE Token"
+      "name": "PURSE Token (Function X)",
+      "description": "PURSE Token",
+      "unlisted": true
     },
     {
       "chain_name": "injective",
@@ -12012,9 +12012,9 @@
           "validated": true
         }
       ],
-      "unlisted": true,
       "name": "Kleomedes",
-      "description": "Kleomedes Token"
+      "description": "Kleomedes Token",
+      "unlisted": true
     }
   ]
 }

--- a/osmosis-1/generated/zone_asset_config.json
+++ b/osmosis-1/generated/zone_asset_config.json
@@ -234,7 +234,11 @@
         }
       ],
       "name": "Tether USD (Axelar)",
-      "description": "Tether's USD stablecoin on Axelar"
+      "description": "Tether's USD stablecoin on Axelar",
+      "sort_with": {
+        "chain_name": "axelar",
+        "base_denom": "uaxl"
+      }
     },
     {
       "chain_name": "axelar",
@@ -688,7 +692,11 @@
         }
       ],
       "name": "Wrapped Polkadot (Axelar)",
-      "description": "Wrapped Polkadot on Axelar"
+      "description": "Wrapped Polkadot on Axelar",
+      "sort_with": {
+        "chain_name": "axelar",
+        "base_denom": "uaxl"
+      }
     },
     {
       "chain_name": "evmos",
@@ -2922,7 +2930,11 @@
         }
       ],
       "name": "Wrapped Bitcoin (Gravity Bridge)",
-      "description": "Gravity Bridge WBTC"
+      "description": "Gravity Bridge WBTC",
+      "sort_with": {
+        "chain_name": "gravitybridge",
+        "base_denom": "ugrav"
+      }
     },
     {
       "chain_name": "gravitybridge",
@@ -2969,7 +2981,11 @@
         }
       ],
       "name": "Ether (Gravity Bridge)",
-      "description": "Gravity Bridge WETH"
+      "description": "Gravity Bridge WETH",
+      "sort_with": {
+        "chain_name": "gravitybridge",
+        "base_denom": "ugrav"
+      }
     },
     {
       "chain_name": "gravitybridge",
@@ -3020,7 +3036,11 @@
         }
       ],
       "name": "USD Coin (Gravity Bridge)",
-      "description": "Gravity Bridge USDC"
+      "description": "Gravity Bridge USDC",
+      "sort_with": {
+        "chain_name": "gravitybridge",
+        "base_denom": "ugrav"
+      }
     },
     {
       "chain_name": "gravitybridge",
@@ -3070,7 +3090,11 @@
         }
       ],
       "name": "DAI Stablecoin (Gravity Bridge)",
-      "description": "Gravity Bridge DAI"
+      "description": "Gravity Bridge DAI",
+      "sort_with": {
+        "chain_name": "gravitybridge",
+        "base_denom": "ugrav"
+      }
     },
     {
       "chain_name": "gravitybridge",
@@ -3121,7 +3145,11 @@
         }
       ],
       "name": "Tether USD (Gravity Bridge)",
-      "description": "Gravity Bridge USDT"
+      "description": "Gravity Bridge USDT",
+      "sort_with": {
+        "chain_name": "gravitybridge",
+        "base_denom": "ugrav"
+      }
     },
     {
       "chain_name": "juno",
@@ -4948,7 +4976,7 @@
       "validated": true,
       "api_include": true,
       "price": {
-        "pool": "1136",
+        "pool": "1283",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -5020,7 +5048,11 @@
         }
       ],
       "name": "Stride Staked STARS",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "juno",
@@ -5293,7 +5325,11 @@
         }
       ],
       "name": "Stride Staked JUNO",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "stride",
@@ -5340,7 +5376,11 @@
         }
       ],
       "name": "Stride Staked OSMO",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "juno",
@@ -6567,7 +6607,11 @@
         }
       ],
       "name": "Quicksilver Liquid Staked STARS",
-      "description": "Quicksilver Liquid Staked STARS"
+      "description": "Quicksilver Liquid Staked STARS",
+      "sort_with": {
+        "chain_name": "quicksilver",
+        "base_denom": "uqck"
+      }
     },
     {
       "chain_name": "juno",
@@ -6845,7 +6889,11 @@
         }
       ],
       "name": "Stride Staked LUNA",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "stride",
@@ -6892,7 +6940,11 @@
         }
       ],
       "name": "Stride Staked EVMOS",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "juno",
@@ -7028,7 +7080,11 @@
         }
       ],
       "name": "Quicksilver Liquid Staked ATOM",
-      "description": "Quicksilver Liquid Staked ATOM"
+      "description": "Quicksilver Liquid Staked ATOM",
+      "sort_with": {
+        "chain_name": "quicksilver",
+        "base_denom": "uqck"
+      }
     },
     {
       "chain_name": "comdex",
@@ -7119,7 +7175,11 @@
         }
       ],
       "name": "Quicksilver Liquid Staked Regen",
-      "description": "Quicksilver Liquid Staked REGEN"
+      "description": "Quicksilver Liquid Staked REGEN",
+      "sort_with": {
+        "chain_name": "quicksilver",
+        "base_denom": "uqck"
+      }
     },
     {
       "chain_name": "juno",
@@ -7294,7 +7354,11 @@
         }
       ],
       "name": "Quicksilver Liquid Staked OSMO",
-      "description": "Quicksilver Liquid Staked OSMO"
+      "description": "Quicksilver Liquid Staked OSMO",
+      "sort_with": {
+        "chain_name": "quicksilver",
+        "base_denom": "uqck"
+      }
     },
     {
       "chain_name": "noble",
@@ -8684,7 +8748,11 @@
         }
       ],
       "name": "Wrapped Lido Staked Ether (Axelar)",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "axelar",
+        "base_denom": "uaxl"
+      }
     },
     {
       "chain_name": "gitopia",
@@ -8825,7 +8893,11 @@
         }
       ],
       "name": "Stride Staked UMEE",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "osmosis",
@@ -9608,7 +9680,11 @@
         }
       ],
       "name": "Quicksilver Liquid Staked SOMM",
-      "description": "Quicksilver Liquid Staked SOMM"
+      "description": "Quicksilver Liquid Staked SOMM",
+      "sort_with": {
+        "chain_name": "quicksilver",
+        "base_denom": "uqck"
+      }
     },
     {
       "chain_name": "passage",
@@ -9698,7 +9774,11 @@
         }
       ],
       "name": "Stride Staked SOMM",
-      "description": ""
+      "description": "",
+      "sort_with": {
+        "chain_name": "stride",
+        "base_denom": "ustrd"
+      }
     },
     {
       "chain_name": "gateway",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -22,7 +22,6 @@
       "osmosis_verified": true,
       "osmosis_validated": true,
       "override_properties": {
-        "symbol": "USDC.axl",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.axl.svg",
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.axl.png"

--- a/osmosis-1/osmosis.zone_config.json
+++ b/osmosis-1/osmosis.zone_config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../zone.schema.json",
+  "chain_name": "osmosis",
+  "config": {
+    "interoperability": {
+      "suffixes": [
+        {
+          "provider": "Axelar",
+          "suffix": ".axl"
+        },
+        {
+          "provider": "Gravity Bridge",
+          "suffix": ".grv"
+        },
+        {
+          "provider": "Wormhole",
+          "suffix": ".wh"
+        },
+        {
+          "provider": "Composable",
+          "suffix": ".comp"
+        }
+      ]
+    }
+  }
+}

--- a/osmosis-1/osmosis.zone_config.json
+++ b/osmosis-1/osmosis.zone_config.json
@@ -21,6 +21,50 @@
           "suffix": ".comp"
         }
       ]
-    }
+    },
+    "provider_primary_token": [
+      {
+        "provider": "Axelar",
+        "token": {
+          "chain_name": "axelar",
+          "base_denom": "uaxl"
+        }
+      },
+      {
+        "provider": "Gravity Bridge",
+        "token": {
+          "chain_name": "gravitybridge",
+          "base_denom": "ugrav"
+        }
+      },
+      {
+        "provider": "Composable",
+        "token": {
+          "chain_name": "composable",
+          "base_denom": "ppica"
+        }
+      },
+      {
+        "provider": "Stride",
+        "token": {
+          "chain_name": "stride",
+          "base_denom": "ustrd"
+        }
+      },
+      {
+        "provider": "Quicksilver",
+        "token": {
+          "chain_name": "quicksilver",
+          "base_denom": "uqck"
+        }
+      },
+      {
+        "provider": "Persistence",
+        "token": {
+          "chain_name": "persistence",
+          "base_denom": "uxprt"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description

Added a zone config file for constant data pertaining to bridges and providers so that we can properly sort assets based on provider wherever a cgid is missing, add suffix asset symbols based on the bridge/interoperability provider, and update the name property with '(Bridge Provider)' suffix.

Note that there are now many custom overrides that no longer need to be there, mostly about changing symbols and name to account for a bridged asset no holding canonical status.

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->
