### PR TITLE
updating achihuahuawifhat on Chihuahua Chain for POOL 1356 osmosis.zone_assets.json

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2400,8 +2400,7 @@
       "chain_name": "chihuahua",
       "base_denom": "factory/chihuahua1x4q2vkrz4dfgd9hcw0p5m2f2nuv2uqmt9xr8k2/achihuahuawifhat",
       "path": "transfer/channel-113/factory/chihuahua1x4q2vkrz4dfgd9hcw0p5m2f2nuv2uqmt9xr8k2/achihuahuawifhat",
-      "osmosis_verified": false,
-      "osmosis_unlisted": true
+      "osmosis_verified": false
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
Removed "osmosis_unlisted": true, trying to fix osmosis front end not showing baddog on swaps page or pool swap page.

## Description

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->



### On-chain liquidity

For each new asset, please provide the plan for on-chain liquidity of the asset: (choose one)
- [ ] Ready -- A liquidity pool has been created. The pool ID is: 1356
- [ ] Soon -- A pool will be created. (See: [Pool Setup Guilde](https://docs.osmosis.zone/overview/integrate/pool-setup).)
  - [ ] (optional) A preview of the Osmosis Zone app with the new asset added is requested for creating the pool. (Supercharged Liquidity pools cannot be created via Osmosis Zone app)
- [ ] StreamSwap -- The token is, or will be, going through a StreamSwap stream; thus, the token should be listed without requiring on-chain liquidity. A Pool ID will be provided in this PR following the stream's completion once the team has had a chance to create a pool using the earned funds.
