### PR TITLE
nyx: update endpoints & add cosmwasm feature

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1108,12 +1108,13 @@
     },
     {
       "chain_name": "nyx",
-      "rpc": "https://nym-rpc.polkachu.com",
-      "rest": "https://nym-api.polkachu.com",
+      "rpc": "https://rpc.nymtech.net",
+      "rest": "https://api.nymtech.net",
       "explorer_tx_url": "https://www.mintscan.io/nyx/transactions/${txHash}",
       "keplr_features": [
         "ibc-transfer",
-        "ibc-go"
+        "ibc-go",
+        "cosmwasm"
       ]
     }
   ]


### PR DESCRIPTION
As mentioned by @JeremyParish69, the existing RPC endpoint didn't support websocket connections. 