### PR TITLE
Fix getPools Script

### DIFF
--- a/.github/workflows/utility/getPools.mjs
+++ b/.github/workflows/utility/getPools.mjs
@@ -224,6 +224,7 @@ function getRoute(asset, route, hops, ignore_assets){
   if (!asset.largest_pools) {
     let sizes = [];
     asset_pools.forEach((pool) => {
+      if(isNaN(pool.pool_assets.get(asset.base).size)){ return }
       sizes.push(pool.pool_assets.get(asset.base).size);
     });
     sizes.sort(function(a, b){return b - a});

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -1134,7 +1134,7 @@
       "keywords": [
         "osmosis-main",
         "osmosis-info",
-        "osmosis-price:uosmo:1111"
+        "osmosis-price:uosmo:605"
       ]
     },
     {
@@ -4951,7 +4951,7 @@
       },
       "coingecko_id": "usdx",
       "keywords": [
-        "osmosis-price:ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858:792"
+        "osmosis-price:uosmo:1390"
       ]
     },
     {
@@ -10735,7 +10735,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
       },
       "keywords": [
-        "osmosis-main"
+        "osmosis-main",
+        "osmosis-info",
+        "osmosis-price:uosmo:1216"
       ]
     },
     {
@@ -11608,7 +11610,7 @@
       "keywords": [
         "osmosis-main",
         "osmosis-info",
-        "osmosis-price:ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4:1253"
+        "osmosis-price:ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F:1284"
       ]
     },
     {
@@ -12928,7 +12930,11 @@
       ],
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/baddog.png"
-      }
+      },
+      "keywords": [
+        "osmosis-info",
+        "osmosis-price:ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228:1356"
+      ]
     },
     {
       "description": "clownmaxxed store of value",


### PR DESCRIPTION
## Description

Update getPools Script to filter out empty concentrated liquidity pools from it's routing candidates

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->
