### PR TITLE
Update Genesis L1 RPC endpoint

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -492,7 +492,7 @@
     },
     {
       "chain_name": "genesisl1",
-      "rpc": "https://26657.genesisl1.org",
+      "rpc": "https://rpc.genesisl1.org",
       "rest": "https://api.genesisl1.org",
       "explorer_tx_url": "https://ping.pub/genesisL1/tx/${txHash}",
       "keplr_features": [


### PR DESCRIPTION
## Description

Update Genesis L1 RPC endpoint

to "rpc": "https://rpc.genesisl1.org",
referenced in their TG group.

Current endpoint has CORS blocking