### PR TITLE
Update Testnet IBC channels for Mars and Juno

### DIFF
--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -36,13 +36,13 @@
     {
       "chain_name": "junotestnet",
       "base_denom": "ujunox",
-      "path": "transfer/channel-4167/ujunox",
+      "path": "transfer/channel-5498/ujunox",
       "osmosis_verified": true
     },
     {
       "chain_name": "marstestnet",
       "base_denom": "umars",
-      "path": "transfer/channel-4168/umars",
+      "path": "transfer/channel-5499/umars",
       "osmosis_verified": true
     },
     {


### PR DESCRIPTION
## Description

Update Testnet IBC channels for Mars and Juno
because they were updated at the chain registry.
