### PR TITLE
Fix Display Unit for 0 exp Assets

### DIFF
--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -460,6 +460,9 @@ const generateAssets = async (chainName, zoneConfig, zone_assets, zone_config_as
             unit.aliases = [];
           }
           addArrayItem(unit.denom, unit.aliases);
+          if (asset.display == unit.denom) {
+            asset.display = generated_asset.coinMinimalDenom;
+          }
           unit.denom = generated_asset.coinMinimalDenom;
           return;
         }

--- a/osmosis-1/generated/chain_registry/assetlist.json
+++ b/osmosis-1/generated/chain_registry/assetlist.json
@@ -1897,7 +1897,7 @@
       "type_asset": "ics20",
       "base": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "name": "bostrom",
-      "display": "boot",
+      "display": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "symbol": "BOOT",
       "traces": [
         {
@@ -6706,7 +6706,7 @@
       "type_asset": "ics20",
       "base": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "name": "Dyson Protocol",
-      "display": "dys",
+      "display": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "symbol": "DYS",
       "traces": [
         {
@@ -12264,7 +12264,7 @@
       "type_asset": "ics20",
       "base": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "name": "Bostrom Hydrogen",
-      "display": "hydrogen",
+      "display": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "symbol": "HYDROGEN",
       "traces": [
         {
@@ -12305,7 +12305,7 @@
       "type_asset": "ics20",
       "base": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "name": "Bostrom Tocyb",
-      "display": "tocyb",
+      "display": "ibc/BCDB35B7390806F35E716D275E1E017999F8281A81B6F128F087EF34D1DFA761",
       "symbol": "TOCYB",
       "traces": [
         {


### PR DESCRIPTION
## Description

Fix Display Unit for 0 exp Assets
before we were replacing the base denom_unit with the ibc/hash, but the display field wasn't changing, so the decimals became undefined. This fixes that.
