### PR TITLE
Add defi and meme Categories

### DIFF
--- a/.github/workflows/utility/getPools.mjs
+++ b/.github/workflows/utility/getPools.mjs
@@ -80,7 +80,7 @@ async function queryPools(domain) {
   console.log(domain);
   //console.log(baseUrl);
 
-  //queryApi.queryAPI(baseUrl, params, domain, fileName);
+  queryApi.queryAPI(baseUrl, params, domain, fileName);
 
   let storedResult = queryApi.readQueryResponse(domain, fileName);
   if (!storedResult?.pools) { return; }

--- a/.github/workflows/utility/getPools.mjs
+++ b/.github/workflows/utility/getPools.mjs
@@ -80,7 +80,7 @@ async function queryPools(domain) {
   console.log(domain);
   //console.log(baseUrl);
 
-  queryApi.queryAPI(baseUrl, params, domain, fileName);
+  //queryApi.queryAPI(baseUrl, params, domain, fileName);
 
   let storedResult = queryApi.readQueryResponse(domain, fileName);
   if (!storedResult?.pools) { return; }

--- a/osmo-test-5/generated/frontend/assetlist.json
+++ b/osmo-test-5/generated/frontend/assetlist.json
@@ -17,6 +17,9 @@
         "pool": "331",
         "denom": "ibc/3642669AD14386D3E38F43F30CFCA859B3E8A05BF6BD6A23DEBD2115AD1325E9"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "Osmosis Testnet",
       "description": "The native token of Osmosis",
       "relatedAssets": [
@@ -66,6 +69,9 @@
         "pool": "308",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -252,6 +258,9 @@
       },
       "coingeckoId": "juno-network",
       "verified": true,
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -299,6 +308,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
       },
       "verified": true,
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -347,6 +359,9 @@
       "coingeckoId": "usd-coin",
       "verified": true,
       "apiInclude": true,
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -393,6 +408,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
       },
       "verified": true,
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -444,6 +462,9 @@
         "pool": "4",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -495,6 +516,9 @@
         "pool": "34",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -545,6 +569,9 @@
         "pool": "40",
         "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -596,6 +623,9 @@
         "pool": "85",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -647,6 +677,9 @@
         "pool": "333",
         "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -697,6 +730,9 @@
         "pool": "369",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -748,6 +784,9 @@
         "pool": "254",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -15,9 +15,12 @@
       "verified": true,
       "apiInclude": true,
       "price": {
-        "pool": "1221",
+        "pool": "1263",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "Osmosis",
       "description": "The native token of Osmosis\n\nOsmosis (OSMO) is the premier DEX and cross-chain DeFi hub within the Cosmos ecosystem, a network of over 50 sovereign, interoperable blockchains seamlessly connected through the Inter-Blockchain Communication Protocol (IBC). Pioneering in its approach, Osmosis offers a dynamic trading and liquidity provision experience, integrating non-IBC assets from other ecosystems, including Ethereum, Solana, Avalanche, and Polkadot. Initially adopting Balancer-style pools, Osmosis now also features a concentrated liquidity model that is orders of magnitude more capital efficient, meaning that significantly less liquidity is required to handle the same amount of trading volume with minimal slippage.\n\nAs a true appchain, Osmosis has greater control over the full blockchain stack than traditional smart contract DEXs, which must follow the code of the parent chain that it is built on. This fine-grained control has enabled, for example, the development of Superfluid Staking, an extension of Proof of Stake that allows assets at the application layer to be staked to secure the chain. The customizability of appchains also allows implementing features like the Protocol Revenue module, which enables Osmosis to conduct on-chain arbitrage on behalf of OSMO stakers, balancing prices across pools while generating real yield revenue from this volume. Additionally, as a sovereign appchain, Osmosis governance can vote on upgrades to the protocol. One example of this was the introduction of a Taker Fee, which switched on the collection of exchange fees to generate diverse yield from Osmosis volume and distribute it to OSMO stakers.\n\nOsmosis is bringing the full centralized exchange experience to the decentralized world by building a cross-chain native DEX and trading suite that connects all chains over IBC, including Ethereum and Bitcoin. To reach this goal, Osmosis hosts an ever-expanding suite of DeFi applications aimed at providing a one-stop experience that includes lending, credit, margin, DeFi strategy vaults, power perps, fiat on-ramps, NFTs, stablecoins, and more — all of the functionalities that centralized exchange offer and more, in the trust-minimized environment of decentralized finance.",
       "twitterURL": "https://twitter.com/osmosiszone",
@@ -78,7 +81,7 @@
       "verified": true,
       "apiInclude": true,
       "price": {
-        "pool": "1100",
+        "pool": "2",
         "denom": "uosmo"
       },
       "name": "Ion DAO",
@@ -141,7 +144,8 @@
       "verified": true,
       "apiInclude": true,
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -278,6 +282,9 @@
         "pool": "1134",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Axelar Bridge",
@@ -523,7 +530,8 @@
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -636,7 +644,8 @@
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -851,6 +860,9 @@
         "pool": "1265",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -945,6 +957,9 @@
         "pool": "9",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -1353,6 +1368,9 @@
         "pool": "800",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Terra Bridge",
@@ -1421,6 +1439,9 @@
         "pool": "497",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -1625,6 +1646,9 @@
         "pool": "722",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Evmos App",
@@ -1726,6 +1750,9 @@
         "pool": "1105",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -1821,6 +1848,9 @@
         "pool": "1095",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -1909,7 +1939,8 @@
         "denom": "uosmo"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "algorithmic",
       "transferMethods": [
@@ -1974,6 +2005,9 @@
         "pool": "1096",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2069,6 +2103,9 @@
         "pool": "1111",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2135,6 +2172,9 @@
         "pool": "1101",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2231,7 +2271,8 @@
         "denom": "uosmo"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -2352,6 +2393,9 @@
         "pool": "1093",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2406,6 +2450,9 @@
         "pool": "42",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2501,6 +2548,9 @@
         "pool": "6",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2555,6 +2605,9 @@
         "pool": "8",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2608,6 +2661,9 @@
         "pool": "197",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2662,6 +2718,9 @@
         "pool": "463",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2778,6 +2837,9 @@
         "pool": "553",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2831,6 +2893,9 @@
         "pool": "558",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2884,6 +2949,9 @@
         "pool": "571",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2937,6 +3005,9 @@
         "pool": "1109",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -2991,6 +3062,9 @@
         "pool": "577",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3049,6 +3123,9 @@
         "pool": "586",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3102,6 +3179,9 @@
         "pool": "912",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3172,6 +3252,9 @@
         "pool": "601",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3234,6 +3317,9 @@
         "pool": "1273",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3287,6 +3373,9 @@
         "pool": "608",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3340,6 +3429,9 @@
         "pool": "613",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3393,6 +3485,9 @@
         "pool": "619",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3445,6 +3540,9 @@
         "pool": "621",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3498,6 +3596,9 @@
         "pool": "1372",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3593,6 +3694,9 @@
         "pool": "626",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3647,6 +3751,9 @@
         "pool": "637",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3700,6 +3807,9 @@
         "pool": "1110",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3794,6 +3904,9 @@
         "pool": "625",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3889,6 +4002,9 @@
         "pool": "644",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -3937,11 +4053,13 @@
       },
       "coingeckoId": "marble",
       "verified": false,
-      "apiInclude": true,
       "price": {
         "pool": "649",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4036,6 +4154,9 @@
         "pool": "651",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Carbon Demex",
@@ -4095,6 +4216,9 @@
         "pool": "662",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4149,6 +4273,9 @@
         "pool": "681",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4202,6 +4329,9 @@
         "pool": "686",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4256,6 +4386,9 @@
         "pool": "631",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4350,6 +4483,9 @@
         "pool": "1319",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Injective Hub",
@@ -4451,7 +4587,8 @@
         "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "algorithmic",
       "transferMethods": [
@@ -4516,6 +4653,9 @@
         "pool": "547",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4570,6 +4710,9 @@
         "pool": "629",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4624,6 +4767,9 @@
         "pool": "1020",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4676,6 +4822,9 @@
         "pool": "653",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4770,6 +4919,9 @@
         "pool": "669",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -4864,7 +5016,8 @@
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "hybrid",
       "transferMethods": [
@@ -5211,7 +5364,8 @@
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -5327,7 +5481,8 @@
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -5444,7 +5599,8 @@
         "denom": "uosmo"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -5560,6 +5716,9 @@
         "pool": "691",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -5654,6 +5813,9 @@
         "pool": "693",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -5705,6 +5867,9 @@
         "pool": "697",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -5756,6 +5921,9 @@
         "pool": "695",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -5848,6 +6016,9 @@
         "pool": "700",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -5942,6 +6113,9 @@
         "pool": "701",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -5992,6 +6166,9 @@
         "pool": "771",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -6083,6 +6260,9 @@
         "pool": "718",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -6176,6 +6356,9 @@
         "pool": "1163",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -6270,6 +6453,9 @@
         "pool": "729",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -6607,6 +6793,9 @@
         "pool": "732",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7168,6 +7357,9 @@
         "pool": "1161",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Kujira Blue",
@@ -7240,6 +7432,9 @@
         "pool": "769",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7291,6 +7486,9 @@
         "pool": "848",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Echelon Network",
@@ -7349,6 +7547,9 @@
         "pool": "777",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7535,6 +7736,9 @@
         "pool": "772",
         "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7707,6 +7911,9 @@
         "pool": "778",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7800,6 +8007,9 @@
         "pool": "790",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7893,6 +8103,9 @@
         "pool": "786",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7944,6 +8157,9 @@
         "pool": "788",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -7998,6 +8214,9 @@
         "pool": "799",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8051,6 +8270,9 @@
         "pool": "796",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8197,6 +8419,9 @@
         "pool": "1104",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8313,6 +8538,9 @@
         "pool": "807",
         "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8401,6 +8629,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
       },
       "coingeckoId": "stakeeasy-bjuno",
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8495,6 +8726,9 @@
         "pool": "806",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8591,7 +8825,8 @@
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -8688,7 +8923,8 @@
         "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -8783,6 +9019,9 @@
         "pool": "941",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8875,6 +9114,9 @@
         "pool": "808",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -8969,6 +9211,9 @@
         "pool": "812",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9064,6 +9309,9 @@
         "pool": "813",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9117,6 +9365,9 @@
         "pool": "816",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9171,7 +9422,8 @@
         "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -9264,11 +9516,12 @@
       "verified": true,
       "apiInclude": true,
       "price": {
-        "pool": "833",
+        "pool": "1252",
         "denom": "uosmo"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -9357,6 +9610,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
       },
       "verified": false,
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9450,6 +9706,9 @@
         "pool": "826",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9502,6 +9761,9 @@
         "pool": "827",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Kujira Blue",
@@ -9573,6 +9835,9 @@
         "pool": "1240",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9626,6 +9891,9 @@
         "pool": "832",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -9678,6 +9946,9 @@
         "pool": "845",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -9768,6 +10039,9 @@
         "pool": "985",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -9856,6 +10130,9 @@
         "pool": "846",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -9945,6 +10222,9 @@
         "pool": "853",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -10035,6 +10315,9 @@
         "pool": "854",
         "denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -10126,6 +10409,9 @@
         "pool": "856",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10173,6 +10459,9 @@
       },
       "coingeckoId": "fanfury",
       "verified": false,
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10266,6 +10555,9 @@
         "pool": "858",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10329,7 +10621,8 @@
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -10393,6 +10686,9 @@
         "pool": "866",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10445,6 +10741,9 @@
         "pool": "1329",
         "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10498,6 +10797,9 @@
         "pool": "1255",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10590,6 +10892,9 @@
         "pool": "984",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -10681,6 +10986,9 @@
         "pool": "882",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10828,6 +11136,9 @@
         "pool": "950",
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -10880,6 +11191,9 @@
         "pool": "894",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -11041,6 +11355,9 @@
         "pool": "1218",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "TFM IBC Transfer",
@@ -11217,6 +11534,9 @@
         "pool": "901",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -11270,7 +11590,8 @@
         "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -11370,6 +11691,9 @@
         "pool": "902",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -11464,7 +11788,8 @@
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -11585,7 +11910,8 @@
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -11706,6 +12032,9 @@
         "pool": "1099",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -11827,7 +12156,8 @@
         "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -11924,7 +12254,8 @@
         "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -12019,6 +12350,9 @@
         "pool": "924",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -12113,6 +12447,9 @@
         "pool": "935",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -12166,7 +12503,8 @@
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -12327,7 +12665,8 @@
         "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -12424,6 +12763,9 @@
         "pool": "949",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -12516,6 +12858,9 @@
         "pool": "952",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -12608,6 +12953,9 @@
         "pool": "954",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -12662,7 +13010,8 @@
         "denom": "uosmo"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -12855,6 +13204,9 @@
         "pool": "1318",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -12918,6 +13270,9 @@
         "pool": "959",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13009,6 +13364,9 @@
         "pool": "961",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13100,6 +13458,9 @@
         "pool": "962",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13192,6 +13553,9 @@
         "pool": "964",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13377,6 +13741,9 @@
         "pool": "974",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13467,6 +13834,9 @@
         "pool": "975",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13557,6 +13927,9 @@
         "pool": "977",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13647,6 +14020,9 @@
         "pool": "969",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13737,6 +14113,9 @@
         "pool": "978",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13827,6 +14206,9 @@
         "pool": "981",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -13917,6 +14299,9 @@
         "pool": "982",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14010,6 +14395,9 @@
         "pool": "992",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14061,6 +14449,9 @@
         "pool": "993",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14151,6 +14542,9 @@
         "pool": "1009",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14244,6 +14638,9 @@
         "pool": "1358",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Secret Network IBC Transfer",
@@ -14332,6 +14729,9 @@
         "pool": "1000",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14422,6 +14822,9 @@
         "pool": "997",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14631,6 +15034,9 @@
         "pool": "1003",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14724,6 +15130,9 @@
         "pool": "1170",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14810,6 +15219,9 @@
         "pool": "1007",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -14968,6 +15380,9 @@
         "pool": "1023",
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -15058,6 +15473,9 @@
         "pool": "1016",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -15256,6 +15674,9 @@
         "pool": "1254",
         "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "IBC Index",
       "description": "",
       "relatedAssets": [
@@ -15317,7 +15738,8 @@
         "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -15423,7 +15845,8 @@
         "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -15529,7 +15952,8 @@
         "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -15647,7 +16071,8 @@
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -15770,6 +16195,9 @@
         "pool": "1036",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -15822,6 +16250,9 @@
         "pool": "1043",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "TFM IBC Transfer",
@@ -15922,7 +16353,8 @@
         "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -16017,6 +16449,9 @@
         "pool": "1107",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "Staked IBCX",
       "description": "",
       "relatedAssets": [
@@ -16079,6 +16514,9 @@
         "pool": "1041",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -16130,6 +16568,9 @@
         "pool": "1072",
         "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "TFM IBC Transfer",
@@ -16226,6 +16667,9 @@
         "pool": "1073",
         "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "TFM IBC Transfer",
@@ -16325,6 +16769,9 @@
         "pool": "1388",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -16417,6 +16864,9 @@
         "pool": "1028",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -16509,6 +16959,9 @@
         "pool": "1057",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Composable Trustless Zone",
@@ -16864,6 +17317,9 @@
         "pool": "1314",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -16914,9 +17370,12 @@
       "verified": true,
       "apiInclude": true,
       "price": {
-        "pool": "1298",
-        "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
+        "pool": "1375",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -16969,6 +17428,9 @@
         "pool": "1065",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "TFM IBC Transfer",
@@ -17023,6 +17485,9 @@
         "pool": "1071",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -17116,6 +17581,9 @@
         "pool": "1075",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -17170,7 +17638,8 @@
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
-        "stablecoin"
+        "stablecoin",
+        "defi"
       ],
       "pegMechanism": "collateralized",
       "transferMethods": [
@@ -17275,6 +17744,9 @@
         "pool": "1067",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "name": "ERIS Amplified OSMO",
       "description": "ERIS liquid staked OSMO",
       "relatedAssets": [
@@ -17337,6 +17809,9 @@
         "pool": "1114",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "TFM IBC Transfer",
@@ -17401,7 +17876,8 @@
         "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -17500,6 +17976,9 @@
         "pool": "1137",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -17553,7 +18032,8 @@
         "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -17766,6 +18246,9 @@
         "pool": "1129",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Wormhole Portal Bridge",
@@ -17873,6 +18356,9 @@
         "pool": "1131",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Wormhole Portal Bridge",
@@ -18198,6 +18684,9 @@
         "pool": "1215",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Kujira Blue",
@@ -18266,6 +18755,9 @@
         "pool": "1143",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -18357,6 +18849,11 @@
         "pool": "1216",
         "denom": "uosmo"
       },
+      "categories": [
+        "stablecoin",
+        "defi"
+      ],
+      "pegMechanism": "collateralized",
       "transferMethods": [
         {
           "name": "Wormhole Portal Bridge",
@@ -18466,6 +18963,9 @@
         "pool": "1214",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Wormhole Portal Bridge",
@@ -18697,7 +19197,8 @@
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -18806,6 +19307,9 @@
         "pool": "1173",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "XPLA",
@@ -18862,6 +19366,9 @@
         "pool": "1210",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19017,6 +19524,9 @@
         "pool": "1180",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Realio Network",
@@ -19074,6 +19584,11 @@
         "pool": "1268",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "stablecoin",
+        "defi"
+      ],
+      "pegMechanism": "collateralized",
       "name": "CDT Stablecoin",
       "description": "Membrane's CDP-style stablecoin called CDT",
       "relatedAssets": [
@@ -19135,6 +19650,9 @@
         "pool": "1225",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "Membrane",
       "description": "Membrane's protocol token",
       "relatedAssets": [
@@ -19197,6 +19715,9 @@
         "pool": "1233",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19249,6 +19770,9 @@
         "pool": "1230",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19342,7 +19866,8 @@
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -19437,6 +19962,9 @@
         "pool": "1234",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19529,6 +20057,9 @@
         "pool": "1239",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19581,6 +20112,9 @@
         "pool": "1244",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19634,6 +20168,9 @@
         "pool": "1248",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19728,6 +20265,9 @@
         "pool": "1246",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -19823,6 +20363,9 @@
         "pool": "1241",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Starscan",
@@ -19983,6 +20526,9 @@
         "pool": "1305",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -20034,6 +20580,9 @@
         "pool": "1267",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "OSMO Squared",
       "description": "Margined Power Token sqOSMO",
       "relatedAssets": [
@@ -20090,6 +20639,9 @@
       },
       "coingeckoId": "unstake-fi",
       "verified": false,
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -20155,6 +20707,9 @@
         "pool": "1288",
         "denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -20245,11 +20800,12 @@
       "verified": true,
       "apiInclude": true,
       "price": {
-        "pool": "1292",
+        "pool": "1431",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "transferMethods": [
         {
@@ -20366,6 +20922,9 @@
         "pool": "1299",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "ATOM Squared",
       "description": "Margined Power Token sqATOM",
       "relatedAssets": [
@@ -20421,6 +20980,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqbtc.svg"
       },
       "verified": true,
+      "categories": [
+        "defi"
+      ],
       "name": "BTC Squared",
       "description": "Margined Power Token sqBTC",
       "unlisted": true,
@@ -20482,6 +21044,9 @@
         "pool": "1295",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -20809,6 +21374,9 @@
         "pool": "1311",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21064,6 +21632,9 @@
         "pool": "1337",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "Levana",
       "description": "Levana native token",
       "relatedAssets": [
@@ -21124,6 +21695,9 @@
         "pool": "1332",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21189,6 +21763,9 @@
         "pool": "1334",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21283,7 +21860,8 @@
         "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"
       },
       "categories": [
-        "liquid_staking"
+        "liquid_staking",
+        "defi"
       ],
       "name": "milkTIA",
       "description": "MilkyWay's liquid staked TIA",
@@ -21345,6 +21923,9 @@
         "pool": "1360",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21409,6 +21990,9 @@
         "pool": "1359",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21473,6 +22057,9 @@
         "pool": "1342",
         "denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21538,6 +22125,9 @@
         "pool": "1343",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21585,6 +22175,9 @@
       },
       "coingeckoId": "autism",
       "verified": false,
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -21956,6 +22549,9 @@
         "pool": "1421",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22043,6 +22639,9 @@
       },
       "coingeckoId": "",
       "verified": true,
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22100,6 +22699,9 @@
         "pool": "1361",
         "denom": "uosmo"
       },
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22155,6 +22757,9 @@
         "pool": "1420",
         "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22217,6 +22822,9 @@
         "pool": "1391",
         "denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22307,6 +22915,9 @@
         "pool": "1377",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22399,6 +23010,9 @@
         "pool": "1365",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22652,6 +23266,9 @@
         "pool": "1381",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22744,6 +23361,9 @@
         "pool": "1392",
         "denom": "uosmo"
       },
+      "categories": [
+        "meme"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -22900,6 +23520,9 @@
         "pool": "1378",
         "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"
       },
+      "categories": [
+        "defi"
+      ],
       "name": "TIA Squared",
       "description": "Margined Power Token sqTIA",
       "listingDate": "2024-01-19T15:51:00.000Z",
@@ -22962,6 +23585,7 @@
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
+        "defi",
         "new_asset"
       ],
       "transferMethods": [
@@ -23059,6 +23683,7 @@
       },
       "categories": [
         "liquid_staking",
+        "defi",
         "new_asset"
       ],
       "transferMethods": [
@@ -23161,6 +23786,7 @@
       },
       "categories": [
         "liquid_staking",
+        "defi",
         "new_asset"
       ],
       "transferMethods": [
@@ -23256,6 +23882,9 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.svg"
       },
       "verified": false,
+      "categories": [
+        "defi"
+      ],
       "transferMethods": [
         {
           "name": "Osmosis IBC Transfer",
@@ -23433,6 +24062,9 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/RAPTR.png"
       },
       "verified": false,
+      "categories": [
+        "meme"
+      ],
       "name": "RAPTR",
       "description": "Rapture insurance is the first ever P2P insurance platform on $OSMO. Get rewarded to take care of peoples loved ones after the Rapture.",
       "unlisted": true,

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -2104,7 +2104,7 @@
         "denom": "uosmo"
       },
       "categories": [
-        "defi"
+        "meme"
       ],
       "transferMethods": [
         {
@@ -18357,8 +18357,10 @@
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
-        "meme"
+        "stablecoin",
+        "defi"
       ],
+      "pegMechanism": "collateralized",
       "transferMethods": [
         {
           "name": "Wormhole Portal Bridge",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1995,7 +1995,7 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "osmosis_verified": true,
-      "pegMechanism": "collateralized",
+      "peg_mechanism": "collateralized",
       "override_properties": {
         "symbol": "USDT.wh",
         "logo_URIs": {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -301,7 +301,10 @@
       "chain_name": "chihuahua",
       "base_denom": "uhuahua",
       "path": "transfer/channel-113/uhuahua",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "meme"
+      ]
     },
     {
       "chain_name": "persistence",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -75,6 +75,9 @@
         "chain_name": "ethereum",
         "base_denom": "wei"
       },
+      "categories": [
+        "defi"
+      ],
       "transfer_methods": [
         {
           "name": "Axelar Bridge",
@@ -738,13 +741,19 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
       "path": "transfer/channel-169/cw20:juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "meme",
       "base_denom": "umeme",
       "path": "transfer/channel-238/umeme",
-      "osmosis_verified": false
+      "osmosis_verified": false,
+      "categories": [
+        "meme"
+      ]
     },
     {
       "chain_name": "juno",
@@ -913,7 +922,7 @@
       "chain_name": "odin",
       "base_denom": "loki",
       "path": "transfer/channel-258/loki",
-      "osmosis_unstable": true,	  
+      "osmosis_unstable": true,
       "osmosis_verified": true
     },
     {
@@ -957,13 +966,19 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
       "path": "transfer/channel-169/cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "juno",
       "base_denom": "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
       "path": "transfer/channel-169/cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "crescent",
@@ -1105,6 +1120,9 @@
           "type": "external_interface",
           "deposit_url": "https://blue.kujira.app/ibc?destination=osmosis-1&source=kaiyo-1&denom=factory%2Fkujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7%2Fuusk"
         }
+      ],
+      "categories": [
+        "defi"
       ]
     },
     {
@@ -1156,6 +1174,9 @@
           "type": "external_interface",
           "deposit_url": "https://dash.scrt.network/ibc"
         }
+      ],
+      "categories": [
+        "defi"
       ]
     },
     {
@@ -1169,6 +1190,9 @@
           "type": "external_interface",
           "deposit_url": "https://dash.scrt.network/ibc"
         }
+      ],
+      "categories": [
+        "defi"
       ]
     },
     {
@@ -1321,7 +1345,10 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "path": "transfer/channel-169/cw20:juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "axelar",
@@ -1562,6 +1589,9 @@
           "type": "external_interface",
           "deposit_url": "https://dash.scrt.network/ibc"
         }
+      ],
+      "categories": [
+        "defi"
       ]
     },
     {
@@ -1600,7 +1630,10 @@
       "chain_name": "secretnetwork",
       "base_denom": "cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
       "path": "transfer/channel-476/cw20:secret153wu605vvp934xhd4k9dtd640zsep5jkesstdm",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "bluzelle",
@@ -1646,7 +1679,10 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "axelar",
@@ -1720,7 +1756,10 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "nolus",
@@ -1932,6 +1971,9 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/95mnwzvJZJ3fKz77xfGN2nR5to9pZmH8YNvaxgLgw5AR",
       "osmosis_verified": true,
+      "categories": [
+        "meme"
+      ],
       "canonical": {
         "chain_name": "solana",
         "base_denom": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263"
@@ -1950,6 +1992,7 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "osmosis_verified": true,
+      "pegMechanism": "collateralized",
       "override_properties": {
         "symbol": "USDT.wh",
         "logo_URIs": {
@@ -2030,6 +2073,7 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
       "osmosis_verified": true,
+      "peg_mechanism": "collateralized",
       "override_properties": {
         "symbol": "USDC.wh",
         "logo_URIs": {
@@ -2050,6 +2094,9 @@
       "base_denom": "factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
       "path": "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
       "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ],
       "override_properties": {
         "symbol": "wETH.wh",
         "logo_URIs": {
@@ -2139,12 +2186,16 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "peg_mechanism": "collateralized"
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "sge",
@@ -2229,7 +2280,10 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "kujira",
@@ -2256,13 +2310,19 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqatom",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqbtc",
       "osmosis_verified": true,
-      "osmosis_unlisted": true
+      "osmosis_unlisted": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "qwoyn",
@@ -2327,7 +2387,10 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "chihuahua",
@@ -2506,14 +2569,20 @@
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqtia",
       "osmosis_verified": true,
-      "listing_date_time_utc": "2024-01-19T15:51:00Z"
+      "listing_date_time_utc": "2024-01-19T15:51:00Z",
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "neutron",
       "base_denom": "factory/neutron154gg0wtm2v4h9ur8xg32ep64e8ef0g5twlsgvfeajqwghdryvyqsqhgk8e/APOLLO",
       "path": "transfer/channel-874/factory/neutron154gg0wtm2v4h9ur8xg32ep64e8ef0g5twlsgvfeajqwghdryvyqsqhgk8e/APOLLO",
       "osmosis_verified": true,
-      "listing_date_time_utc": "2024-01-22T21:05:00Z"
+      "listing_date_time_utc": "2024-01-22T21:05:00Z",
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "stride",
@@ -2539,7 +2608,10 @@
       "override_properties": {
         "symbol": "injective.GLTO",
         "name": "Gelotto (Injective)"
-      }
+      },
+      "categories": [
+        "defi"
+      ]
     },
     {
       "chain_name": "dymension",

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -166,10 +166,8 @@
           "items": {
             "type": "string",
             "enum": [
-              "l1",
               "defi",
-              "store value",
-              "web3"
+              "meme"
             ]
           },
           "minItems": 1


### PR DESCRIPTION
## Description

Add defi and meme Categories

Defines some categories manually in zone_assets
  like where the chain is a meme, like with MEME network or Chihuahua.
  or where cw20 or factory tokens are legitimately used as defi tokens (like with LVN or sqOSMO or GLTO, etc)

Some liquid staking tokens and stablecoins may still be labelled as memes. This should be corrected by registering the proper traces in the chain registry (for liquid staking) or by defining a peg mechanism (for stablecoins).