### PR TITLE
Update FE Assetlist Properties

### DIFF
--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -218,7 +218,7 @@ const generateAssets = async (chainName, zoneConfig, zone_assets, zone_config_as
     // Calculate the difference in weeks
     let differenceInDays = differenceInMilliseconds / (1000 * 60 * 60 * 24);
     if (differenceInDays <= daysForNewAssetCategory) {
-      addArrayItem("new_asset", categories);
+      //addArrayItem("new_asset", categories);
     }
 
     //-DeFi-

--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -160,7 +160,7 @@ const generateAssets = async (chainName, zoneConfig, zone_assets, zone_config_as
       if(price) {
         let price_parts = price.split(':');
         generated_asset.price = {
-          pool: price_parts[2],
+          poolId: price_parts[2],
           denom: price_parts[1]
         }
       }
@@ -670,7 +670,13 @@ const generateAssets = async (chainName, zoneConfig, zone_assets, zone_config_as
 
     //--Add Flags--
     generated_asset.unstable = zone_asset.osmosis_unstable;
+    generated_asset.disabled = zone_asset.osmosis_disabled || zone_asset.osmosis_unstable;
     generated_asset.unlisted = zone_asset.osmosis_unlisted;
+
+
+
+
+    generated_asset.tooltip_message = zone_asset.tooltip_message;
 
     
     
@@ -753,19 +759,20 @@ function reformatZoneConfigAssets(assets) {
       logoURIs:         asset.logo_URIs,
       coingeckoId:      asset.coingecko_id,
       verified:         asset.verified,
-      apiInclude:       asset.api_include,
       price:            asset.price,
       categories:       asset.categories,
       pegMechanism:     asset.peg_mechanism,
       transferMethods:  asset.transfer_methods,
       counterparty:     asset.counterparty,
-      commonKey:        asset.common_key,
+      variantGroupKey:  asset.common_key,
       name:             asset.name,
       description:      asset.description,
       unstable:         asset.unstable,
+      disabled:         asset.disabled,
+      tooltipMessage:   asset.tooltip_message,
       sortWith:         asset.sort_with,
       twitterURL:       asset.twitter_URL,
-      unlisted:         asset.unlisted,
+      preview:          asset.unlisted,
       listingDate:      asset.listing_date,
       relatedAssets:    asset.relatedAssets,
     }

--- a/osmo-test-5/generated/frontend/assetlist.json
+++ b/osmo-test-5/generated/frontend/assetlist.json
@@ -14,7 +14,7 @@
       "coingeckoId": "osmosis",
       "verified": true,
       "price": {
-        "pool": "331",
+        "poolId": "331",
         "denom": "ibc/3642669AD14386D3E38F43F30CFCA859B3E8A05BF6BD6A23DEBD2115AD1325E9"
       },
       "categories": [
@@ -42,7 +42,7 @@
       "coingeckoId": "ion",
       "verified": true,
       "price": {
-        "pool": "1",
+        "poolId": "1",
         "denom": "uosmo"
       },
       "name": "Ion",
@@ -66,7 +66,7 @@
       },
       "verified": true,
       "price": {
-        "pool": "308",
+        "poolId": "308",
         "denom": "uosmo"
       },
       "categories": [
@@ -103,7 +103,7 @@
           }
         }
       ],
-      "commonKey": "ATOM",
+      "variantGroupKey": "ATOM",
       "name": "Cosmos Hub Public Testnet",
       "description": "The native staking and governance token of the Theta testnet version of the Cosmos Hub.",
       "relatedAssets": []
@@ -158,7 +158,7 @@
           }
         }
       ],
-      "commonKey": "aUSDC",
+      "variantGroupKey": "aUSDC",
       "name": "USD Coin (Axelar)",
       "description": "Circle's stablecoin on Axelar",
       "sortWith": {
@@ -232,7 +232,7 @@
           }
         }
       ],
-      "commonKey": "ETH",
+      "variantGroupKey": "ETH",
       "name": "Wrapped Ether (Axelar)",
       "description": "Wrapped Ether on Axelar",
       "sortWith": {
@@ -292,7 +292,7 @@
           }
         }
       ],
-      "commonKey": "JUNOX",
+      "variantGroupKey": "JUNOX",
       "name": "Juno Testnet",
       "description": "The native token of JUNO Chain",
       "relatedAssets": []
@@ -342,7 +342,7 @@
           }
         }
       ],
-      "commonKey": "MARS",
+      "variantGroupKey": "MARS",
       "name": "Mars Hub Testnet",
       "description": "The native token of Mars Protocol",
       "relatedAssets": []
@@ -358,7 +358,6 @@
       },
       "coingeckoId": "usd-coin",
       "verified": true,
-      "apiInclude": true,
       "categories": [
         "defi"
       ],
@@ -392,7 +391,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin",
       "description": "USD Coin",
       "relatedAssets": []
@@ -442,7 +441,7 @@
           }
         }
       ],
-      "commonKey": "AKT",
+      "variantGroupKey": "AKT",
       "name": "Sandbox",
       "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
       "relatedAssets": []
@@ -459,7 +458,7 @@
       },
       "verified": true,
       "price": {
-        "pool": "4",
+        "poolId": "4",
         "denom": "uosmo"
       },
       "categories": [
@@ -496,7 +495,7 @@
           }
         }
       ],
-      "commonKey": "KYVE",
+      "variantGroupKey": "KYVE",
       "name": "KYVE Kaon",
       "description": "The native utility token of the Kaon testnet version of KYVE.",
       "relatedAssets": []
@@ -513,7 +512,7 @@
       "coingeckoId": "quicksilver",
       "verified": true,
       "price": {
-        "pool": "34",
+        "poolId": "34",
         "denom": "uosmo"
       },
       "categories": [
@@ -549,7 +548,7 @@
           }
         }
       ],
-      "commonKey": "QCK",
+      "variantGroupKey": "QCK",
       "name": "Quicksilver Testnet",
       "description": "QCK - native token of Quicksilver",
       "relatedAssets": []
@@ -566,7 +565,7 @@
       "coingeckoId": "",
       "verified": true,
       "price": {
-        "pool": "40",
+        "poolId": "40",
         "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE"
       },
       "categories": [
@@ -602,7 +601,7 @@
           }
         }
       ],
-      "commonKey": "C4E",
+      "variantGroupKey": "C4E",
       "name": "Chain4Energy Testnet",
       "description": "The native token of Chain4Energy",
       "relatedAssets": []
@@ -620,7 +619,7 @@
       "coingeckoId": "persistence",
       "verified": true,
       "price": {
-        "pool": "85",
+        "poolId": "85",
         "denom": "uosmo"
       },
       "categories": [
@@ -657,7 +656,7 @@
           }
         }
       ],
-      "commonKey": "XPRT",
+      "variantGroupKey": "XPRT",
       "name": "Persistence Testnet",
       "description": "The XPRT token is primarily a governance token for the Persistence chain.",
       "relatedAssets": []
@@ -672,9 +671,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "333",
+        "poolId": "333",
         "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58"
       },
       "categories": [
@@ -710,7 +708,7 @@
           }
         }
       ],
-      "commonKey": "XION",
+      "variantGroupKey": "XION",
       "name": "Xion Testnet",
       "description": "The native staking token of the Xion network.",
       "relatedAssets": []
@@ -727,7 +725,7 @@
       },
       "verified": true,
       "price": {
-        "pool": "369",
+        "poolId": "369",
         "denom": "uosmo"
       },
       "categories": [
@@ -764,7 +762,7 @@
           }
         }
       ],
-      "commonKey": "TSAGA",
+      "variantGroupKey": "TSAGA",
       "name": "Saga Testnet",
       "description": "The native token of Saga Testnet",
       "relatedAssets": []
@@ -781,7 +779,7 @@
       },
       "verified": true,
       "price": {
-        "pool": "254",
+        "poolId": "254",
         "denom": "uosmo"
       },
       "categories": [
@@ -818,7 +816,7 @@
           }
         }
       ],
-      "commonKey": "IXO",
+      "variantGroupKey": "IXO",
       "name": "ixo",
       "description": "The native token of IXO Chain",
       "relatedAssets": []

--- a/osmosis-1/generated/chain_registry/assetlist.json
+++ b/osmosis-1/generated/chain_registry/assetlist.json
@@ -2953,8 +2953,7 @@
         }
       ],
       "keywords": [
-        "osmosis_unstable",
-        "osmosis-unstable"
+        "osmosis_unstable"
       ]
     },
     {
@@ -14070,9 +14069,6 @@
         {
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/badkid.png"
         }
-      ],
-      "keywords": [
-        "osmosis-unlisted"
       ]
     },
     {

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -13,9 +13,8 @@
       },
       "coingeckoId": "osmosis",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1221",
+        "poolId": "1263",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -79,9 +78,8 @@
       },
       "coingeckoId": "ion",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "2",
+        "poolId": "2",
         "denom": "uosmo"
       },
       "name": "Ion DAO",
@@ -142,7 +140,6 @@
       },
       "coingeckoId": "axlusdc",
       "verified": true,
-      "apiInclude": true,
       "categories": [
         "stablecoin",
         "defi"
@@ -224,7 +221,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin (Axelar)",
       "description": "Circle's stablecoin on Axelar",
       "relatedAssets": [
@@ -281,9 +278,8 @@
       },
       "coingeckoId": "ethereum",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1134",
+        "poolId": "1134",
         "denom": "uosmo"
       },
       "categories": [
@@ -364,7 +360,7 @@
           }
         }
       ],
-      "commonKey": "ETH",
+      "variantGroupKey": "ETH",
       "name": "Ether",
       "description": "Ethereum (ETH) is a decentralized, open-source blockchain system featuring smart contract functionality. It's the native cryptocurrency of the Ethereum platform, often regarded as the second most popular digital currency after Bitcoin. Ethereum was proposed in late 2013 and development was crowdfunded in 2014, leading to its network going live on 30 July 2015.\n\nETH, as a digital currency, is used for a variety of purposes within the Ethereum ecosystem, including the execution of decentralized smart contracts and as a mode of payment. Unlike Bitcoin, Ethereum was designed to be a platform for applications that can operate without the need for intermediaries, using blockchain technology. This has made Ethereum a leading platform for various applications, including decentralized finance (DeFi), non-fungible tokens (NFTs), and more. Ethereum is constantly evolving, with a significant upgrade termed Ethereum 2.0, which aims to improve its scalability, security, and sustainability.",
       "relatedAssets": [
@@ -421,9 +417,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wbtc.axl.png"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1090",
+        "poolId": "1090",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -469,7 +464,7 @@
           }
         }
       ],
-      "commonKey": "WBTC",
+      "variantGroupKey": "WBTC",
       "name": "Wrapped Bitcoin (Axelar)",
       "description": "Wrapped Bitcoin on Axelar",
       "sortWith": {
@@ -529,9 +524,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.axl.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1150",
+        "poolId": "1150",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
@@ -582,7 +576,7 @@
           }
         }
       ],
-      "commonKey": "USDT",
+      "variantGroupKey": "USDT",
       "name": "Tether USD (Axelar)",
       "description": "Tether's USD stablecoin on Axelar",
       "sortWith": {
@@ -643,9 +637,8 @@
       },
       "coingeckoId": "dai",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1260",
+        "poolId": "1260",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -696,7 +689,7 @@
           }
         }
       ],
-      "commonKey": "DAI",
+      "variantGroupKey": "DAI",
       "name": "Dai Stablecoin",
       "description": "Multi-Collateral Dai, brings a lot of new and exciting features, such as support for new CDP collateral types and Dai Savings Rate.",
       "relatedAssets": [
@@ -754,9 +747,8 @@
       },
       "coingeckoId": "binance-usd",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "877",
+        "poolId": "877",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "transferMethods": [
@@ -802,7 +794,7 @@
           }
         }
       ],
-      "commonKey": "BUSD",
+      "variantGroupKey": "BUSD",
       "name": "Binance USD",
       "description": "Binance USD (BUSD) is a dollar-backed stablecoin issued and custodied by Paxos Trust Company, and regulated by the New York State Department of Financial Services. BUSD is available directly for sale 1:1 with USD on Paxos.com and will be listed for trading on Binance.",
       "relatedAssets": [
@@ -860,9 +852,8 @@
       },
       "coingeckoId": "cosmos",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1265",
+        "poolId": "1265",
         "denom": "uosmo"
       },
       "categories": [
@@ -899,7 +890,7 @@
           }
         }
       ],
-      "commonKey": "ATOM",
+      "variantGroupKey": "ATOM",
       "name": "Cosmos Hub",
       "description": "The native staking and governance token of the Cosmos Hub.\n\nIn a nutshell, Cosmos Hub bills itself as a project that solves some of the hardest problems facing the blockchain industry. It aims to offer an antidote to slow, expensive, unscalable and environmentally harmful proof-of-work protocols, like those used by Bitcoin, by offering an ecosystem of connected blockchains.\n\nThe project’s other goals include making blockchain technology less complex and difficult for developers thanks to a modular framework that demystifies decentralized apps. Last but not least, an Inter-blockchain Communication protocol makes it easier for blockchain networks to communicate with each other — preventing fragmentation in the industry.\n\nCosmos Hub's origins can be dated back to 2014, when Tendermint, a core contributor to the network, was founded. In 2016, a white paper for Cosmos was published — and a token sale was held the following year. ATOM tokens are earned through a hybrid proof-of-stake algorithm, and they help to keep the Cosmos Hub, the project’s flagship blockchain, secure. This cryptocurrency also has a role in the network’s governance.",
       "twitterURL": "https://twitter.com/cosmoshub",
@@ -957,9 +948,8 @@
       },
       "coingeckoId": "crypto-com-chain",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "9",
+        "poolId": "9",
         "denom": "uosmo"
       },
       "categories": [
@@ -995,7 +985,7 @@
           }
         }
       ],
-      "commonKey": "CRO",
+      "variantGroupKey": "CRO",
       "name": "Cronos POS Chain",
       "description": "CRO is the native token of the Crypto.org Chain, referred to as Native CRO.\n\nCronos PoS Chain is a public, open-source and permissionless blockchain - a fully decentralized network with high speed and low fees, designed to be a public good that helps drive mass adoption of blockchain technology through use cases like Payments, DeFi and NFTs.",
       "twitterURL": "https://twitter.com/cronos_chain",
@@ -1013,9 +1003,8 @@
       },
       "coingeckoId": "binancecoin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "840",
+        "poolId": "840",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -1075,7 +1064,7 @@
           }
         }
       ],
-      "commonKey": "BNB",
+      "variantGroupKey": "BNB",
       "name": "Binance Coin",
       "description": "BNB powers the BNB Chain ecosystem and is the native coin of the BNB Beacon Chain and BNB Smart Chain.",
       "relatedAssets": [
@@ -1132,9 +1121,8 @@
       },
       "coingeckoId": "matic-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "789",
+        "poolId": "789",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -1193,7 +1181,7 @@
           }
         }
       ],
-      "commonKey": "MATIC",
+      "variantGroupKey": "MATIC",
       "name": "Polygon",
       "description": "Polygon (formerly Matic) Network brings massive scale to Ethereum using an adapted version of Plasma with PoS based side chains. Polygon is a well-structured, easy-to-use platform for Ethereum scaling and infrastructure development.",
       "relatedAssets": [
@@ -1250,9 +1238,8 @@
       },
       "coingeckoId": "avalanche-2",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1427",
+        "poolId": "899",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -1310,7 +1297,7 @@
           }
         }
       ],
-      "commonKey": "AVAX",
+      "variantGroupKey": "AVAX",
       "name": "Avalanche",
       "description": "AVAX is the native token of Avalanche. It is a hard-capped, scarce asset that is used to pay for fees, secure the platform through staking, and provide a basic unit of account between the multiple subnets created on Avalanche.",
       "relatedAssets": [
@@ -1368,9 +1355,8 @@
       },
       "coingeckoId": "terra-luna",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "800",
+        "poolId": "800",
         "denom": "uosmo"
       },
       "categories": [
@@ -1413,7 +1399,7 @@
           }
         }
       ],
-      "commonKey": "LUNC",
+      "variantGroupKey": "LUNC",
       "name": "Luna Classic",
       "description": "The native staking token of Terra Classic.",
       "relatedAssets": [
@@ -1439,9 +1425,8 @@
       },
       "coingeckoId": "juno-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "497",
+        "poolId": "497",
         "denom": "uosmo"
       },
       "categories": [
@@ -1478,7 +1463,7 @@
           }
         }
       ],
-      "commonKey": "JUNO",
+      "variantGroupKey": "JUNO",
       "name": "Juno",
       "description": "The native token of JUNO Chain\n\nJuno is a completely community owned and operated smart contract platform.",
       "twitterURL": "https://twitter.com/JunoNetwork",
@@ -1535,9 +1520,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dot.axl.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1091",
+        "poolId": "1091",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -1584,7 +1568,7 @@
           }
         }
       ],
-      "commonKey": "xcDOT",
+      "variantGroupKey": "xcDOT",
       "name": "Wrapped Polkadot (Axelar)",
       "description": "Wrapped Polkadot on Axelar",
       "sortWith": {
@@ -1646,9 +1630,8 @@
       },
       "coingeckoId": "evmos",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "722",
+        "poolId": "722",
         "denom": "uosmo"
       },
       "categories": [
@@ -1691,7 +1674,7 @@
           }
         }
       ],
-      "commonKey": "EVMOS",
+      "variantGroupKey": "EVMOS",
       "name": "Evmos",
       "description": "The native EVM, governance and staking token of the Evmos Hub\n\nDevelopers use Evmos as the Ethereum Canary Chain to deploy applications of the future. Get all the functionalities of Ethereum with the power of IBC and Interchain composability.",
       "twitterURL": "https://twitter.com/EvmosOrg",
@@ -1750,9 +1733,8 @@
       },
       "coingeckoId": "kava",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1105",
+        "poolId": "1105",
         "denom": "uosmo"
       },
       "categories": [
@@ -1789,7 +1771,7 @@
           }
         }
       ],
-      "commonKey": "KAVA",
+      "variantGroupKey": "KAVA",
       "name": "Kava",
       "description": "The native staking and governance token of Kava\n\nKava is a decentralized blockchain that combines the speed and interoperability of Cosmos with the developer power of Ethereum.",
       "twitterURL": "https://twitter.com/KAVA_CHAIN",
@@ -1848,9 +1830,8 @@
       },
       "coingeckoId": "secret",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "584",
+        "poolId": "1095",
         "denom": "uosmo"
       },
       "categories": [
@@ -1887,7 +1868,7 @@
           }
         }
       ],
-      "commonKey": "SCRT",
+      "variantGroupKey": "SCRT",
       "name": "Secret Network",
       "description": "The native token of Secret Network\n\nSecret Network is the first blockchain with customizable privacy. You get to choose what you share, with whom, and how. This protects users, and empowers developers to build a better Web3.",
       "twitterURL": "https://twitter.com/SecretNetwork",
@@ -1938,9 +1919,8 @@
       },
       "coingeckoId": "terrausd",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "560",
+        "poolId": "560",
         "denom": "uosmo"
       },
       "categories": [
@@ -1979,7 +1959,7 @@
           }
         }
       ],
-      "commonKey": "USTC",
+      "variantGroupKey": "USTC",
       "name": "TerraClassicUSD",
       "description": "The USD stablecoin of Terra Classic.",
       "relatedAssets": [
@@ -2005,9 +1985,8 @@
       },
       "coingeckoId": "stargaze",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1096",
+        "poolId": "1096",
         "denom": "uosmo"
       },
       "categories": [
@@ -2044,7 +2023,7 @@
           }
         }
       ],
-      "commonKey": "STARS",
+      "variantGroupKey": "STARS",
       "name": "Stargaze",
       "description": "The native token of Stargaze\n\nThe premier community-focused blockchain for NFTs. Stargaze empowers creators, developers, collectors, and traders to participate on the platform. The Stargaze chain consists of various NFT-related apps such as a Launchpad, and a Marketplace with offers and auctions.",
       "twitterURL": "https://twitter.com/StargazeZone",
@@ -2103,9 +2082,8 @@
       },
       "coingeckoId": "chihuahua-token",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1111",
+        "poolId": "1111",
         "denom": "uosmo"
       },
       "categories": [
@@ -2142,7 +2120,7 @@
           }
         }
       ],
-      "commonKey": "HUAHUA",
+      "variantGroupKey": "HUAHUA",
       "name": "Chihuahua",
       "description": "The native token of Chihuahua Chain",
       "relatedAssets": [
@@ -2172,9 +2150,8 @@
       },
       "coingeckoId": "persistence",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1101",
+        "poolId": "1101",
         "denom": "uosmo"
       },
       "categories": [
@@ -2211,7 +2188,7 @@
           }
         }
       ],
-      "commonKey": "XPRT",
+      "variantGroupKey": "XPRT",
       "name": "Persistence",
       "description": "The XPRT token is primarily a governance token for the Persistence chain.\n\nPersistence is an app chain for Liquid Staking powering an ecosystem of DeFi applications focused on unlocking the liquidity of staked assets.",
       "twitterURL": "https://twitter.com/PersistenceOne",
@@ -2270,9 +2247,8 @@
       },
       "coingeckoId": "pstake-finance",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "648",
+        "poolId": "648",
         "denom": "uosmo"
       },
       "categories": [
@@ -2335,7 +2311,7 @@
           }
         }
       ],
-      "commonKey": "PSTAKE",
+      "variantGroupKey": "PSTAKE",
       "name": "pSTAKE Finance",
       "description": "pSTAKE is a liquid staking protocol unlocking the liquidity of staked assets. Stakers of PoS tokens can stake their assets while maintaining the liquidity of these assets. Users earn staking rewards + receive 1:1 pegged staked representative tokens which can be used to generate additional yield.",
       "relatedAssets": [
@@ -2393,10 +2369,9 @@
       },
       "coingeckoId": "akash-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1301",
-        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+        "poolId": "1093",
+        "denom": "uosmo"
       },
       "categories": [
         "defi"
@@ -2432,7 +2407,7 @@
           }
         }
       ],
-      "commonKey": "AKT",
+      "variantGroupKey": "AKT",
       "name": "Akash",
       "description": "Akash Token (AKT) is the Akash Network's native utility token, used as the primary means to govern, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.\n\nAkash is open-source Supercloud that lets users buy and sell computing resources securely and efficiently. Purpose-built for public utility.",
       "twitterURL": "https://twitter.com/akashnet_",
@@ -2450,9 +2425,8 @@
       },
       "coingeckoId": "regen",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "42",
+        "poolId": "42",
         "denom": "uosmo"
       },
       "categories": [
@@ -2489,7 +2463,7 @@
           }
         }
       ],
-      "commonKey": "REGEN",
+      "variantGroupKey": "REGEN",
       "name": "Regen",
       "description": "REGEN coin is the token for the Regen Network Platform\n\nRegen Network, a platform to originate and invest in high-integrity carbon and biodiversity credits from ecological regeneration projects.",
       "twitterURL": "https://twitter.com/regen_network",
@@ -2548,9 +2522,8 @@
       },
       "coingeckoId": "sentinel",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "6",
+        "poolId": "6",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -2587,7 +2560,7 @@
           }
         }
       ],
-      "commonKey": "DVPN",
+      "variantGroupKey": "DVPN",
       "name": "Sentinel",
       "description": "DVPN is the native token of the Sentinel Hub.\n\nThe Sentinel ecosystem is a global network of autonomous dVPN applications that enable private and censorship resistant internet access.",
       "twitterURL": "https://twitter.com/SentinelVPN",
@@ -2605,9 +2578,8 @@
       },
       "coingeckoId": "iris-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "8",
+        "poolId": "8",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -2644,7 +2616,7 @@
           }
         }
       ],
-      "commonKey": "IRIS",
+      "variantGroupKey": "IRIS",
       "name": "IRISnet",
       "description": "The IRIS token is the native governance token for the IrisNet chain.",
       "relatedAssets": []
@@ -2661,9 +2633,8 @@
       },
       "coingeckoId": "starname",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "197",
+        "poolId": "197",
         "denom": "uosmo"
       },
       "categories": [
@@ -2700,7 +2671,7 @@
           }
         }
       ],
-      "commonKey": "IOV",
+      "variantGroupKey": "IOV",
       "name": "Starname",
       "description": "IOV coin is the token for the Starname (IOV) Asset Name Service\n\nStarname is the best way to claim your part of the blockchain. You can use it for decentralized identification, payments, ownership and applications. Starname can be integrated into digital wallets, dapps and exchanges.",
       "twitterURL": "https://twitter.com/starname_me",
@@ -2718,9 +2689,8 @@
       },
       "coingeckoId": "e-money",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "463",
+        "poolId": "463",
         "denom": "uosmo"
       },
       "categories": [
@@ -2757,7 +2727,7 @@
           }
         }
       ],
-      "commonKey": "NGM",
+      "variantGroupKey": "NGM",
       "name": "e-Money",
       "description": "e-Money NGM staking token. In addition to earning staking rewards the token is bought back and burned based on e-Money stablecoin inflation.",
       "relatedAssets": [
@@ -2779,9 +2749,8 @@
       },
       "coingeckoId": "e-money-eur",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "481",
+        "poolId": "481",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -2815,7 +2784,7 @@
           }
         }
       ],
-      "commonKey": "EEUR",
+      "variantGroupKey": "EEUR",
       "name": "e-Money EUR",
       "description": "e-Money EUR stablecoin. Audited and backed by fiat EUR deposits and government bonds.",
       "relatedAssets": [
@@ -2837,9 +2806,8 @@
       },
       "coingeckoId": "likecoin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "553",
+        "poolId": "553",
         "denom": "uosmo"
       },
       "categories": [
@@ -2876,7 +2844,7 @@
           }
         }
       ],
-      "commonKey": "LIKE",
+      "variantGroupKey": "LIKE",
       "name": "LikeCoin",
       "description": "LIKE is the native staking and governance token of LikeCoin chain, a Decentralized Publishing Infrastructure to empower content ownership, authenticity, and provenance.",
       "relatedAssets": []
@@ -2893,9 +2861,8 @@
       },
       "coingeckoId": "ixo",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "558",
+        "poolId": "558",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -2932,7 +2899,7 @@
           }
         }
       ],
-      "commonKey": "IXO",
+      "variantGroupKey": "IXO",
       "name": "Impacts Hub",
       "description": "The native token of IXO Chain",
       "relatedAssets": []
@@ -2949,9 +2916,8 @@
       },
       "coingeckoId": "bitcanna",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "571",
+        "poolId": "571",
         "denom": "uosmo"
       },
       "categories": [
@@ -2988,7 +2954,7 @@
           }
         }
       ],
-      "commonKey": "BCNA",
+      "variantGroupKey": "BCNA",
       "name": "BitCanna",
       "description": "The BCNA coin is the transactional token within the BitCanna network, serving the legal cannabis industry through its payment network, supply chain and trust network.",
       "relatedAssets": []
@@ -3005,9 +2971,8 @@
       },
       "coingeckoId": "bitsong",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1109",
+        "poolId": "1109",
         "denom": "uosmo"
       },
       "categories": [
@@ -3044,7 +3009,7 @@
           }
         }
       ],
-      "commonKey": "BTSG",
+      "variantGroupKey": "BTSG",
       "name": "BitSong",
       "description": "BitSong Native Token\n\nArtists, Fans, Managers and Labels in One Single Holistic Ecosystem: $BTSG. Earn real-time royalties, discover exclusive content, mint and trade Fantokens, buy & sell NFTs.",
       "twitterURL": "https://twitter.com/BitSongOfficial",
@@ -3062,9 +3027,8 @@
       },
       "coingeckoId": "ki",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "577",
+        "poolId": "577",
         "denom": "uosmo"
       },
       "categories": [
@@ -3101,7 +3065,7 @@
           }
         }
       ],
-      "commonKey": "XKI",
+      "variantGroupKey": "XKI",
       "name": "Ki",
       "description": "The native token of Ki Chain",
       "relatedAssets": [
@@ -3123,9 +3087,8 @@
       },
       "coingeckoId": "medibloc",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "586",
+        "poolId": "586",
         "denom": "uosmo"
       },
       "categories": [
@@ -3162,7 +3125,7 @@
           }
         }
       ],
-      "commonKey": "MED",
+      "variantGroupKey": "MED",
       "name": "Medibloc",
       "description": "Panacea is a public blockchain launched by MediBloc, which is the key infrastructure for reinventing the patient-centered healthcare data ecosystem",
       "relatedAssets": []
@@ -3179,9 +3142,8 @@
       },
       "coingeckoId": "bostrom",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "912",
+        "poolId": "912",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
@@ -3218,7 +3180,7 @@
           }
         }
       ],
-      "commonKey": "BOOT",
+      "variantGroupKey": "BOOT",
       "name": "bostrom",
       "description": "The staking token of Bostrom",
       "relatedAssets": [
@@ -3252,9 +3214,8 @@
       },
       "coingeckoId": "comdex",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "601",
+        "poolId": "601",
         "denom": "uosmo"
       },
       "categories": [
@@ -3291,7 +3252,7 @@
           }
         }
       ],
-      "commonKey": "CMDX",
+      "variantGroupKey": "CMDX",
       "name": "Comdex",
       "description": "Native Token of Comdex Protocol",
       "relatedAssets": [
@@ -3317,9 +3278,8 @@
       },
       "coingeckoId": "cheqd-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1273",
+        "poolId": "1273",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -3356,7 +3316,7 @@
           }
         }
       ],
-      "commonKey": "CHEQ",
+      "variantGroupKey": "CHEQ",
       "name": "Cheqd",
       "description": "Native token for the cheqd network",
       "relatedAssets": []
@@ -3373,9 +3333,8 @@
       },
       "coingeckoId": "lum-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "608",
+        "poolId": "608",
         "denom": "uosmo"
       },
       "categories": [
@@ -3412,7 +3371,7 @@
           }
         }
       ],
-      "commonKey": "LUM",
+      "variantGroupKey": "LUM",
       "name": "Lum Network",
       "description": "Native token of the Lum Network",
       "relatedAssets": []
@@ -3429,9 +3388,8 @@
       },
       "coingeckoId": "vidulum",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "613",
+        "poolId": "613",
         "denom": "uosmo"
       },
       "categories": [
@@ -3468,7 +3426,7 @@
           }
         }
       ],
-      "commonKey": "VDL",
+      "variantGroupKey": "VDL",
       "name": "Vidulum",
       "description": "The native token of Vidulum",
       "relatedAssets": []
@@ -3485,9 +3443,8 @@
       },
       "coingeckoId": "desmos",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "619",
+        "poolId": "619",
         "denom": "uosmo"
       },
       "categories": [
@@ -3524,7 +3481,7 @@
           }
         }
       ],
-      "commonKey": "DSM",
+      "variantGroupKey": "DSM",
       "name": "Desmos",
       "description": "The native token of Desmos",
       "relatedAssets": []
@@ -3540,9 +3497,8 @@
       },
       "coingeckoId": "dig-chain",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "621",
+        "poolId": "621",
         "denom": "uosmo"
       },
       "categories": [
@@ -3578,10 +3534,11 @@
           }
         }
       ],
-      "commonKey": "DIG",
+      "variantGroupKey": "DIG",
       "name": "Dig Chain",
       "description": "Native token of Dig Chain",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -3596,9 +3553,8 @@
       },
       "coingeckoId": "sommelier",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1372",
+        "poolId": "1372",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -3635,7 +3591,7 @@
           }
         }
       ],
-      "commonKey": "SOMM",
+      "variantGroupKey": "SOMM",
       "name": "Sommelier",
       "description": "Somm Token (SOMM) is the native staking token of the Sommelier Chain\n\nAutomated vaults find best-in-class yields while mitigating risk.",
       "twitterURL": "https://twitter.com/sommfinance",
@@ -3694,9 +3650,8 @@
       },
       "coingeckoId": "band-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "626",
+        "poolId": "626",
         "denom": "uosmo"
       },
       "categories": [
@@ -3733,7 +3688,7 @@
           }
         }
       ],
-      "commonKey": "BAND",
+      "variantGroupKey": "BAND",
       "name": "Band Protocol",
       "description": "The native token of BandChain\n\nBand Protocol is a cross-chain data oracle platform that aggregates and connects real-world data and APIs to smart contracts.",
       "twitterURL": "https://twitter.com/BandProtocol",
@@ -3751,9 +3706,8 @@
       },
       "coingeckoId": "darcmatter-coin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "637",
+        "poolId": "637",
         "denom": "uosmo"
       },
       "categories": [
@@ -3790,10 +3744,11 @@
           }
         }
       ],
-      "commonKey": "DARC",
+      "variantGroupKey": "DARC",
       "name": "Konstellation",
       "description": "The native token of Konstellation Network",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -3808,9 +3763,8 @@
       },
       "coingeckoId": "umee",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1110",
+        "poolId": "1110",
         "denom": "uosmo"
       },
       "categories": [
@@ -3847,7 +3801,7 @@
           }
         }
       ],
-      "commonKey": "UMEE",
+      "variantGroupKey": "UMEE",
       "name": "Umee",
       "description": "The native token of Umee",
       "relatedAssets": [
@@ -3905,9 +3859,8 @@
       },
       "coingeckoId": "graviton",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "625",
+        "poolId": "625",
         "denom": "uosmo"
       },
       "categories": [
@@ -3944,7 +3897,7 @@
           }
         }
       ],
-      "commonKey": "GRAV",
+      "variantGroupKey": "GRAV",
       "name": "Gravity Bridge",
       "description": "The native token of Gravity Bridge\n\nAn open, decentralized bridge that unlocks the power of interoperability & liquidity between blockchain ecosystems.",
       "twitterURL": "https://twitter.com/gravity_bridge",
@@ -4003,9 +3956,8 @@
       },
       "coingeckoId": "decentr",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "644",
+        "poolId": "644",
         "denom": "uosmo"
       },
       "categories": [
@@ -4042,7 +3994,7 @@
           }
         }
       ],
-      "commonKey": "DEC",
+      "variantGroupKey": "DEC",
       "name": "Decentr",
       "description": "The native token of Decentr",
       "relatedAssets": []
@@ -4060,7 +4012,7 @@
       "coingeckoId": "marble",
       "verified": false,
       "price": {
-        "pool": "649",
+        "poolId": "649",
         "denom": "uosmo"
       },
       "categories": [
@@ -4097,7 +4049,7 @@
           }
         }
       ],
-      "commonKey": "MARBLE",
+      "variantGroupKey": "MARBLE",
       "name": "Marble",
       "description": "The native token cw20 for Marble DAO on Juno Chain",
       "relatedAssets": [
@@ -4155,9 +4107,8 @@
       },
       "coingeckoId": "switcheo",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "651",
+        "poolId": "651",
         "denom": "uosmo"
       },
       "categories": [
@@ -4200,7 +4151,7 @@
           }
         }
       ],
-      "commonKey": "SWTH",
+      "variantGroupKey": "SWTH",
       "name": "Carbon",
       "description": "The native governance token of Carbon",
       "relatedAssets": []
@@ -4217,9 +4168,8 @@
       },
       "coingeckoId": "cerberus-2",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "662",
+        "poolId": "662",
         "denom": "uosmo"
       },
       "categories": [
@@ -4256,10 +4206,11 @@
           }
         }
       ],
-      "commonKey": "CRBRUS",
+      "variantGroupKey": "CRBRUS",
       "name": "Cerberus",
       "description": "The native token of Cerberus Chain",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -4274,9 +4225,8 @@
       },
       "coingeckoId": "fetch-ai",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "681",
+        "poolId": "681",
         "denom": "uosmo"
       },
       "categories": [
@@ -4313,7 +4263,7 @@
           }
         }
       ],
-      "commonKey": "FET",
+      "variantGroupKey": "FET",
       "name": "Fetch.ai",
       "description": "The native staking and governance token of the Fetch Hub.",
       "relatedAssets": []
@@ -4330,9 +4280,8 @@
       },
       "coingeckoId": "assetmantle",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "686",
+        "poolId": "686",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -4369,7 +4318,7 @@
           }
         }
       ],
-      "commonKey": "MNTL",
+      "variantGroupKey": "MNTL",
       "name": "AssetMantle",
       "description": "The native token of Asset Mantle\n\nAssetMantle’s suite of products is focused on the NFT ecosystem, helping you up your game with digital asset ownership.",
       "twitterURL": "https://twitter.com/AssetMantle",
@@ -4387,9 +4336,8 @@
       },
       "coingeckoId": "neta",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "631",
+        "poolId": "631",
         "denom": "uosmo"
       },
       "categories": [
@@ -4426,7 +4374,7 @@
           }
         }
       ],
-      "commonKey": "NETA",
+      "variantGroupKey": "NETA",
       "name": "Neta",
       "description": "The native token cw20 for Neta on Juno Chain",
       "relatedAssets": [
@@ -4484,9 +4432,8 @@
       },
       "coingeckoId": "injective-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1319",
+        "poolId": "1319",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -4529,7 +4476,7 @@
           }
         }
       ],
-      "commonKey": "INJ",
+      "variantGroupKey": "INJ",
       "name": "Injective",
       "description": "The INJ token is the native governance token for the Injective chain.\n\nInjective’s mission is to create a truly free and inclusive financial system through decentralization.",
       "twitterURL": "https://twitter.com/Injective_",
@@ -4589,7 +4536,7 @@
       "coingeckoId": "terrakrw",
       "verified": false,
       "price": {
-        "pool": "581",
+        "poolId": "581",
         "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
       },
       "categories": [
@@ -4628,7 +4575,7 @@
           }
         }
       ],
-      "commonKey": "KRTC",
+      "variantGroupKey": "KRTC",
       "name": "TerraClassicKRW",
       "description": "The KRW stablecoin of Terra Classic.",
       "relatedAssets": [
@@ -4654,9 +4601,8 @@
       },
       "coingeckoId": "microtick",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "547",
+        "poolId": "547",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -4693,10 +4639,11 @@
           }
         }
       ],
-      "commonKey": "TICK",
+      "variantGroupKey": "TICK",
       "name": "Microtick",
       "description": "TICK coin is the token for the Microtick Price Discovery & Oracle App",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -4711,9 +4658,8 @@
       },
       "coingeckoId": "sifchain",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "629",
+        "poolId": "629",
         "denom": "uosmo"
       },
       "categories": [
@@ -4750,10 +4696,9 @@
           }
         }
       ],
-      "commonKey": "ROWAN",
+      "variantGroupKey": "ROWAN",
       "name": "Sifchain",
       "description": "Rowan Token (ROWAN) is the Sifchain Network's native utility token, used as the primary means to govern, provide liquidity, secure the blockchain, incentivize participants, and provide a default mechanism to store and exchange value.",
-      "unstable": true,
       "relatedAssets": []
     },
     {
@@ -4768,9 +4713,8 @@
       },
       "coingeckoId": "certik",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1020",
+        "poolId": "1020",
         "denom": "uosmo"
       },
       "categories": [
@@ -4807,7 +4751,7 @@
           }
         }
       ],
-      "commonKey": "CTK",
+      "variantGroupKey": "CTK",
       "name": "Shentu",
       "description": "The native token of Shentu",
       "relatedAssets": []
@@ -4825,7 +4769,7 @@
       "coingeckoId": "hope-galaxy",
       "verified": false,
       "price": {
-        "pool": "653",
+        "poolId": "653",
         "denom": "uosmo"
       },
       "categories": [
@@ -4862,7 +4806,7 @@
           }
         }
       ],
-      "commonKey": "HOPE",
+      "variantGroupKey": "HOPE",
       "name": "Hope Galaxy",
       "description": "Hope Galaxy is an NFT collection based on its own native Token $HOPE, a cw20 token on Juno chain.",
       "relatedAssets": [
@@ -4920,9 +4864,8 @@
       },
       "coingeckoId": "racoon",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "669",
+        "poolId": "669",
         "denom": "uosmo"
       },
       "categories": [
@@ -4959,7 +4902,7 @@
           }
         }
       ],
-      "commonKey": "RAC",
+      "variantGroupKey": "RAC",
       "name": "Racoon",
       "description": "Racoon aims to simplify accessibility to AI, NFTs and Gambling on the Cosmos Ecosystem",
       "relatedAssets": [
@@ -5016,9 +4959,8 @@
       },
       "coingeckoId": "frax",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "679",
+        "poolId": "679",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -5068,7 +5010,7 @@
           }
         }
       ],
-      "commonKey": "FRAX",
+      "variantGroupKey": "FRAX",
       "name": "Frax",
       "description": "Frax is a fractional-algorithmic stablecoin protocol. It aims to provide a highly scalable, decentralized, algorithmic money in place of fixed-supply assets like BTC. Additionally, FXS is the value accrual and governance token of the entire Frax ecosystem.",
       "relatedAssets": [
@@ -5125,7 +5067,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "694",
+        "poolId": "694",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "transferMethods": [
@@ -5178,7 +5120,7 @@
           }
         }
       ],
-      "commonKey": "WBTC",
+      "variantGroupKey": "WBTC",
       "name": "Wrapped Bitcoin (Gravity Bridge)",
       "description": "Gravity Bridge WBTC",
       "sortWith": {
@@ -5238,9 +5180,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.grv.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1297",
+        "poolId": "1297",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "transferMethods": [
@@ -5304,7 +5245,7 @@
           }
         }
       ],
-      "commonKey": "ETH",
+      "variantGroupKey": "ETH",
       "name": "Ether (Gravity Bridge)",
       "description": "Gravity Bridge WETH",
       "sortWith": {
@@ -5364,9 +5305,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.grv.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "872",
+        "poolId": "872",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -5422,7 +5362,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin (Gravity Bridge)",
       "description": "Gravity Bridge USDC",
       "sortWith": {
@@ -5483,7 +5423,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "702",
+        "poolId": "702",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -5539,7 +5479,7 @@
           }
         }
       ],
-      "commonKey": "DAI",
+      "variantGroupKey": "DAI",
       "name": "DAI Stablecoin (Gravity Bridge)",
       "description": "Gravity Bridge DAI",
       "sortWith": {
@@ -5599,9 +5539,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.grv.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "818",
+        "poolId": "818",
         "denom": "uosmo"
       },
       "categories": [
@@ -5657,7 +5596,7 @@
           }
         }
       ],
-      "commonKey": "USDT",
+      "variantGroupKey": "USDT",
       "name": "Tether USD (Gravity Bridge)",
       "description": "Gravity Bridge USDT",
       "sortWith": {
@@ -5719,7 +5658,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "691",
+        "poolId": "691",
         "denom": "uosmo"
       },
       "categories": [
@@ -5756,7 +5695,7 @@
           }
         }
       ],
-      "commonKey": "BLOCK",
+      "variantGroupKey": "BLOCK",
       "name": "Block",
       "description": "The native token of Marble DEX on Juno Chain",
       "relatedAssets": [
@@ -5814,9 +5753,8 @@
       },
       "coingeckoId": "provenance-blockchain",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "693",
+        "poolId": "693",
         "denom": "uosmo"
       },
       "categories": [
@@ -5853,7 +5791,7 @@
           }
         }
       ],
-      "commonKey": "HASH",
+      "variantGroupKey": "HASH",
       "name": "Provenance",
       "description": "Hash is the staking token of the Provenance Blockchain",
       "relatedAssets": []
@@ -5870,7 +5808,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "697",
+        "poolId": "697",
         "denom": "uosmo"
       },
       "categories": [
@@ -5907,7 +5845,7 @@
           }
         }
       ],
-      "commonKey": "GLX",
+      "variantGroupKey": "GLX",
       "name": "Galaxy",
       "description": "GLX is the staking token of the Galaxy Chain",
       "relatedAssets": []
@@ -5922,9 +5860,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "695",
+        "poolId": "695",
         "denom": "uosmo"
       },
       "categories": [
@@ -5960,7 +5897,7 @@
           }
         }
       ],
-      "commonKey": "DHK",
+      "variantGroupKey": "DHK",
       "name": "DHK",
       "description": "The DAO token to build consensus among Hong Kong People",
       "relatedAssets": [
@@ -6019,7 +5956,7 @@
       "coingeckoId": "junoswap-raw-dao",
       "verified": true,
       "price": {
-        "pool": "700",
+        "poolId": "700",
         "denom": "uosmo"
       },
       "categories": [
@@ -6056,7 +5993,7 @@
           }
         }
       ],
-      "commonKey": "RAW",
+      "variantGroupKey": "RAW",
       "name": "JunoSwap",
       "description": "Token governance for Junoswap",
       "relatedAssets": [
@@ -6114,9 +6051,8 @@
       },
       "coingeckoId": "meme-network",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "701",
+        "poolId": "701",
         "denom": "uosmo"
       },
       "categories": [
@@ -6153,7 +6089,7 @@
           }
         }
       ],
-      "commonKey": "MEME",
+      "variantGroupKey": "MEME",
       "name": "MEME",
       "description": "MEME Token (MEME) is the native staking token of the MEME Chain",
       "relatedAssets": []
@@ -6169,7 +6105,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "771",
+        "poolId": "771",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -6205,7 +6141,7 @@
           }
         }
       ],
-      "commonKey": "ASVT",
+      "variantGroupKey": "ASVT",
       "name": "Another.Software Validator Token",
       "description": "Profit sharing token for Another.Software validator. Hold and receive dividends from Another.Software validator commissions!",
       "relatedAssets": [
@@ -6261,9 +6197,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "718",
+        "poolId": "718",
         "denom": "uosmo"
       },
       "categories": [
@@ -6299,7 +6234,7 @@
           }
         }
       ],
-      "commonKey": "JOE",
+      "variantGroupKey": "JOE",
       "name": "JoeDAO",
       "description": "DAO dedicated to building tools on the Juno Network",
       "relatedAssets": [
@@ -6357,9 +6292,8 @@
       },
       "coingeckoId": "terra-luna-2",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1163",
+        "poolId": "1163",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
@@ -6396,7 +6330,7 @@
           }
         }
       ],
-      "commonKey": "LUNA",
+      "variantGroupKey": "LUNA",
       "name": "Luna",
       "description": "The native staking token of Terra.\n\nFueled by a passionate community and deep developer talent pool, the Terra blockchain is built to enable the next generation of Web3 products and services.",
       "twitterURL": "https://twitter.com/terra_money",
@@ -6456,7 +6390,7 @@
       "coingeckoId": "rizon",
       "verified": false,
       "price": {
-        "pool": "729",
+        "poolId": "729",
         "denom": "uosmo"
       },
       "categories": [
@@ -6493,7 +6427,7 @@
           }
         }
       ],
-      "commonKey": "ATOLO",
+      "variantGroupKey": "ATOLO",
       "name": "Rizon",
       "description": "Native token of Rizon Chain",
       "relatedAssets": []
@@ -6541,7 +6475,7 @@
           }
         }
       ],
-      "commonKey": "HARD",
+      "variantGroupKey": "HARD",
       "name": "Kava Hard",
       "description": "Governance token of Kava Lend Protocol",
       "relatedAssets": [
@@ -6630,7 +6564,7 @@
           }
         }
       ],
-      "commonKey": "SWP",
+      "variantGroupKey": "SWP",
       "name": "Kava Swap",
       "description": "Governance token of Kava Swap Protocol",
       "relatedAssets": [
@@ -6688,9 +6622,8 @@
       },
       "coingeckoId": "chainlink",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "731",
+        "poolId": "731",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -6737,7 +6670,7 @@
           }
         }
       ],
-      "commonKey": "LINK",
+      "variantGroupKey": "LINK",
       "name": "Chainlink",
       "description": "A blockchain-based middleware, acting as a bridge between cryptocurrency smart contracts, data feeds, APIs and traditional bank account payments.",
       "relatedAssets": [
@@ -6794,9 +6727,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "732",
+        "poolId": "732",
         "denom": "uosmo"
       },
       "categories": [
@@ -6833,10 +6765,11 @@
           }
         }
       ],
-      "commonKey": "L1",
+      "variantGroupKey": "L1",
       "name": "GenesisL1",
       "description": "L1 coin is the GenesisL1 blockchain utility, governance and EVM token",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -6892,10 +6825,10 @@
           }
         }
       ],
-      "commonKey": "AAVE",
+      "variantGroupKey": "AAVE",
       "name": "Aave",
       "description": "Aave is an Open Source and Non-Custodial protocol to earn interest on deposits & borrow assets. It also features access to highly innovative flash loans, which let developers borrow instantly and easily; no collateral needed. With 16 different assets, 5 of which are stablecoins.",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "axelar",
@@ -6992,10 +6925,10 @@
           }
         }
       ],
-      "commonKey": "APE",
+      "variantGroupKey": "APE",
       "name": "ApeCoin",
       "description": "ApeCoin found new expression in web3 through art, gaming, entertainment, and events. APE is a token made to support what’s next, controlled, and built on by the community. It will serve as a decentralized protocol layer for community-led initiatives that drive culture forward into the metaverse.",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "axelar",
@@ -7051,7 +6984,7 @@
       "coingeckoId": "maker",
       "verified": true,
       "price": {
-        "pool": "734",
+        "poolId": "734",
         "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
       },
       "transferMethods": [
@@ -7096,7 +7029,7 @@
           }
         }
       ],
-      "commonKey": "MKR",
+      "variantGroupKey": "MKR",
       "name": "Maker",
       "description": "Maker is a Decentralized Autonomous Organization that creates and insures the dai stablecoin on the Ethereum blockchain",
       "relatedAssets": [
@@ -7195,10 +7128,10 @@
           }
         }
       ],
-      "commonKey": "RAI",
+      "variantGroupKey": "RAI",
       "name": "Rai Reflex Index",
       "description": "RAI is a non-pegged, ETH-backed stable asset. It is useful as more 'stable' collateral for other DeFi protocols (compared to ETH or BTC) or as a stable asset with an embedded interest rate.",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "axelar",
@@ -7254,7 +7187,7 @@
       "coingeckoId": "shiba-inu",
       "verified": false,
       "price": {
-        "pool": "880",
+        "poolId": "880",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -7299,10 +7232,10 @@
           }
         }
       ],
-      "commonKey": "SHIB",
+      "variantGroupKey": "SHIB",
       "name": "Shiba Inu",
       "description": "SHIBA INU is a 100% decentralized community experiment with it claims that 1/2 the tokens have been sent to Vitalik and the other half were locked to a Uniswap pool and the keys burned.",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "axelar",
@@ -7358,9 +7291,8 @@
       },
       "coingeckoId": "kujira",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1161",
+        "poolId": "1161",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
@@ -7402,7 +7334,7 @@
           }
         }
       ],
-      "commonKey": "KUJI",
+      "variantGroupKey": "KUJI",
       "name": "Kujira",
       "description": "The native staking and governance token of the Kujira chain.\n\nA decentralized ecosystem for protocols, builders and web3 users seeking sustainable FinTech.",
       "twitterURL": "https://twitter.com/TeamKujira",
@@ -7433,9 +7365,8 @@
       },
       "coingeckoId": "tgrade",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "769",
+        "poolId": "769",
         "denom": "uosmo"
       },
       "categories": [
@@ -7472,7 +7403,7 @@
           }
         }
       ],
-      "commonKey": "TGD",
+      "variantGroupKey": "TGD",
       "name": "Tgrade",
       "description": "The native token of Tgrade",
       "relatedAssets": []
@@ -7489,7 +7420,7 @@
       "coingeckoId": "echelon",
       "verified": false,
       "price": {
-        "pool": "848",
+        "poolId": "848",
         "denom": "uosmo"
       },
       "categories": [
@@ -7531,7 +7462,7 @@
           }
         }
       ],
-      "commonKey": "ECH",
+      "variantGroupKey": "ECH",
       "name": "Echelon",
       "description": "Echelon - a scalable EVM on Cosmos, built on Proof-of-Stake with fast-finality that prioritizes interoperability and novel economics",
       "relatedAssets": []
@@ -7548,9 +7479,8 @@
       },
       "coingeckoId": "odin-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "777",
+        "poolId": "777",
         "denom": "uosmo"
       },
       "categories": [
@@ -7587,7 +7517,7 @@
           }
         }
       ],
-      "commonKey": "ODIN",
+      "variantGroupKey": "ODIN",
       "name": "Odin Protocol",
       "description": "Staking and governance token for ODIN Protocol",
       "relatedAssets": [
@@ -7612,9 +7542,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "787",
+        "poolId": "787",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -7648,7 +7577,7 @@
           }
         }
       ],
-      "commonKey": "GEO",
+      "variantGroupKey": "GEO",
       "name": "GEO",
       "description": "GEO token for ODIN Protocol",
       "relatedAssets": [
@@ -7673,9 +7602,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "805",
+        "poolId": "805",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -7709,7 +7637,7 @@
           }
         }
       ],
-      "commonKey": "O9W",
+      "variantGroupKey": "O9W",
       "name": "O9W",
       "description": "O9W token for ODIN Protocol",
       "relatedAssets": [
@@ -7734,9 +7662,8 @@
       },
       "coingeckoId": "lvn",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "772",
+        "poolId": "772",
         "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
       },
       "categories": [
@@ -7772,7 +7699,7 @@
           }
         }
       ],
-      "commonKey": "LVN",
+      "variantGroupKey": "LVN",
       "name": "LVN",
       "description": "ELEVENPARIS loyalty token on KiChain",
       "relatedAssets": [
@@ -7794,7 +7721,7 @@
       "coingeckoId": "moonbeam",
       "verified": false,
       "price": {
-        "pool": "825",
+        "poolId": "825",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -7852,7 +7779,7 @@
           }
         }
       ],
-      "commonKey": "GLMR",
+      "variantGroupKey": "GLMR",
       "name": "Moonbeam",
       "description": "Glimmer (GLMR) is the utility token of the Moonbeam Network, Moonbeam’s primary deployment on the Polkadot network that serves as a developer-friendly parachain.",
       "relatedAssets": [
@@ -7909,9 +7836,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "778",
+        "poolId": "778",
         "denom": "uosmo"
       },
       "categories": [
@@ -7948,7 +7874,7 @@
           }
         }
       ],
-      "commonKey": "GLTO",
+      "variantGroupKey": "GLTO",
       "name": "Gelotto",
       "description": "DeFi gaming platform built on Juno",
       "relatedAssets": [
@@ -8005,9 +7931,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "790",
+        "poolId": "790",
         "denom": "uosmo"
       },
       "categories": [
@@ -8044,7 +7969,7 @@
           }
         }
       ],
-      "commonKey": "GKEY",
+      "variantGroupKey": "GKEY",
       "name": "GKey",
       "description": "Gelotto Year 1 Grand Prize Token",
       "relatedAssets": [
@@ -8103,7 +8028,7 @@
       "coingeckoId": "crescent-network",
       "verified": true,
       "price": {
-        "pool": "786",
+        "poolId": "786",
         "denom": "uosmo"
       },
       "categories": [
@@ -8140,7 +8065,7 @@
           }
         }
       ],
-      "commonKey": "CRE",
+      "variantGroupKey": "CRE",
       "name": "Crescent",
       "description": "The native token of Crescent",
       "relatedAssets": []
@@ -8157,7 +8082,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "788",
+        "poolId": "788",
         "denom": "uosmo"
       },
       "categories": [
@@ -8194,10 +8119,11 @@
           }
         }
       ],
-      "commonKey": "LUMEN",
+      "variantGroupKey": "LUMEN",
       "name": "LumenX",
       "description": "The native token of LumenX Network",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -8212,9 +8138,8 @@
       },
       "coingeckoId": "oraichain-token",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "799",
+        "poolId": "799",
         "denom": "uosmo"
       },
       "categories": [
@@ -8251,7 +8176,7 @@
           }
         }
       ],
-      "commonKey": "ORAI",
+      "variantGroupKey": "ORAI",
       "name": "Oraichain",
       "description": "The native token of Oraichain",
       "relatedAssets": []
@@ -8268,9 +8193,8 @@
       },
       "coingeckoId": "cudos",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "796",
+        "poolId": "796",
         "denom": "uosmo"
       },
       "categories": [
@@ -8307,7 +8231,7 @@
           }
         }
       ],
-      "commonKey": "CUDOS",
+      "variantGroupKey": "CUDOS",
       "name": "Cudos",
       "description": "The native token of the Cudos blockchain",
       "relatedAssets": []
@@ -8325,7 +8249,7 @@
       "coingeckoId": "usdx",
       "verified": false,
       "price": {
-        "pool": "1390",
+        "poolId": "1390",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -8359,7 +8283,7 @@
           }
         }
       ],
-      "commonKey": "USDX",
+      "variantGroupKey": "USDX",
       "name": "Kava USDX",
       "description": "The native stablecoin of Kava",
       "relatedAssets": [
@@ -8417,9 +8341,8 @@
       },
       "coingeckoId": "agoric",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1104",
+        "poolId": "1104",
         "denom": "uosmo"
       },
       "categories": [
@@ -8456,7 +8379,7 @@
           }
         }
       ],
-      "commonKey": "BLD",
+      "variantGroupKey": "BLD",
       "name": "Agoric",
       "description": "BLD is the token used to secure the Agoric chain through staking and to backstop Inter Protocol.\n\nThe Agoric platform makes it safe and seamless to build decentralized apps using your existing JavaScript knowledge.",
       "twitterURL": "https://twitter.com/agoric",
@@ -8479,9 +8402,8 @@
       },
       "coingeckoId": "inter-stable-token",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1224",
+        "poolId": "1224",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "transferMethods": [
@@ -8515,7 +8437,7 @@
           }
         }
       ],
-      "commonKey": "IST",
+      "variantGroupKey": "IST",
       "name": "Inter Stable Token",
       "description": "IST is the stable token used by the Agoric chain for execution fees and commerce.",
       "relatedAssets": [
@@ -8538,7 +8460,7 @@
       "coingeckoId": "stakeeasy-juno-derivative",
       "verified": false,
       "price": {
-        "pool": "807",
+        "poolId": "807",
         "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
       },
       "categories": [
@@ -8575,7 +8497,7 @@
           }
         }
       ],
-      "commonKey": "SEJUNO",
+      "variantGroupKey": "SEJUNO",
       "name": "StakeEasy seJUNO",
       "description": "Staking derivative seJUNO for staked JUNO",
       "relatedAssets": [
@@ -8666,7 +8588,7 @@
           }
         }
       ],
-      "commonKey": "BJUNO",
+      "variantGroupKey": "BJUNO",
       "name": "StakeEasy bJUNO",
       "description": "Staking derivative bJUNO for staked JUNO",
       "relatedAssets": [
@@ -8724,9 +8646,8 @@
       },
       "coingeckoId": "stride",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "806",
+        "poolId": "806",
         "denom": "uosmo"
       },
       "categories": [
@@ -8763,7 +8684,7 @@
           }
         }
       ],
-      "commonKey": "STRD",
+      "variantGroupKey": "STRD",
       "name": "Stride",
       "description": "The native token of Stride\n\nStride is a blockchain that provides liquidity for staked tokens. Using Stride, you can earn both taking and DeFi yields across the Cosmos IBC ecosystem.",
       "twitterURL": "https://twitter.com/stride_zone",
@@ -8822,9 +8743,8 @@
       },
       "coingeckoId": "stride-staked-atom",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1136",
+        "poolId": "1136",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -8862,7 +8782,7 @@
           }
         }
       ],
-      "commonKey": "stATOM",
+      "variantGroupKey": "stATOM",
       "name": "Stride Staked ATOM",
       "description": "",
       "relatedAssets": [
@@ -8920,9 +8840,8 @@
       },
       "coingeckoId": "stride-staked-stars",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1397",
+        "poolId": "1397",
         "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
       },
       "categories": [
@@ -8960,7 +8879,7 @@
           }
         }
       ],
-      "commonKey": "stSTARS",
+      "variantGroupKey": "stSTARS",
       "name": "Stride Staked STARS",
       "description": "",
       "relatedAssets": [
@@ -9017,9 +8936,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "941",
+        "poolId": "941",
         "denom": "uosmo"
       },
       "categories": [
@@ -9056,7 +8974,7 @@
           }
         }
       ],
-      "commonKey": "SOLAR",
+      "variantGroupKey": "SOLAR",
       "name": "Solarbank DAO",
       "description": "Solarbank DAO Governance Token for speeding up the shift to renewable and green energy",
       "relatedAssets": [
@@ -9114,7 +9032,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "808",
+        "poolId": "808",
         "denom": "uosmo"
       },
       "categories": [
@@ -9151,7 +9069,7 @@
           }
         }
       ],
-      "commonKey": "SEASY",
+      "variantGroupKey": "SEASY",
       "name": "StakeEasy SEASY",
       "description": "StakeEasy governance token",
       "relatedAssets": [
@@ -9209,9 +9127,8 @@
       },
       "coingeckoId": "axelar",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "812",
+        "poolId": "812",
         "denom": "uosmo"
       },
       "categories": [
@@ -9248,7 +9165,7 @@
           }
         }
       ],
-      "commonKey": "AXL",
+      "variantGroupKey": "AXL",
       "name": "Axelar",
       "description": "The native token of Axelar\n\nAxelar delivers secure cross-chain communication for Web3. Our infrastructure enables dApp users to interact with any asset or application, on any chain, with one click.",
       "twitterURL": "https://twitter.com/axelarnetwork",
@@ -9307,9 +9224,8 @@
       },
       "coingeckoId": "rebus",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "813",
+        "poolId": "813",
         "denom": "uosmo"
       },
       "categories": [
@@ -9346,7 +9262,7 @@
           }
         }
       ],
-      "commonKey": "REBUS",
+      "variantGroupKey": "REBUS",
       "name": "Rebus",
       "description": "REBUS, the native coin of the Rebus chain.",
       "relatedAssets": []
@@ -9363,9 +9279,8 @@
       },
       "coingeckoId": "teritori",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "816",
+        "poolId": "816",
         "denom": "uosmo"
       },
       "categories": [
@@ -9402,7 +9317,7 @@
           }
         }
       ],
-      "commonKey": "TORI",
+      "variantGroupKey": "TORI",
       "name": "Teritori",
       "description": "The native token of Teritori",
       "relatedAssets": []
@@ -9419,9 +9334,8 @@
       },
       "coingeckoId": "stride-staked-juno",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "817",
+        "poolId": "817",
         "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
       },
       "categories": [
@@ -9459,7 +9373,7 @@
           }
         }
       ],
-      "commonKey": "stJUNO",
+      "variantGroupKey": "stJUNO",
       "name": "Stride Staked JUNO",
       "description": "",
       "relatedAssets": [
@@ -9517,9 +9431,8 @@
       },
       "coingeckoId": "stride-staked-osmo",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1252",
+        "poolId": "1252",
         "denom": "uosmo"
       },
       "categories": [
@@ -9557,7 +9470,7 @@
           }
         }
       ],
-      "commonKey": "stOSMO",
+      "variantGroupKey": "stOSMO",
       "name": "Stride Staked OSMO",
       "description": "",
       "relatedAssets": [
@@ -9646,7 +9559,7 @@
           }
         }
       ],
-      "commonKey": "MUSE",
+      "variantGroupKey": "MUSE",
       "name": "MuseDAO",
       "description": "The native token cw20 for MuseDAO on Juno Chain",
       "relatedAssets": [
@@ -9704,9 +9617,8 @@
       },
       "coingeckoId": "lambda",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "826",
+        "poolId": "826",
         "denom": "uosmo"
       },
       "categories": [
@@ -9743,7 +9655,7 @@
           }
         }
       ],
-      "commonKey": "LAMB",
+      "variantGroupKey": "LAMB",
       "name": "Lambda",
       "description": "The native token of Lambda",
       "relatedAssets": []
@@ -9761,7 +9673,7 @@
       "coingeckoId": "usk",
       "verified": true,
       "price": {
-        "pool": "827",
+        "poolId": "827",
         "denom": "uosmo"
       },
       "categories": [
@@ -9803,7 +9715,7 @@
           }
         }
       ],
-      "commonKey": "USK",
+      "variantGroupKey": "USK",
       "name": "USK",
       "description": "The native over-collateralized stablecoin from the Kujira chain.",
       "relatedAssets": [
@@ -9833,9 +9745,8 @@
       },
       "coingeckoId": "unification",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1240",
+        "poolId": "1240",
         "denom": "uosmo"
       },
       "categories": [
@@ -9872,7 +9783,7 @@
           }
         }
       ],
-      "commonKey": "FUND",
+      "variantGroupKey": "FUND",
       "name": "Unification",
       "description": "Staking and governance coin for the Unification Blockchain",
       "relatedAssets": []
@@ -9889,9 +9800,8 @@
       },
       "coingeckoId": "jackal-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "832",
+        "poolId": "832",
         "denom": "uosmo"
       },
       "categories": [
@@ -9928,7 +9838,7 @@
           }
         }
       ],
-      "commonKey": "JKL",
+      "variantGroupKey": "JKL",
       "name": "Jackal",
       "description": "The native staking and governance token of Jackal.",
       "relatedAssets": []
@@ -9946,7 +9856,7 @@
       "coingeckoId": "alter",
       "verified": false,
       "price": {
-        "pool": "845",
+        "poolId": "845",
         "denom": "uosmo"
       },
       "categories": [
@@ -9988,7 +9898,7 @@
           }
         }
       ],
-      "commonKey": "ALTER",
+      "variantGroupKey": "ALTER",
       "name": "Alter",
       "description": "The native token cw20 for Alter on Secret Network",
       "relatedAssets": [
@@ -10039,7 +9949,7 @@
       "coingeckoId": "buttcoin-2",
       "verified": false,
       "price": {
-        "pool": "985",
+        "poolId": "985",
         "denom": "uosmo"
       },
       "categories": [
@@ -10081,7 +9991,7 @@
           }
         }
       ],
-      "commonKey": "BUTT",
+      "variantGroupKey": "BUTT",
       "name": "Button",
       "description": "The native token cw20 for Button on Secret Network",
       "relatedAssets": [
@@ -10130,7 +10040,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "846",
+        "poolId": "846",
         "denom": "uosmo"
       },
       "categories": [
@@ -10171,7 +10081,7 @@
           }
         }
       ],
-      "commonKey": "SHD(old)",
+      "variantGroupKey": "SHD(old)",
       "name": "Shade (old)",
       "description": "The native token cw20 for Shade on Secret Network",
       "relatedAssets": [
@@ -10222,7 +10132,7 @@
       "coingeckoId": "sienna",
       "verified": false,
       "price": {
-        "pool": "853",
+        "poolId": "853",
         "denom": "uosmo"
       },
       "categories": [
@@ -10264,7 +10174,7 @@
           }
         }
       ],
-      "commonKey": "SIENNA",
+      "variantGroupKey": "SIENNA",
       "name": "SIENNA",
       "description": "The native token cw20 for SIENNA on Secret Network",
       "relatedAssets": [
@@ -10315,7 +10225,7 @@
       "coingeckoId": "stkd-scrt",
       "verified": false,
       "price": {
-        "pool": "854",
+        "poolId": "854",
         "denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A"
       },
       "categories": [
@@ -10357,7 +10267,7 @@
           }
         }
       ],
-      "commonKey": "stkd-SCRT",
+      "variantGroupKey": "stkd-SCRT",
       "name": "SCRT Staking Derivatives",
       "description": "The native token cw20 for SCRT Staking Derivatives on Secret Network",
       "relatedAssets": [
@@ -10407,9 +10317,8 @@
       },
       "coingeckoId": "bzedge",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "856",
+        "poolId": "856",
         "denom": "uosmo"
       },
       "categories": [
@@ -10446,7 +10355,7 @@
           }
         }
       ],
-      "commonKey": "BZE",
+      "variantGroupKey": "BZE",
       "name": "BeeZee",
       "description": "BeeZee native blockchain",
       "relatedAssets": []
@@ -10495,7 +10404,7 @@
           }
         }
       ],
-      "commonKey": "FURY",
+      "variantGroupKey": "FURY",
       "name": "Fanfury",
       "description": "The native token cw20 for Fanfury on Juno Chain",
       "relatedAssets": [
@@ -10553,9 +10462,8 @@
       },
       "coingeckoId": "arable-protocol",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "858",
+        "poolId": "858",
         "denom": "uosmo"
       },
       "categories": [
@@ -10592,7 +10500,7 @@
           }
         }
       ],
-      "commonKey": "ACRE",
+      "variantGroupKey": "ACRE",
       "name": "Acrechain",
       "description": "The native EVM, governance and staking token of the Acrechain",
       "relatedAssets": [
@@ -10618,9 +10526,8 @@
       },
       "coingeckoId": "composite",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1258",
+        "poolId": "1258",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -10659,7 +10566,7 @@
           }
         }
       ],
-      "commonKey": "CMST",
+      "variantGroupKey": "CMST",
       "name": "CMST",
       "description": "Stable Token of Harbor protocol on Comdex network",
       "relatedAssets": [
@@ -10686,7 +10593,7 @@
       "coingeckoId": "imv",
       "verified": false,
       "price": {
-        "pool": "866",
+        "poolId": "866",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -10723,7 +10630,7 @@
           }
         }
       ],
-      "commonKey": "IMV",
+      "variantGroupKey": "IMV",
       "name": "Imversed",
       "description": "The native EVM, governance and staking token of the Imversed",
       "relatedAssets": []
@@ -10739,9 +10646,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1329",
+        "poolId": "1329",
         "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
       },
       "categories": [
@@ -10778,7 +10684,7 @@
           }
         }
       ],
-      "commonKey": "MEDAS",
+      "variantGroupKey": "MEDAS",
       "name": "Medas Digital Network",
       "description": "The native token of Medas Digital Network",
       "relatedAssets": []
@@ -10795,9 +10701,8 @@
       },
       "coingeckoId": "posthuman",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1255",
+        "poolId": "1255",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -10834,7 +10739,7 @@
           }
         }
       ],
-      "commonKey": "PHMN",
+      "variantGroupKey": "PHMN",
       "name": "POSTHUMAN",
       "description": "The native token cw20 for PHMN on Juno Chain",
       "relatedAssets": [
@@ -10892,7 +10797,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "984",
+        "poolId": "984",
         "denom": "uosmo"
       },
       "categories": [
@@ -10934,7 +10839,7 @@
           }
         }
       ],
-      "commonKey": "AMBER",
+      "variantGroupKey": "AMBER",
       "name": "Amber",
       "description": "The native token cw20 for Amber on Secret Network",
       "relatedAssets": [
@@ -10984,9 +10889,8 @@
       },
       "coingeckoId": "onomy-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "882",
+        "poolId": "882",
         "denom": "uosmo"
       },
       "categories": [
@@ -11023,7 +10927,7 @@
           }
         }
       ],
-      "commonKey": "NOM",
+      "variantGroupKey": "NOM",
       "name": "Onomy",
       "description": "The native token of Onomy Protocol",
       "relatedAssets": []
@@ -11040,9 +10944,8 @@
       },
       "coingeckoId": "stkatom",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "886",
+        "poolId": "886",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "transferMethods": [
@@ -11076,7 +10979,7 @@
           }
         }
       ],
-      "commonKey": "stkATOM",
+      "variantGroupKey": "stkATOM",
       "name": "PSTAKE staked ATOM",
       "description": "PSTAKE Liquid-Staked ATOM",
       "relatedAssets": [
@@ -11134,9 +11037,8 @@
       },
       "coingeckoId": "",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "950",
+        "poolId": "950",
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
       },
       "categories": [
@@ -11173,7 +11075,7 @@
           }
         }
       ],
-      "commonKey": "DYS",
+      "variantGroupKey": "DYS",
       "name": "Dyson Protocol",
       "description": "The native staking and governance token of the Dyson Protocol",
       "relatedAssets": []
@@ -11191,7 +11093,7 @@
       "coingeckoId": "hopers-io",
       "verified": false,
       "price": {
-        "pool": "894",
+        "poolId": "894",
         "denom": "uosmo"
       },
       "categories": [
@@ -11228,7 +11130,7 @@
           }
         }
       ],
-      "commonKey": "HOPERS",
+      "variantGroupKey": "HOPERS",
       "name": "Hopers",
       "description": "The native token cw20 for Hopers on Juno Chain",
       "relatedAssets": [
@@ -11287,7 +11189,7 @@
       "coingeckoId": "arable-usd",
       "verified": false,
       "price": {
-        "pool": "895",
+        "poolId": "895",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "transferMethods": [
@@ -11327,7 +11229,7 @@
           }
         }
       ],
-      "commonKey": "arUSD",
+      "variantGroupKey": "arUSD",
       "name": "Arable USD",
       "description": "Overcollateralized stable coin for Arable derivatives v1",
       "relatedAssets": [
@@ -11353,9 +11255,8 @@
       },
       "coingeckoId": "planq",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1218",
+        "poolId": "1218",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -11397,7 +11298,7 @@
           }
         }
       ],
-      "commonKey": "PLQ",
+      "variantGroupKey": "PLQ",
       "name": "Planq",
       "description": "The native EVM, governance and staking token of the Planq Network",
       "relatedAssets": []
@@ -11414,9 +11315,8 @@
       },
       "coingeckoId": "fantom",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "900",
+        "poolId": "900",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -11475,7 +11375,7 @@
           }
         }
       ],
-      "commonKey": "FTM",
+      "variantGroupKey": "FTM",
       "name": "Fantom",
       "description": "Fantom's native utility token — FTM — powers the entire Fantom blockchain ecosystem. FTM tokens are used for staking, governance, payments, and fees on the network.",
       "relatedAssets": [
@@ -11534,7 +11434,7 @@
       "coingeckoId": "canto",
       "verified": true,
       "price": {
-        "pool": "901",
+        "poolId": "901",
         "denom": "uosmo"
       },
       "categories": [
@@ -11571,7 +11471,7 @@
           }
         }
       ],
-      "commonKey": "CANTO",
+      "variantGroupKey": "CANTO",
       "name": "Canto",
       "description": "Canto is a Layer-1 blockchain built to deliver on the promise of DeFi",
       "relatedAssets": []
@@ -11587,9 +11487,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "903",
+        "poolId": "903",
         "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
       },
       "categories": [
@@ -11627,7 +11526,7 @@
           }
         }
       ],
-      "commonKey": "qSTARS",
+      "variantGroupKey": "qSTARS",
       "name": "Quicksilver Liquid Staked STARS",
       "description": "Quicksilver Liquid Staked STARS",
       "sortWith": {
@@ -11689,9 +11588,8 @@
       },
       "coingeckoId": "wynd",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "902",
+        "poolId": "902",
         "denom": "uosmo"
       },
       "categories": [
@@ -11728,7 +11626,7 @@
           }
         }
       ],
-      "commonKey": "WYND",
+      "variantGroupKey": "WYND",
       "name": "Wynd DAO Governance Token",
       "description": "WYND DAO Governance Token",
       "relatedAssets": [
@@ -11785,9 +11683,8 @@
       },
       "coingeckoId": "usd-coin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "938",
+        "poolId": "938",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -11850,7 +11747,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin (Polygon)",
       "description": "USDC is a fully collateralized US Dollar stablecoin developed by CENTRE, the open source project with Circle being the first of several forthcoming issuers.",
       "relatedAssets": [
@@ -11907,9 +11804,8 @@
       },
       "coingeckoId": "usd-coin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "938",
+        "poolId": "938",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -11972,7 +11868,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin (Avalanche)",
       "description": "USDC is a fully collateralized US Dollar stablecoin developed by CENTRE, the open source project with Circle being the first of several forthcoming issuers.",
       "relatedAssets": [
@@ -12030,9 +11926,8 @@
       },
       "coingeckoId": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1099",
+        "poolId": "1099",
         "denom": "uosmo"
       },
       "categories": [
@@ -12069,7 +11964,7 @@
           }
         }
       ],
-      "commonKey": "MARS",
+      "variantGroupKey": "MARS",
       "name": "Mars Hub",
       "description": "Mars protocol token\n\nLend, borrow and earn with an autonomous credit protocol in the Cosmos universe. Open to all, closed to none.",
       "twitterURL": "https://twitter.com/mars_protocol",
@@ -12086,9 +11981,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/cnto.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "909",
+        "poolId": "909",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "transferMethods": [
@@ -12128,7 +12022,7 @@
           }
         }
       ],
-      "commonKey": "CNTO",
+      "variantGroupKey": "CNTO",
       "name": "Ciento Token",
       "description": "Ciento Exchange Token",
       "relatedAssets": [
@@ -12155,7 +12049,7 @@
       "coingeckoId": "stride-staked-luna",
       "verified": true,
       "price": {
-        "pool": "913",
+        "poolId": "913",
         "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
       },
       "categories": [
@@ -12193,7 +12087,7 @@
           }
         }
       ],
-      "commonKey": "stLUNA",
+      "variantGroupKey": "stLUNA",
       "name": "Stride Staked LUNA",
       "description": "",
       "relatedAssets": [
@@ -12251,9 +12145,8 @@
       },
       "coingeckoId": "stride-staked-evmos",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "922",
+        "poolId": "922",
         "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
       },
       "categories": [
@@ -12291,7 +12184,7 @@
           }
         }
       ],
-      "commonKey": "stEVMOS",
+      "variantGroupKey": "stEVMOS",
       "name": "Stride Staked EVMOS",
       "description": "",
       "relatedAssets": [
@@ -12348,9 +12241,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "924",
+        "poolId": "924",
         "denom": "uosmo"
       },
       "categories": [
@@ -12387,7 +12279,7 @@
           }
         }
       ],
-      "commonKey": "NRIDE",
+      "variantGroupKey": "NRIDE",
       "name": "nRide Token",
       "description": "nRide Token",
       "relatedAssets": [
@@ -12445,9 +12337,8 @@
       },
       "coingeckoId": "",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "935",
+        "poolId": "935",
         "denom": "uosmo"
       },
       "categories": [
@@ -12484,7 +12375,7 @@
           }
         }
       ],
-      "commonKey": "EBL",
+      "variantGroupKey": "EBL",
       "name": "8ball",
       "description": "The native staking token of 8ball.",
       "relatedAssets": []
@@ -12500,9 +12391,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qatom.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "944",
+        "poolId": "944",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -12540,7 +12430,7 @@
           }
         }
       ],
-      "commonKey": "qATOM",
+      "variantGroupKey": "qATOM",
       "name": "Quicksilver Liquid Staked ATOM",
       "description": "Quicksilver Liquid Staked ATOM",
       "sortWith": {
@@ -12603,7 +12493,7 @@
       "coingeckoId": "harbor-2",
       "verified": false,
       "price": {
-        "pool": "967",
+        "poolId": "967",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -12637,7 +12527,7 @@
           }
         }
       ],
-      "commonKey": "HARBOR",
+      "variantGroupKey": "HARBOR",
       "name": "Harbor",
       "description": "Governance Token of Harbor protocol on Comdex network",
       "relatedAssets": [
@@ -12662,9 +12552,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qregen.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "948",
+        "poolId": "948",
         "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
       },
       "categories": [
@@ -12702,7 +12591,7 @@
           }
         }
       ],
-      "commonKey": "qREGEN",
+      "variantGroupKey": "qREGEN",
       "name": "Quicksilver Liquid Staked Regen",
       "description": "Quicksilver Liquid Staked REGEN",
       "sortWith": {
@@ -12763,7 +12652,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "949",
+        "poolId": "949",
         "denom": "uosmo"
       },
       "categories": [
@@ -12799,7 +12688,7 @@
           }
         }
       ],
-      "commonKey": "FOX",
+      "variantGroupKey": "FOX",
       "name": "Juno Fox",
       "description": "Inspired by Bonk. A community project to celebrate the settlers of JunoNetwork.",
       "relatedAssets": [
@@ -12856,9 +12745,8 @@
       },
       "coingeckoId": "quicksilver",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "952",
+        "poolId": "952",
         "denom": "uosmo"
       },
       "categories": [
@@ -12894,7 +12782,7 @@
           }
         }
       ],
-      "commonKey": "QCK",
+      "variantGroupKey": "QCK",
       "name": "Quicksilver",
       "description": "QCK - native token of Quicksilver\n\nLiquid Stake your Cosmos assets with your preferred validator and receive liquid staked assets (qASSETs) that you can use for swapping, pooling, lending, and more, all while your original stake earns staking APY from securing the network.",
       "twitterURL": "https://twitter.com/quicksilverzone",
@@ -12953,7 +12841,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "954",
+        "poolId": "954",
         "denom": "uosmo"
       },
       "categories": [
@@ -12990,10 +12878,11 @@
           }
         }
       ],
-      "commonKey": "ARKH",
+      "variantGroupKey": "ARKH",
       "name": "Arkhadian",
       "description": "The native token of Arkhadian",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": []
     },
     {
@@ -13007,9 +12896,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "956",
+        "poolId": "956",
         "denom": "uosmo"
       },
       "categories": [
@@ -13047,7 +12935,7 @@
           }
         }
       ],
-      "commonKey": "qOSMO",
+      "variantGroupKey": "qOSMO",
       "name": "Quicksilver Liquid Staked OSMO",
       "description": "Quicksilver Liquid Staked OSMO",
       "sortWith": {
@@ -13108,9 +12996,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/frnz.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1012",
+        "poolId": "1012",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "transferMethods": [
@@ -13144,7 +13031,7 @@
           }
         }
       ],
-      "commonKey": "FRNZ",
+      "variantGroupKey": "FRNZ",
       "name": "Frienzies",
       "description": "Frienzies are an IBC token redeemable exclusively for a physical asset issued by the Noble entity.",
       "relatedAssets": [
@@ -13202,9 +13089,8 @@
       },
       "coingeckoId": "white-whale",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1318",
+        "poolId": "1318",
         "denom": "uosmo"
       },
       "categories": [
@@ -13241,7 +13127,7 @@
           }
         }
       ],
-      "commonKey": "WHALE",
+      "variantGroupKey": "WHALE",
       "name": "Migaloo",
       "description": "The native token of Migaloo Chain",
       "relatedAssets": [
@@ -13270,7 +13156,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "959",
+        "poolId": "959",
         "denom": "uosmo"
       },
       "categories": [
@@ -13306,7 +13192,7 @@
           }
         }
       ],
-      "commonKey": "GRDN",
+      "variantGroupKey": "GRDN",
       "name": "Guardian",
       "description": "Evmos Guardians governance token.",
       "relatedAssets": [
@@ -13364,7 +13250,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "961",
+        "poolId": "961",
         "denom": "uosmo"
       },
       "categories": [
@@ -13401,7 +13287,7 @@
           }
         }
       ],
-      "commonKey": "MNPU",
+      "variantGroupKey": "MNPU",
       "name": "Mini Punks",
       "description": "Mini Punks Token",
       "relatedAssets": [
@@ -13458,7 +13344,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "962",
+        "poolId": "962",
         "denom": "uosmo"
       },
       "categories": [
@@ -13494,7 +13380,7 @@
           }
         }
       ],
-      "commonKey": "SHIBAC",
+      "variantGroupKey": "SHIBAC",
       "name": "ShibaCosmos",
       "description": "Shiba Cosmos",
       "relatedAssets": [
@@ -13551,9 +13437,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sikoba.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "964",
+        "poolId": "964",
         "denom": "uosmo"
       },
       "categories": [
@@ -13590,7 +13475,7 @@
           }
         }
       ],
-      "commonKey": "SKOJ",
+      "variantGroupKey": "SKOJ",
       "name": "Sikoba Token",
       "description": "Sikoba Governance Token",
       "relatedAssets": [
@@ -13648,9 +13533,8 @@
       },
       "coingeckoId": "toucan-protocol-nature-carbon-tonne",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "972",
+        "poolId": "972",
         "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
       },
       "transferMethods": [
@@ -13684,7 +13568,7 @@
           }
         }
       ],
-      "commonKey": "NCT",
+      "variantGroupKey": "NCT",
       "name": "Nature Carbon Ton",
       "description": "Nature Carbon Ton (NCT) is a carbon token standard backed 1:1 by carbon credits issued by Verra, a global leader in the voluntary carbon market. NCT credits on Regen Network have been tokenized by Toucan.earth.",
       "relatedAssets": [
@@ -13741,7 +13625,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "974",
+        "poolId": "974",
         "denom": "uosmo"
       },
       "categories": [
@@ -13777,7 +13661,7 @@
           }
         }
       ],
-      "commonKey": "CLST",
+      "variantGroupKey": "CLST",
       "name": "Celestims",
       "description": "Celestims",
       "relatedAssets": [
@@ -13834,7 +13718,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "975",
+        "poolId": "975",
         "denom": "uosmo"
       },
       "categories": [
@@ -13870,7 +13754,7 @@
           }
         }
       ],
-      "commonKey": "OSDOGE",
+      "variantGroupKey": "OSDOGE",
       "name": "Osmosis Doge",
       "description": "The First Doge on Osmosis",
       "relatedAssets": [
@@ -13927,7 +13811,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "977",
+        "poolId": "977",
         "denom": "uosmo"
       },
       "categories": [
@@ -13963,7 +13847,7 @@
           }
         }
       ],
-      "commonKey": "APEMOS",
+      "variantGroupKey": "APEMOS",
       "name": "Apemos",
       "description": "Apemos",
       "relatedAssets": [
@@ -14020,7 +13904,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "969",
+        "poolId": "969",
         "denom": "uosmo"
       },
       "categories": [
@@ -14056,7 +13940,7 @@
           }
         }
       ],
-      "commonKey": "INVDRS",
+      "variantGroupKey": "INVDRS",
       "name": "Invaders",
       "description": "Evmos Guardians' Invaders DAO token.",
       "relatedAssets": [
@@ -14113,7 +13997,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "978",
+        "poolId": "978",
         "denom": "uosmo"
       },
       "categories": [
@@ -14149,7 +14033,7 @@
           }
         }
       ],
-      "commonKey": "DOGA",
+      "variantGroupKey": "DOGA",
       "name": "Doge Apr",
       "description": "Doge Apr",
       "relatedAssets": [
@@ -14206,7 +14090,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "981",
+        "poolId": "981",
         "denom": "uosmo"
       },
       "categories": [
@@ -14242,7 +14126,7 @@
           }
         }
       ],
-      "commonKey": "CATMOS",
+      "variantGroupKey": "CATMOS",
       "name": "Catmos",
       "description": "Catmos",
       "relatedAssets": [
@@ -14299,7 +14183,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "982",
+        "poolId": "982",
         "denom": "uosmo"
       },
       "categories": [
@@ -14335,7 +14219,7 @@
           }
         }
       ],
-      "commonKey": "SUMMIT",
+      "variantGroupKey": "SUMMIT",
       "name": "Summit",
       "description": "Social Impact DAO providing showers, meals, and vehicles to the homeless",
       "relatedAssets": [
@@ -14393,9 +14277,8 @@
       },
       "coingeckoId": "omniflix-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "992",
+        "poolId": "992",
         "denom": "uosmo"
       },
       "categories": [
@@ -14432,7 +14315,7 @@
           }
         }
       ],
-      "commonKey": "FLIX",
+      "variantGroupKey": "FLIX",
       "name": "OmniFlix",
       "description": "The native staking token of OmniFlix Hub.\n\nDecentralized media and network layer for Creators & Sovereign Communities powered by NFTs and related distribution protocols.",
       "twitterURL": "https://twitter.com/OmniFlixNetwork",
@@ -14449,7 +14332,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "993",
+        "poolId": "993",
         "denom": "uosmo"
       },
       "categories": [
@@ -14485,7 +14368,7 @@
           }
         }
       ],
-      "commonKey": "SPACER",
+      "variantGroupKey": "SPACER",
       "name": "Spacer",
       "description": "Spacer",
       "relatedAssets": [
@@ -14542,7 +14425,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1009",
+        "poolId": "1009",
         "denom": "uosmo"
       },
       "categories": [
@@ -14578,7 +14461,7 @@
           }
         }
       ],
-      "commonKey": "LIGHT",
+      "variantGroupKey": "LIGHT",
       "name": "LIGHT",
       "description": "Light: LumenX community DAO treasury token",
       "relatedAssets": [
@@ -14636,9 +14519,8 @@
       },
       "coingeckoId": "silk-bcec1136-561c-4706-a42c-8b67d0d7f7d2",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1358",
+        "poolId": "1358",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -14680,7 +14562,7 @@
           }
         }
       ],
-      "commonKey": "SILK",
+      "variantGroupKey": "SILK",
       "name": "Silk",
       "description": "The native token cw20 for Silk on Secret Network",
       "relatedAssets": [
@@ -14729,7 +14611,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1000",
+        "poolId": "1000",
         "denom": "uosmo"
       },
       "categories": [
@@ -14765,7 +14647,7 @@
           }
         }
       ],
-      "commonKey": "MILE",
+      "variantGroupKey": "MILE",
       "name": "Mille",
       "description": "Mille: the 1000th token on osmosis",
       "relatedAssets": [
@@ -14822,7 +14704,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "997",
+        "poolId": "997",
         "denom": "uosmo"
       },
       "categories": [
@@ -14858,7 +14740,7 @@
           }
         }
       ],
-      "commonKey": "MANNA",
+      "variantGroupKey": "MANNA",
       "name": "Manna",
       "description": "Social Impact DAO dedicated to combatting food insecurity and malnutrition",
       "relatedAssets": [
@@ -14917,7 +14799,7 @@
       "coingeckoId": "filecoin",
       "verified": true,
       "price": {
-        "pool": "1006",
+        "poolId": "1006",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -14977,7 +14859,7 @@
           }
         }
       ],
-      "commonKey": "FIL",
+      "variantGroupKey": "FIL",
       "name": "Filecoin",
       "description": "Filecoin is a decentralized storage network designed to turn cloud storage into an algorithmic market. The network facilitates open markets for storing and retrieving data, where users pay to store their files on storage miners. Filecoin is built on top of the InterPlanetary File System (IPFS), a peer-to-peer storage network. Filecoin aims to store data in a decentralized manner, unlike traditional cloud storage providers.\n\nParticipants in the Filecoin network are incentivized to act honestly and store as much data as possible because they earn the Filecoin cryptocurrency (FIL) in exchange for their storage services. This setup ensures the integrity and accessibility of data stored. Filecoin's model allows for a variety of storage options, including long-term archival storage and more rapid retrieval services, making it a versatile solution for decentralized data storage. The project, developed by Protocol Labs, also focuses on ensuring that data is stored reliably and efficiently.",
       "relatedAssets": [
@@ -15034,7 +14916,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1003",
+        "poolId": "1003",
         "denom": "uosmo"
       },
       "categories": [
@@ -15070,7 +14952,7 @@
           }
         }
       ],
-      "commonKey": "VOID",
+      "variantGroupKey": "VOID",
       "name": "Void",
       "description": "Void",
       "relatedAssets": [
@@ -15128,9 +15010,8 @@
       },
       "coingeckoId": "shade-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1170",
+        "poolId": "1170",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
@@ -15167,7 +15048,7 @@
           }
         }
       ],
-      "commonKey": "SHD",
+      "variantGroupKey": "SHD",
       "name": "Shade",
       "description": "The native token cw20 for Shade on Secret Network",
       "relatedAssets": [
@@ -15217,9 +15098,8 @@
       },
       "coingeckoId": "bluzelle",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1007",
+        "poolId": "1007",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -15256,7 +15136,7 @@
           }
         }
       ],
-      "commonKey": "BLZ",
+      "variantGroupKey": "BLZ",
       "name": "Bluzelle",
       "description": "The native token of Bluzelle",
       "relatedAssets": []
@@ -15273,9 +15153,8 @@
       },
       "coingeckoId": "arbitrum",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1011",
+        "poolId": "1011",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -15322,7 +15201,7 @@
           }
         }
       ],
-      "commonKey": "ARB",
+      "variantGroupKey": "ARB",
       "name": "Arbitrum",
       "description": "Native token of Arbitrum",
       "relatedAssets": [
@@ -15378,9 +15257,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/silica.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1023",
+        "poolId": "1023",
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
       },
       "categories": [
@@ -15416,7 +15294,7 @@
           }
         }
       ],
-      "commonKey": "SLCA",
+      "variantGroupKey": "SLCA",
       "name": "Silica",
       "description": "Silica",
       "relatedAssets": [
@@ -15473,7 +15351,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1016",
+        "poolId": "1016",
         "denom": "uosmo"
       },
       "categories": [
@@ -15509,7 +15387,7 @@
           }
         }
       ],
-      "commonKey": "PEPEC",
+      "variantGroupKey": "PEPEC",
       "name": "Pepec",
       "description": "Pepec",
       "relatedAssets": [
@@ -15568,7 +15446,7 @@
       "coingeckoId": "pepe",
       "verified": true,
       "price": {
-        "pool": "1018",
+        "poolId": "1018",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -15615,7 +15493,7 @@
           }
         }
       ],
-      "commonKey": "PEPE",
+      "variantGroupKey": "PEPE",
       "name": "Pepe",
       "description": "",
       "relatedAssets": [
@@ -15672,9 +15550,8 @@
       },
       "coingeckoId": "ibc-index",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1254",
+        "poolId": "1254",
         "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B"
       },
       "categories": [
@@ -15737,7 +15614,7 @@
       "coingeckoId": "coinbase-wrapped-staked-eth",
       "verified": true,
       "price": {
-        "pool": "1030",
+        "poolId": "1030",
         "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
       },
       "categories": [
@@ -15786,7 +15663,7 @@
           }
         }
       ],
-      "commonKey": "cbETH",
+      "variantGroupKey": "cbETH",
       "name": "Coinbase Wrapped Staked ETH",
       "description": "Coinbase Wrapped Staked ETH (“cbETH”) is a utility token and liquid representation of ETH staked through Coinbase. cbETH gives customers the option to sell, transfer, or otherwise use their staked ETH in dapps while it remains locked by the Ethereum protocol.",
       "relatedAssets": [
@@ -15844,7 +15721,7 @@
       "coingeckoId": "rocket-pool-eth",
       "verified": true,
       "price": {
-        "pool": "1030",
+        "poolId": "1030",
         "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
       },
       "categories": [
@@ -15893,7 +15770,7 @@
           }
         }
       ],
-      "commonKey": "rETH",
+      "variantGroupKey": "rETH",
       "name": "Rocket Pool Ether",
       "description": "Rocket Pool is a decentralised Ethereum Proof of Stake pool.",
       "relatedAssets": [
@@ -15951,7 +15828,7 @@
       "coingeckoId": "staked-frax-ether",
       "verified": true,
       "price": {
-        "pool": "1030",
+        "poolId": "1030",
         "denom": "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C"
       },
       "categories": [
@@ -16013,7 +15890,7 @@
           }
         }
       ],
-      "commonKey": "frxETH",
+      "variantGroupKey": "frxETH",
       "name": "Staked Frax Ether",
       "description": "sfrxETH is the version of frxETH which accrues staking yield. All profit generated from Frax Ether validators is distributed to sfrxETH holders. By exchanging frxETH for sfrxETH, one become's eligible for staking yield, which is redeemed upon converting sfrxETH back to frxETH.",
       "relatedAssets": [
@@ -16070,7 +15947,7 @@
       },
       "verified": true,
       "price": {
-        "pool": "1024",
+        "poolId": "1024",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
@@ -16131,7 +16008,7 @@
           }
         }
       ],
-      "commonKey": "stETH",
+      "variantGroupKey": "stETH",
       "name": "Wrapped Lido Staked Ether (Axelar)",
       "description": "",
       "sortWith": {
@@ -16193,9 +16070,8 @@
       },
       "coingeckoId": "gitopia",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1036",
+        "poolId": "1036",
         "denom": "uosmo"
       },
       "categories": [
@@ -16232,7 +16108,7 @@
           }
         }
       ],
-      "commonKey": "LORE",
+      "variantGroupKey": "LORE",
       "name": "Gitopia",
       "description": "The native token of Gitopia\n\nGitopia is the next-generation Code Collaboration Platform fuelled by a decentralized network and interactive token economy. It is designed to optimize the open-source software development process through collaboration, transparency, and incentivization.",
       "twitterURL": "https://twitter.com/gitopiaDAO",
@@ -16250,7 +16126,7 @@
       "coingeckoId": "lion-dao",
       "verified": true,
       "price": {
-        "pool": "1043",
+        "poolId": "1043",
         "denom": "uosmo"
       },
       "categories": [
@@ -16292,7 +16168,7 @@
           }
         }
       ],
-      "commonKey": "ROAR",
+      "variantGroupKey": "ROAR",
       "name": "Lion DAO",
       "description": "Lion DAO is a community DAO that lives on the Terra blockchain with the mission to reactivate the LUNAtic community and showcase Terra protocols & tooling",
       "relatedAssets": [
@@ -16350,9 +16226,8 @@
       },
       "coingeckoId": "stride-staked-umee",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1035",
+        "poolId": "1035",
         "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
       },
       "categories": [
@@ -16390,7 +16265,7 @@
           }
         }
       ],
-      "commonKey": "stUMEE",
+      "variantGroupKey": "stUMEE",
       "name": "Stride Staked UMEE",
       "description": "",
       "relatedAssets": [
@@ -16447,9 +16322,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1107",
+        "poolId": "1107",
         "denom": "uosmo"
       },
       "categories": [
@@ -16512,9 +16386,8 @@
       },
       "coingeckoId": "nolus",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1041",
+        "poolId": "1041",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -16551,7 +16424,7 @@
           }
         }
       ],
-      "commonKey": "NLS",
+      "variantGroupKey": "NLS",
       "name": "Nolus",
       "description": "The native token of Nolus chain\n\nElevate your game with up to 3x equity. Dive into a world of minimized risks and unlock the full potential of your assets.",
       "twitterURL": "https://twitter.com/NolusProtocol",
@@ -16568,7 +16441,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1072",
+        "poolId": "1072",
         "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
       },
       "categories": [
@@ -16610,7 +16483,7 @@
           }
         }
       ],
-      "commonKey": "CUB",
+      "variantGroupKey": "CUB",
       "name": "Lion Cub DAO",
       "description": "Lion Cub DAO is a useless meme community DAO on Terra",
       "relatedAssets": [
@@ -16667,7 +16540,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1073",
+        "poolId": "1073",
         "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
       },
       "categories": [
@@ -16709,7 +16582,7 @@
           }
         }
       ],
-      "commonKey": "BLUE",
+      "variantGroupKey": "BLUE",
       "name": "BLUE CUB DAO",
       "description": "BLUE CUB DAO is a community DAO on Terra",
       "relatedAssets": [
@@ -16767,10 +16640,9 @@
       },
       "coingeckoId": "neutron-3",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1388",
-        "denom": "uosmo"
+        "poolId": "1324",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
         "defi"
@@ -16806,7 +16678,7 @@
           }
         }
       ],
-      "commonKey": "NTRN",
+      "variantGroupKey": "NTRN",
       "name": "Neutron",
       "description": "The native token of Neutron chain.\n\nThe most secure CosmWasm platform in Cosmos, Neutron lets smart-contracts leverage bleeding-edge Interchain technology with minimal overhead.",
       "twitterURL": "https://twitter.com/Neutron_org",
@@ -16864,7 +16736,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1028",
+        "poolId": "1028",
         "denom": "uosmo"
       },
       "categories": [
@@ -16900,7 +16772,7 @@
           }
         }
       ],
-      "commonKey": "CASA",
+      "variantGroupKey": "CASA",
       "name": "Casa",
       "description": "An innovative DAO dedicated to housing the most vulnerable",
       "relatedAssets": [
@@ -16957,9 +16829,8 @@
       },
       "coingeckoId": "picasso",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1057",
+        "poolId": "1057",
         "denom": "uosmo"
       },
       "categories": [
@@ -17011,7 +16882,7 @@
           }
         }
       ],
-      "commonKey": "PICA",
+      "variantGroupKey": "PICA",
       "name": "Composable",
       "description": "The native staking and governance token of Composable.\n\nComposable is the base layer connecting L1s and L2s. We are scaling IBC to other ecosystems, pushing the boundaries of trust-minimized interoperability. We abstract the cross-chain experience for users, delivering seamless chain-agnostic execution of user intentions.",
       "twitterURL": "https://twitter.com/ComposableFin",
@@ -17069,9 +16940,8 @@
       },
       "coingeckoId": "kusama",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1151",
+        "poolId": "1151",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -17130,7 +17000,7 @@
           }
         }
       ],
-      "commonKey": "KSM",
+      "variantGroupKey": "KSM",
       "name": "Kusama",
       "description": "The native fee, governance, staking, and bonding token of the Polkadot platform.",
       "relatedAssets": [
@@ -17187,9 +17057,8 @@
       },
       "coingeckoId": "polkadot",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1145",
+        "poolId": "1145",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -17258,7 +17127,7 @@
           }
         }
       ],
-      "commonKey": "DOT",
+      "variantGroupKey": "DOT",
       "name": "Polkadot",
       "description": "The native fee, governance, staking, and bonding token of the Polkadot platform.",
       "relatedAssets": [
@@ -17315,9 +17184,8 @@
       },
       "coingeckoId": "quasar-2",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1314",
+        "poolId": "1314",
         "denom": "uosmo"
       },
       "categories": [
@@ -17353,7 +17221,7 @@
           }
         }
       ],
-      "commonKey": "QSR",
+      "variantGroupKey": "QSR",
       "name": "Quasar",
       "description": "The native token of Quasar\n\nQuasar is the first decentralized asset management (D.A.M.) platform enabled by IBC. A secure, permissionless, composable, and diversified interchain DeFi experience is finally here.",
       "twitterURL": "https://twitter.com/QuasarFi",
@@ -17371,9 +17239,8 @@
       },
       "coingeckoId": "archway",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1298",
+        "poolId": "1298",
         "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
       },
       "categories": [
@@ -17410,7 +17277,7 @@
           }
         }
       ],
-      "commonKey": "ARCH",
+      "variantGroupKey": "ARCH",
       "name": "Archway",
       "description": "The native token of Archway network\n\nAn incentivized L1 blockchain that allows developers to capture the value their dapps create, enabling sustainable economic models.",
       "twitterURL": "https://twitter.com/archwayHQ",
@@ -17426,9 +17293,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/empowerchain/images/mpwr.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1065",
+        "poolId": "1065",
         "denom": "uosmo"
       },
       "categories": [
@@ -17469,7 +17335,7 @@
           }
         }
       ],
-      "commonKey": "MPWR",
+      "variantGroupKey": "MPWR",
       "name": "EmpowerChain",
       "description": "The native staking and governance token of Empower.",
       "relatedAssets": []
@@ -17485,7 +17351,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1071",
+        "poolId": "1071",
         "denom": "uosmo"
       },
       "categories": [
@@ -17521,7 +17387,7 @@
           }
         }
       ],
-      "commonKey": "WATR",
+      "variantGroupKey": "WATR",
       "name": "WATR",
       "description": "A revolutionary DAO created to bring clean drinking water to men, women, and children worldwide. We hope you join us on our journey!",
       "relatedAssets": [
@@ -17579,9 +17445,8 @@
       },
       "coingeckoId": "kyve-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1075",
+        "poolId": "1075",
         "denom": "uosmo"
       },
       "categories": [
@@ -17618,7 +17483,7 @@
           }
         }
       ],
-      "commonKey": "KYVE",
+      "variantGroupKey": "KYVE",
       "name": "KYVE",
       "description": "The native utility token of the KYVE network.\n\nRevolutionizing data reliability in the Web3 space, KYVE Network provides fast and easy tooling for data validation, immutability, and retrieval, ensuring trustless data for seamless scalability and eliminating data risks and roadblocks.",
       "twitterURL": "https://twitter.com/KYVENetwork",
@@ -17635,9 +17500,8 @@
       },
       "coingeckoId": "tether",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1220",
+        "poolId": "1220",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -17687,7 +17551,7 @@
           }
         }
       ],
-      "commonKey": "USDT",
+      "variantGroupKey": "USDT",
       "name": "Tether USD",
       "description": "Tether gives you the joint benefits of open blockchain technology and traditional currency by converting your cash into a stable digital currency equivalent.",
       "relatedAssets": [
@@ -17744,7 +17608,7 @@
       },
       "verified": true,
       "price": {
-        "pool": "1067",
+        "poolId": "1067",
         "denom": "uosmo"
       },
       "categories": [
@@ -17807,9 +17671,8 @@
       },
       "coingeckoId": "sei-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1114",
+        "poolId": "1114",
         "denom": "uosmo"
       },
       "categories": [
@@ -17851,7 +17714,7 @@
           }
         }
       ],
-      "commonKey": "SEI",
+      "variantGroupKey": "SEI",
       "name": "Sei",
       "description": "The native staking token of Sei.\n\nSei is the fastest Layer 1 blockchain, designed to scale with the industry.",
       "twitterURL": "https://twitter.com/SeiNetwork",
@@ -17873,9 +17736,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1087",
+        "poolId": "1087",
         "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
       },
       "categories": [
@@ -17913,7 +17775,7 @@
           }
         }
       ],
-      "commonKey": "qSOMM",
+      "variantGroupKey": "qSOMM",
       "name": "Quicksilver Liquid Staked SOMM",
       "description": "Quicksilver Liquid Staked SOMM",
       "sortWith": {
@@ -17974,9 +17836,8 @@
       },
       "coingeckoId": "passage",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1137",
+        "poolId": "1137",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -18012,7 +17873,7 @@
           }
         }
       ],
-      "commonKey": "PASG",
+      "variantGroupKey": "PASG",
       "name": "Passage",
       "description": "The native staking and governance token of the Passage chain.",
       "relatedAssets": []
@@ -18029,9 +17890,8 @@
       },
       "coingeckoId": "stride-staked-sommelier",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1120",
+        "poolId": "1120",
         "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
       },
       "categories": [
@@ -18069,7 +17929,7 @@
           }
         }
       ],
-      "commonKey": "stSOMM",
+      "variantGroupKey": "stSOMM",
       "name": "Stride Staked SOMM",
       "description": "",
       "relatedAssets": [
@@ -18126,9 +17986,8 @@
       },
       "coingeckoId": "solana",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1294",
+        "poolId": "1294",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "transferMethods": [
@@ -18187,7 +18046,7 @@
           }
         }
       ],
-      "commonKey": "SOL",
+      "variantGroupKey": "SOL",
       "name": "Solana",
       "description": "Solana (SOL) is the native asset of the Solana blockchain.",
       "relatedAssets": [
@@ -18244,9 +18103,8 @@
       },
       "coingeckoId": "bonk",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1129",
+        "poolId": "1129",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
@@ -18298,7 +18156,7 @@
           }
         }
       ],
-      "commonKey": "BONK",
+      "variantGroupKey": "BONK",
       "name": "Bonk",
       "description": "The Official Bonk Inu token",
       "relatedAssets": [
@@ -18354,9 +18212,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.hole.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1131",
+        "poolId": "1131",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "categories": [
@@ -18412,7 +18269,7 @@
           }
         }
       ],
-      "commonKey": "USDT",
+      "variantGroupKey": "USDT",
       "name": "Tether USD (Wormhole)",
       "description": "Tether USD (Wormhole), USDT, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/8iuAc6DSeLvi2JDUtwJxLytsZT8R19itXebZsNReLLNi",
       "relatedAssets": [
@@ -18470,7 +18327,7 @@
       "coingeckoId": "sui",
       "verified": true,
       "price": {
-        "pool": "1127",
+        "poolId": "1127",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "transferMethods": [
@@ -18519,7 +18376,7 @@
           }
         }
       ],
-      "commonKey": "SUI",
+      "variantGroupKey": "SUI",
       "name": "Sui",
       "description": "Sui’s native asset is called SUI.",
       "relatedAssets": [
@@ -18577,7 +18434,7 @@
       "coingeckoId": "aptos",
       "verified": true,
       "price": {
-        "pool": "1125",
+        "poolId": "1125",
         "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB"
       },
       "transferMethods": [
@@ -18626,7 +18483,7 @@
           }
         }
       ],
-      "commonKey": "APT",
+      "variantGroupKey": "APT",
       "name": "Aptos Coin",
       "description": "Aptos token (APT) is the Aptos blockchain native token used for paying network and transaction fees.",
       "relatedAssets": [
@@ -18684,9 +18541,8 @@
       },
       "coingeckoId": "mantadao",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1215",
+        "poolId": "1215",
         "denom": "uosmo"
       },
       "categories": [
@@ -18728,7 +18584,7 @@
           }
         }
       ],
-      "commonKey": "MNTA",
+      "variantGroupKey": "MNTA",
       "name": "MantaDAO",
       "description": "MantaDAO Governance Token",
       "relatedAssets": [
@@ -18757,7 +18613,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1143",
+        "poolId": "1143",
         "denom": "uosmo"
       },
       "categories": [
@@ -18793,7 +18649,7 @@
           }
         }
       ],
-      "commonKey": "DGL",
+      "variantGroupKey": "DGL",
       "name": "Licorice",
       "description": "",
       "relatedAssets": [
@@ -18849,9 +18705,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdc.hole.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1216",
+        "poolId": "1216",
         "denom": "uosmo"
       },
       "categories": [
@@ -18907,7 +18762,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin (Wormhole)",
       "description": "USD Coin (Wormhole), USDC, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt",
       "relatedAssets": [
@@ -18963,9 +18818,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/weth.hole.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1214",
+        "poolId": "1214",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
@@ -19033,7 +18887,7 @@
           }
         }
       ],
-      "commonKey": "ETH",
+      "variantGroupKey": "ETH",
       "name": "Wrapped Ether (Wormhole)",
       "description": "Wrapped Ether (Wormhole), WETH, factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/5BWqpR48Lubd55szM5i62zK7TFkddckhbT48yy6mNbDp",
       "relatedAssets": [
@@ -19090,9 +18944,8 @@
       },
       "coingeckoId": "usd-coin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1223",
+        "poolId": "1223",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "transferMethods": [
@@ -19138,7 +18991,7 @@
           }
         }
       ],
-      "commonKey": "USDC",
+      "variantGroupKey": "USDC",
       "name": "USD Coin",
       "description": "USDC is a fully collateralized US Dollar stablecoin developed by CENTRE, the open source project with Circle being the first of several forthcoming issuers.",
       "relatedAssets": [
@@ -19196,9 +19049,8 @@
       },
       "coingeckoId": "yieldeth-sommelier",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1213",
+        "poolId": "1213",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
@@ -19249,7 +19101,7 @@
           }
         }
       ],
-      "commonKey": "YieldETH",
+      "variantGroupKey": "YieldETH",
       "name": "Real Yield ETH",
       "description": "Maximize ETH yield through leveraged staking across Aave, Compound and Morpho and liquidity provision of ETH liquid staking tokens on Uniswap V3.",
       "relatedAssets": [
@@ -19307,9 +19159,8 @@
       },
       "coingeckoId": "xpla",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1173",
+        "poolId": "1173",
         "denom": "uosmo"
       },
       "categories": [
@@ -19351,7 +19202,7 @@
           }
         }
       ],
-      "commonKey": "XPLA",
+      "variantGroupKey": "XPLA",
       "name": "XPLA",
       "description": "The native staking token of XPLA.",
       "relatedAssets": []
@@ -19368,7 +19219,7 @@
       "coingeckoId": "",
       "verified": false,
       "price": {
-        "pool": "1210",
+        "poolId": "1210",
         "denom": "uosmo"
       },
       "categories": [
@@ -19404,7 +19255,7 @@
           }
         }
       ],
-      "commonKey": "OIN",
+      "variantGroupKey": "OIN",
       "name": "OIN STORE OF VALUE",
       "description": "OIN Token ($OIN) is a groundbreaking digital asset developed on the $SEI Blockchain. It transcends being merely a cryptocurrency; $OIN stands as a robust store of value, symbolizing the future of decentralized finance and its potential to reshape the crypto landscape.",
       "relatedAssets": [
@@ -19425,9 +19276,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/neok.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1121",
+        "poolId": "1121",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -19466,7 +19316,7 @@
           }
         }
       ],
-      "commonKey": "NEOK",
+      "variantGroupKey": "NEOK",
       "name": "Neokingdom DAO",
       "description": "The token of Neokingdom DAO.",
       "relatedAssets": [
@@ -19524,9 +19374,8 @@
       },
       "coingeckoId": "realio-network",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1180",
+        "poolId": "1180",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -19568,7 +19417,7 @@
           }
         }
       ],
-      "commonKey": "RIO",
+      "variantGroupKey": "RIO",
       "name": "Realio Network",
       "description": "The native currency of the Realio Network.",
       "relatedAssets": []
@@ -19584,9 +19433,8 @@
       },
       "coingeckoId": "collateralized-debt-token",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1268",
+        "poolId": "1268",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -19650,9 +19498,8 @@
       },
       "coingeckoId": "membrane",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1225",
+        "poolId": "1225",
         "denom": "uosmo"
       },
       "categories": [
@@ -19715,9 +19562,8 @@
       },
       "coingeckoId": "six-sigma",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1233",
+        "poolId": "1233",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -19754,7 +19600,7 @@
           }
         }
       ],
-      "commonKey": "SGE",
+      "variantGroupKey": "SGE",
       "name": "SGE",
       "description": "The native token of SGE Network",
       "relatedAssets": []
@@ -19770,9 +19616,8 @@
       },
       "coingeckoId": "stafi",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1230",
+        "poolId": "1230",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -19808,7 +19653,7 @@
           }
         }
       ],
-      "commonKey": "FIS",
+      "variantGroupKey": "FIS",
       "name": "StaFi Hub",
       "description": "The native staking and governance token of the StaFi Hub.",
       "relatedAssets": [
@@ -19865,9 +19710,8 @@
       },
       "coingeckoId": "",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1227",
+        "poolId": "1227",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -19904,7 +19748,7 @@
           }
         }
       ],
-      "commonKey": "rATOM",
+      "variantGroupKey": "rATOM",
       "name": "rATOM",
       "description": "A liquid staking representation of staked ATOMs",
       "relatedAssets": [
@@ -19962,9 +19806,8 @@
       },
       "coingeckoId": "",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1234",
+        "poolId": "1234",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -20001,7 +19844,7 @@
           }
         }
       ],
-      "commonKey": "STRDST",
+      "variantGroupKey": "STRDST",
       "name": "Stardust STRDST",
       "description": "The native token of ohhNFT.",
       "relatedAssets": [
@@ -20057,9 +19900,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/doravota/images/dora.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1239",
+        "poolId": "1239",
         "denom": "uosmo"
       },
       "categories": [
@@ -20095,7 +19937,7 @@
           }
         }
       ],
-      "commonKey": "DORA",
+      "variantGroupKey": "DORA",
       "name": "Dora Vota",
       "description": "The native staking and governance token of the Theta testnet version of the Dora Vota.",
       "relatedAssets": []
@@ -20112,9 +19954,8 @@
       },
       "coingeckoId": "coreum",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1244",
+        "poolId": "1244",
         "denom": "uosmo"
       },
       "categories": [
@@ -20151,7 +19992,7 @@
           }
         }
       ],
-      "commonKey": "COREUM",
+      "variantGroupKey": "COREUM",
       "name": "Coreum",
       "description": "The native token of Coreum",
       "relatedAssets": []
@@ -20168,9 +20009,8 @@
       },
       "coingeckoId": "celestia",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1247",
+        "poolId": "1247",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -20207,7 +20047,7 @@
           }
         }
       ],
-      "commonKey": "TIA",
+      "variantGroupKey": "TIA",
       "name": "Celestia",
       "description": "Celestia is a modular data availability network that securely scales with the number of users, making it easy for anyone to launch their own blockchain.",
       "twitterURL": "https://twitter.com/CelestiaOrg",
@@ -20265,9 +20105,8 @@
       },
       "coingeckoId": "dydx",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1246",
+        "poolId": "1246",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -20304,7 +20143,7 @@
           }
         }
       ],
-      "commonKey": "DYDX",
+      "variantGroupKey": "DYDX",
       "name": "dYdX Protocol",
       "description": "The native staking token of dYdX Protocol.\n\nOur goal is to build open source code that can power a first class product and trading experience.",
       "twitterURL": "https://twitter.com/dYdX",
@@ -20363,9 +20202,8 @@
       },
       "coingeckoId": "fx-coin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1241",
+        "poolId": "1241",
         "denom": "uosmo"
       },
       "categories": [
@@ -20407,7 +20245,7 @@
           }
         }
       ],
-      "commonKey": "FX",
+      "variantGroupKey": "FX",
       "name": "f(x)Core",
       "description": "The native staking token of the Function X",
       "relatedAssets": []
@@ -20423,9 +20261,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nbtc.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1416",
+        "poolId": "1416",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "transferMethods": [
@@ -20469,7 +20306,7 @@
           }
         }
       ],
-      "commonKey": "BTC",
+      "variantGroupKey": "BTC",
       "name": "Nomic Bitcoin",
       "description": "Bitcoin. On Cosmos.",
       "relatedAssets": [
@@ -20526,9 +20363,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nois/images/nois.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1305",
+        "poolId": "1305",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -20565,7 +20401,7 @@
           }
         }
       ],
-      "commonKey": "NOIS",
+      "variantGroupKey": "NOIS",
       "name": "Nois",
       "description": "The native token of Nois",
       "relatedAssets": []
@@ -20580,9 +20416,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqosmo.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1267",
+        "poolId": "1267",
         "denom": "uosmo"
       },
       "categories": [
@@ -20677,7 +20512,7 @@
           }
         }
       ],
-      "commonKey": "NSTK",
+      "variantGroupKey": "NSTK",
       "name": "Unstake Fi",
       "description": "The Revenue & Governance token of Unstake.fi",
       "relatedAssets": [
@@ -20707,9 +20542,8 @@
       },
       "coingeckoId": "",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1288",
+        "poolId": "1288",
         "denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B"
       },
       "categories": [
@@ -20746,7 +20580,7 @@
           }
         }
       ],
-      "commonKey": "BRNCH",
+      "variantGroupKey": "BRNCH",
       "name": "Branch",
       "description": "ohhNFT LP token.",
       "relatedAssets": [
@@ -20803,9 +20637,8 @@
       },
       "coingeckoId": "wrapped-steth",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1431",
+        "poolId": "1292",
         "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
       },
       "categories": [
@@ -20866,7 +20699,7 @@
           }
         }
       ],
-      "commonKey": "stETH",
+      "variantGroupKey": "stETH",
       "name": "Wrapped Lido Staked Ether",
       "description": "wstETH is a wrapped version of stETH. As some DeFi protocols require a constant balance mechanism for tokens, wstETH keeps your balance of stETH fixed and uses an underlying share system to reflect your earned staking rewards.",
       "relatedAssets": [
@@ -20922,9 +20755,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqatom.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1299",
+        "poolId": "1299",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
       },
       "categories": [
@@ -20990,7 +20822,7 @@
       ],
       "name": "BTC Squared",
       "description": "Margined Power Token sqBTC",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "osmosis",
@@ -21044,9 +20876,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qwoyn/images/qwoyn.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1295",
+        "poolId": "1295",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -21082,7 +20913,7 @@
           }
         }
       ],
-      "commonKey": "QWOYN",
+      "variantGroupKey": "QWOYN",
       "name": "Qwoyn",
       "description": "QWOYN is the native governance token for Qwoyn Network",
       "relatedAssets": []
@@ -21098,9 +20929,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/hydrogen.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1326",
+        "poolId": "1326",
         "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
       },
       "transferMethods": [
@@ -21134,7 +20964,7 @@
           }
         }
       ],
-      "commonKey": "HYDROGEN",
+      "variantGroupKey": "HYDROGEN",
       "name": "Bostrom Hydrogen",
       "description": "The liquid staking token of Bostrom",
       "relatedAssets": [
@@ -21168,8 +20998,8 @@
       },
       "verified": false,
       "price": {
-        "pool": "1310",
-        "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20"
+        "poolId": "986",
+        "denom": "uosmo"
       },
       "transferMethods": [
         {
@@ -21202,7 +21032,7 @@
           }
         }
       ],
-      "commonKey": "TOCYB",
+      "variantGroupKey": "TOCYB",
       "name": "Bostrom Tocyb",
       "description": "The staking token of Cyber",
       "relatedAssets": [
@@ -21235,9 +21065,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/volt.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1304",
+        "poolId": "1304",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -21271,7 +21100,7 @@
           }
         }
       ],
-      "commonKey": "V",
+      "variantGroupKey": "V",
       "name": "Bostrom Volt",
       "description": "The resource token of Bostrom",
       "relatedAssets": [
@@ -21304,9 +21133,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/ampere.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1303",
+        "poolId": "1303",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -21340,7 +21168,7 @@
           }
         }
       ],
-      "commonKey": "A",
+      "variantGroupKey": "A",
       "name": "Bostrom Ampere",
       "description": "The resource token of Bostrom",
       "relatedAssets": [
@@ -21374,9 +21202,8 @@
       },
       "coingeckoId": "source",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1311",
+        "poolId": "1311",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -21413,7 +21240,7 @@
           }
         }
       ],
-      "commonKey": "SOURCE",
+      "variantGroupKey": "SOURCE",
       "name": "Source",
       "description": "The native token of SOURCE Chain",
       "relatedAssets": []
@@ -21429,9 +21256,8 @@
       },
       "coingeckoId": "pyth-network",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1315",
+        "poolId": "1315",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "transferMethods": [
@@ -21480,7 +21306,7 @@
           }
         }
       ],
-      "commonKey": "PYTH",
+      "variantGroupKey": "PYTH",
       "name": "Pyth Network",
       "description": "Pyth is a protocol that allows market participants to publish pricing information on-chain for others to use. The protocol is an interaction between three parties:\n-Publishers submit pricing information to Pyth's oracle program. Pyth has multiple data publishers for every product to improve the accuracy and robustness of the system.\n-Pyth's oracle program combines publishers' data to produce a single aggregate price and confidence interval.\nConsumers read the price information produced by the oracle program.\n\nPyth's oracle program runs simultaneously on both Solana mainnet and Pythnet. Each instance of the program is responsible for its own set of price feeds. Solana Price Feeds are available for use by Solana protocols. In this case, since the oracle program itself runs on Solana, the resulting prices are immediately available to consumers without requiring any additional work. Pythnet Price Feeds are available on 12+ blockchains. The prices constructed on Pythnet are transferred cross-chain to reach consumers on these blockchains.\n\nIn both cases, the critical component of the system is the oracle program that combines the data from each individual publisher. This program maintains a number of different Solana accounts that list the products on Pyth and their current price data. Publishers publish their price and confidence by interacting with the oracle program on every slot. The program stores this information in its accounts. The first price update in a slot additionally triggers price aggregation, which combines the price data from the previous slot into a single aggregate price and confidence interval. This aggregate price is written to the Solana account where it is readable by other on-chain programs and available for transmission to other blockchains.",
       "relatedAssets": [
@@ -21538,9 +21364,8 @@
       },
       "coingeckoId": "pstake-staked-osmo",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1323",
+        "poolId": "1323",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -21574,7 +21399,7 @@
           }
         }
       ],
-      "commonKey": "stkOSMO",
+      "variantGroupKey": "stkOSMO",
       "name": "PSTAKE staked OSMO",
       "description": "PSTAKE Liquid-Staked OSMO",
       "relatedAssets": [
@@ -21632,10 +21457,9 @@
       },
       "coingeckoId": "levana-protocol",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1325",
-        "denom": "uosmo"
+        "poolId": "1337",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
         "defi"
@@ -21695,9 +21519,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/puppyhuahua_logo.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1332",
+        "poolId": "1332",
         "denom": "uosmo"
       },
       "categories": [
@@ -21733,10 +21556,11 @@
           }
         }
       ],
-      "commonKey": "PUPPY",
+      "variantGroupKey": "PUPPY",
       "name": "Puppy",
       "description": "Puppy",
       "unstable": true,
+      "disabled": true,
       "relatedAssets": [
         {
           "chainName": "chihuahua",
@@ -21763,9 +21587,8 @@
       },
       "coingeckoId": "newt",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1334",
+        "poolId": "1334",
         "denom": "uosmo"
       },
       "categories": [
@@ -21801,7 +21624,7 @@
           }
         }
       ],
-      "commonKey": "NEWT",
+      "variantGroupKey": "NEWT",
       "name": "Newt",
       "description": "The cutest NEWT token on Neutron chain.",
       "relatedAssets": [
@@ -21859,9 +21682,8 @@
       },
       "coingeckoId": "milkyway-staked-tia",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1335",
+        "poolId": "1335",
         "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"
       },
       "categories": [
@@ -21923,9 +21745,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/ash.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1360",
+        "poolId": "1360",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -21961,7 +21782,7 @@
           }
         }
       ],
-      "commonKey": "ASH",
+      "variantGroupKey": "ASH",
       "name": "ASH",
       "description": "ASH",
       "relatedAssets": [
@@ -21990,9 +21811,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rac.svg"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1359",
+        "poolId": "1359",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -22029,7 +21849,7 @@
           }
         }
       ],
-      "commonKey": "RAC",
+      "variantGroupKey": "RAC",
       "name": "RAC",
       "description": "RAC",
       "relatedAssets": [
@@ -22057,9 +21877,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/guppy.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1342",
+        "poolId": "1342",
         "denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963"
       },
       "categories": [
@@ -22095,7 +21914,7 @@
           }
         }
       ],
-      "commonKey": "GUPPY",
+      "variantGroupKey": "GUPPY",
       "name": "GUPPY",
       "description": "GUPPY",
       "relatedAssets": [
@@ -22125,9 +21944,8 @@
       },
       "coingeckoId": "islamic-coin",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1343",
+        "poolId": "1343",
         "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
       },
       "categories": [
@@ -22164,7 +21982,7 @@
           }
         }
       ],
-      "commonKey": "ISLM",
+      "variantGroupKey": "ISLM",
       "name": "Haqq Network",
       "description": "The native EVM, governance and staking token of the Haqq Network",
       "relatedAssets": []
@@ -22213,10 +22031,10 @@
           }
         }
       ],
-      "commonKey": "AUTISM",
+      "variantGroupKey": "AUTISM",
       "name": "Autism",
       "description": "$AUTISM exists to celebrate autism as a superior biological tech stack for a changing world",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "injective",
@@ -22272,9 +22090,8 @@
       },
       "coingeckoId": "page",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1344",
+        "poolId": "1344",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -22327,7 +22144,7 @@
           }
         }
       ],
-      "commonKey": "PAGE",
+      "variantGroupKey": "PAGE",
       "name": "Page",
       "description": "The PAGE token is used for actions in the PageDAO NFT literary ecosystem and for DAO governance.",
       "relatedAssets": [
@@ -22385,7 +22202,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1394",
+        "poolId": "1394",
         "denom": "uosmo"
       },
       "transferMethods": [
@@ -22431,10 +22248,10 @@
           }
         }
       ],
-      "commonKey": "PURSE",
+      "variantGroupKey": "PURSE",
       "name": "PURSE Token (Function X)",
       "description": "PURSE Token",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": []
     },
     {
@@ -22448,13 +22265,12 @@
       },
       "coingeckoId": "dog-wif-nuchucks",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1384",
+        "poolId": "1384",
         "denom": "uosmo"
       },
       "categories": [
-        "new_asset"
+        "meme"
       ],
       "transferMethods": [
         {
@@ -22492,7 +22308,7 @@
           }
         }
       ],
-      "commonKey": "NINJA",
+      "variantGroupKey": "NINJA",
       "name": "Dog wif nunchucks",
       "description": "The first meme coin on Injective. It’s a dog, but he has nunchucks",
       "listingDate": "2024-01-24T10:58:00.000Z",
@@ -22549,9 +22365,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/kleomedes.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1421",
+        "poolId": "1421",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -22587,7 +22402,7 @@
           }
         }
       ],
-      "commonKey": "KLEO",
+      "variantGroupKey": "KLEO",
       "name": "Kleomedes",
       "description": "Kleomedes Token",
       "relatedAssets": [
@@ -22677,10 +22492,10 @@
           }
         }
       ],
-      "commonKey": "NYX",
+      "variantGroupKey": "NYX",
       "name": "Nym",
       "description": "NYX Token (NYX) is the Nym Network's native token.",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "nyx",
@@ -22699,9 +22514,8 @@
       },
       "coingeckoId": "nym",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1361",
+        "poolId": "1361",
         "denom": "uosmo"
       },
       "categories": [
@@ -22737,7 +22551,7 @@
           }
         }
       ],
-      "commonKey": "NYM",
+      "variantGroupKey": "NYM",
       "name": "NYM",
       "description": "NYM Token (NYM) is the Nym Network's native utility token, used as the primary means to incentivize mixnet node operators.",
       "relatedAssets": [
@@ -22757,9 +22571,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/baddog.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1420",
+        "poolId": "1420",
         "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
       },
       "categories": [
@@ -22795,7 +22608,7 @@
           }
         }
       ],
-      "commonKey": "BADDOG",
+      "variantGroupKey": "BADDOG",
       "name": "Chihuahuawifhat",
       "description": "has a hat",
       "relatedAssets": [
@@ -22824,7 +22637,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1391",
+        "poolId": "1391",
         "denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt"
       },
       "categories": [
@@ -22860,7 +22673,7 @@
           }
         }
       ],
-      "commonKey": "CIRCUS",
+      "variantGroupKey": "CIRCUS",
       "name": "AtomEconomicZone69JaeKwonInu",
       "description": "clownmaxxed store of value",
       "relatedAssets": [
@@ -22917,7 +22730,7 @@
       },
       "verified": false,
       "price": {
-        "pool": "1377",
+        "poolId": "1377",
         "denom": "uosmo"
       },
       "categories": [
@@ -22953,7 +22766,7 @@
           }
         }
       ],
-      "commonKey": "JAPE",
+      "variantGroupKey": "JAPE",
       "name": "Junø Apes",
       "description": "Governance and utility token for the Junø Apes NFT platform on Juno",
       "listingDate": "2024-01-17T17:14:00.000Z",
@@ -23010,9 +22823,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/woof.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1365",
+        "poolId": "1365",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -23048,7 +22860,7 @@
           }
         }
       ],
-      "commonKey": "WOOF",
+      "variantGroupKey": "WOOF",
       "name": "WOOF",
       "description": "Woof",
       "listingDate": "2024-01-17T17:41:00.000Z",
@@ -23079,9 +22891,8 @@
       },
       "coingeckoId": "",
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1403",
+        "poolId": "1403",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -23118,7 +22929,7 @@
           }
         }
       ],
-      "commonKey": "SNEAKY",
+      "variantGroupKey": "SNEAKY",
       "name": "Sneaky Productions",
       "description": "The native coin of Sneaky Productions.",
       "listingDate": "2024-01-22T12:50:00.000Z",
@@ -23176,9 +22987,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1422",
+        "poolId": "1422",
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
       },
       "categories": [
@@ -23209,7 +23019,7 @@
           }
         }
       ],
-      "commonKey": "BTC",
+      "variantGroupKey": "BTC",
       "name": "Wrapped Bitcoin",
       "description": "",
       "listingDate": "2024-01-29T09:57:00.000Z",
@@ -23266,9 +23076,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/bad.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1381",
+        "poolId": "1381",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -23304,7 +23113,7 @@
           }
         }
       ],
-      "commonKey": "BAD",
+      "variantGroupKey": "BAD",
       "name": "Badcoin",
       "description": "Baddest coin on Cosmos",
       "listingDate": "2024-01-15T14:42:00.000Z",
@@ -23361,9 +23170,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sgnl.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1392",
+        "poolId": "1392",
         "denom": "uosmo"
       },
       "categories": [
@@ -23399,7 +23207,7 @@
           }
         }
       ],
-      "commonKey": "SGNL",
+      "variantGroupKey": "SGNL",
       "name": "Signal",
       "description": "Signal Art and Gaming on Juno",
       "listingDate": "2024-01-18T15:42:00.000Z",
@@ -23456,9 +23264,8 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wosmo.png"
       },
       "verified": false,
-      "apiInclude": true,
       "price": {
-        "pool": "1408",
+        "poolId": "1408",
         "denom": "uosmo"
       },
       "categories": [
@@ -23520,9 +23327,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqtia.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1378",
+        "poolId": "1378",
         "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"
       },
       "categories": [
@@ -23584,9 +23390,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/apollo.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1410",
+        "poolId": "1410",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -23622,7 +23427,7 @@
           }
         }
       ],
-      "commonKey": "APOLLO",
+      "variantGroupKey": "APOLLO",
       "name": "Apollo DAO",
       "description": "The deflationary utility token of the Apollo DAO project",
       "listingDate": "2024-01-22T21:05:00.000Z",
@@ -23680,9 +23485,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdydx.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1423",
+        "poolId": "1423",
         "denom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C"
       },
       "categories": [
@@ -23721,7 +23525,7 @@
           }
         }
       ],
-      "commonKey": "stDYDX",
+      "variantGroupKey": "stDYDX",
       "name": "Stride Staked DYDX",
       "description": "Stride's liquid staked DYDX",
       "sortWith": {
@@ -23783,9 +23587,8 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/sttia.svg"
       },
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1428",
+        "poolId": "1428",
         "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877"
       },
       "categories": [
@@ -23824,7 +23627,7 @@
           }
         }
       ],
-      "commonKey": "stTIA",
+      "variantGroupKey": "stTIA",
       "name": "Stride Staked TIA",
       "description": "Stride's liquid staked TIA",
       "sortWith": {
@@ -23945,11 +23748,11 @@
           }
         }
       ],
-      "commonKey": "GLTO",
+      "variantGroupKey": "GLTO",
       "name": "Gelotto (Injective)",
       "description": "GLTO-ERC20 on injective",
       "twitterURL": "https://twitter.com/Gelotto2",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "juno",
@@ -24005,9 +23808,8 @@
       },
       "coingeckoId": "dymension",
       "verified": true,
-      "apiInclude": true,
       "price": {
-        "pool": "1450",
+        "poolId": "1450",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
@@ -24049,7 +23851,7 @@
           }
         }
       ],
-      "commonKey": "DYM",
+      "variantGroupKey": "DYM",
       "name": "Dymension Hub",
       "description": "The native governance and staking token of the Dymension Hub\n\nDymension is a network of easily deployable and lightning fast modular blockchains called RollApps.",
       "twitterURL": "https://twitter.com/dymension",
@@ -24071,7 +23873,7 @@
       ],
       "name": "RAPTR",
       "description": "Rapture insurance is the first ever P2P insurance platform on $OSMO. Get rewarded to take care of peoples loved ones after the Rapture.",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "osmosis",
@@ -24165,11 +23967,11 @@
           }
         }
       ],
-      "commonKey": "ASTRO",
+      "variantGroupKey": "ASTRO",
       "name": "Astroport",
       "description": "Astroport is a neutral marketplace where anyone, from anywhere in the galaxy, can dock to trade their wares.",
       "twitterURL": "https://twitter.com/astroport_fi",
-      "unlisted": true,
+      "preview": true,
       "relatedAssets": [
         {
           "chainName": "terra2",
@@ -24223,12 +24025,18 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/badkid.png"
       },
       "verified": false,
+      "price": {
+        "poolId": "1470",
+        "denom": "uosmo"
+      },
       "categories": [
-        "meme"
+        "meme",
+        "new_asset"
       ],
       "name": "BADKID",
       "description": "A clan of 11y bad kids crafting chaos on the Cosmos eco. One bad memecoin to rule them all  $BADKID. Airdropped to Badkids NFT holders and $STARS stakers. It's so bad, your wallet's throwing a tantrum for it.",
-      "unlisted": true,
+      "tooltipMessage": "This asset is NOT affiliated with the Bad Kids NFT collection.",
+      "listingDate": "2024-02-13T21:32:00.000Z",
       "relatedAssets": [
         {
           "chainName": "osmosis",

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -22992,7 +22992,7 @@
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
       },
       "categories": [
-        "new_asset"
+        "meme"
       ],
       "counterparty": [
         {
@@ -23491,8 +23491,7 @@
       },
       "categories": [
         "liquid_staking",
-        "defi",
-        "new_asset"
+        "defi"
       ],
       "transferMethods": [
         {
@@ -23593,8 +23592,7 @@
       },
       "categories": [
         "liquid_staking",
-        "defi",
-        "new_asset"
+        "defi"
       ],
       "transferMethods": [
         {
@@ -23813,7 +23811,7 @@
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
-        "new_asset"
+        "defi"
       ],
       "transferMethods": [
         {
@@ -24030,8 +24028,7 @@
         "denom": "uosmo"
       },
       "categories": [
-        "meme",
-        "new_asset"
+        "meme"
       ],
       "name": "BADKID",
       "description": "A clan of 11y bad kids crafting chaos on the Cosmos eco. One bad memecoin to rule them all  $BADKID. Airdropped to Badkids NFT holders and $STARS stakers. It's so bad, your wallet's throwing a tantrum for it.",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2657,7 +2657,8 @@
       "listing_date_time_utc": "2024-02-13T21:32:00Z",
       "categories": [
         "meme"
-      ]
+      ],
+      "tooltip_message": "This asset is NOT affiliated with the Bad Kids NFT collection."
     }
   ]
 }

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -52,9 +52,17 @@
           "type": "boolean",
           "description": "Whether the asset can reliably be transferred to or from Osmosis."
         },
+        "osmosis_disabled": {
+          "type": "boolean",
+          "description": "Whether the asset Deposit and Withdraw functions are disabled on Osmosis."
+        },
         "osmosis_unlisted": {
           "type": "boolean",
           "description": "Whether the asset should be temporarily unlisted on the Osmosis Zone app."
+        },
+        "tooltip_message": {
+          "type": "boolean",
+          "description": "A custom on-hover tooltip message descirbing the asset on the Osmosis Zone app."
         },
         "listing_date_time_utc": {
           "type": "string",


### PR DESCRIPTION
## Description

Update several FE Assetlist Properties:

- `apiInclude` removed--not needed by FE
- `pool` renamed to `poolId`--clearer to FE
- `new_asset` category removed--can be determined by FE based on listing_date
- `disabled` added--signals that the Deposit and Withdraw functions should be disabled (for dead chains and such)
  -   meaning 'unstable' now should merely indicate a consistent hard-coded warning message like "Warning: There may be issues, delays, or confusion when transferring this asset."
- `tooltipMessage` added--used to add custom tooltip text associated with each asset.
- `unlisted` renamed to `preview`--more clear to FE
- `commonKey` renamed to `variantGroupKey`--more clear to FE
