### PR TITLE
Update Script to derive Decimals better

### DIFF
--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -39,6 +39,26 @@ function addArrayItem(item, array) {
   }
 }
 
+function getAssetDecimals(asset) {
+
+  let decimals;
+
+  //--Get Decimals--
+  asset.denom_units.forEach((unit) => {
+    if (asset.display === unit.denom || unit.aliases?.includes(asset.display)) {
+      decimals = unit.exponent;
+      return;
+    }
+  });
+
+  if (decimals === undefined) {
+    console.log("Error: $" + asset.symbol + " missing decimals!");
+  }
+
+  return decimals ?? 0;
+
+}
+
 const generateAssets = async (
   chainName,
   zoneConfig,
@@ -113,11 +133,13 @@ const generateAssets = async (
     generated_asset.symbol = reference_asset.symbol;
 
     //--Get Decimals--
-    asset.denom_units.forEach((unit) => {
-      if (unit.denom === asset.display) {
-        generated_asset.decimals = unit.exponent;
-      }
-    });
+    //asset.denom_units.forEach((unit) => {
+      //if (unit.denom === asset.display) {
+        //generated_asset.decimals = unit.exponent;
+      //}
+    //});
+
+    generated_asset.decimals = getAssetDecimals(asset);
 
     //--Get Logos--
     generated_asset.logo_URIs = reference_asset.logo_URIs;

--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -43,13 +43,21 @@ function getAssetDecimals(asset) {
 
   let decimals;
 
-  //--Get Decimals--
   asset.denom_units.forEach((unit) => {
-    if (asset.display === unit.denom || unit.aliases?.includes(asset.display)) {
+    if (asset.display === unit.denom) {
       decimals = unit.exponent;
       return;
     }
   });
+
+  if (decimals === undefined) {
+    asset.denom_units.forEach((unit) => {
+      if (unit.aliases?.includes(asset.display)) {
+        decimals = unit.exponent;
+        return;
+      }
+    });
+  }
 
   if (decimals === undefined) {
     console.log("Error: $" + asset.symbol + " missing decimals!");
@@ -133,12 +141,6 @@ const generateAssets = async (
     generated_asset.symbol = reference_asset.symbol;
 
     //--Get Decimals--
-    //asset.denom_units.forEach((unit) => {
-      //if (unit.denom === asset.display) {
-        //generated_asset.decimals = unit.exponent;
-      //}
-    //});
-
     generated_asset.decimals = getAssetDecimals(asset);
 
     //--Get Logos--


### PR DESCRIPTION
## Description

Update Script to derive Decimals better. In cases where the display value doesn't point to a unit denom, but to a unit aliases, we should still search the aliases arrays for each unit.

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->
