### PR TITLE
Verify Moonbeam GLMR token

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -955,7 +955,7 @@
       "chain_name": "axelar",
       "base_denom": "wglmr-wei",
       "path": "transfer/channel-208/wglmr-wei",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "override_properties": {
         "symbol": "GLMR",
         "name": "Moonbeam"


### PR DESCRIPTION
Changing the "osmosis_verified" value for GLMR to true

This PR aims to modify the verification status of Moonbeam's GLMR token due to its significance. A form has been submitted as per the guidelines outlined in the [rules of token listing](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md).

GLMR is a relatively prominent token and possesses a dedicated [CoinGecko page](https://www.coingecko.com/en/coins/moonbeam)as well as a [CoinMarketCap page ](https://coinmarketcap.com/currencies/moonbeam/). It currently holds the 164th position in terms of Market Capitalization.

The token is available on 'major' centralized exchanges such as [Binance](https://www.binance.com/en/price/moonbeam), [Kraken](https://www.kraken.com/prices/moonbeam), [Bybit](https://www.bybit.com/en/trade/spot/GLMR/USDT) and [KuCoin](https://www.kucoin.com/price/GLMR). You can find more information on its availability on these platforms through the provided links.