### PR TITLE
Mark FUND as a Verified Asset

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1131,7 +1131,7 @@
       "chain_name": "unification",
       "base_denom": "nund",
       "path": "transfer/channel-382/nund",
-      "osmosis_verified": false
+      "osmosis_verified": true
     },
     {
       "chain_name": "jackal",


### PR DESCRIPTION
Proposing to have the [FUND](https://www.coingecko.com/en/coins/unification) coin, the primary asset of the [Unification Chain](https://unification.com/) marked as a verified asset on Osmosis. 

Based on the Qualification Criteria mentioned in the [docs](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md), Unification should be an acceptable candidate, based on its Brand, Community, and Developer presences.

The Unification chain is one of the oldest chains within the Cosmos ecosystem, having its Mainchain debut in [2020](https://medium.com/unificationfoundation/introducing-fund-a0a562dc7f1b)

A public [repo](https://github.com/unification-com) housing all the source code for the chain itself, as well as the services enabled by the presence of the chain. Active community presences can be found on [Telegram](https://t.me/unificationfoundation) and [Discord](https://discord.gg/SeB69w5). 

Currently, there are two community driven pools available on Osmosis - [Pool #1240](https://app.osmosis.zone/pool/1240) and [Pool #1576](https://app.osmosis.zone/pool/1576)