### PR TITLE
Fix conditions for Fetching CoinGecko ID

### DIFF
--- a/.github/workflows/utility/chain_registry.mjs
+++ b/.github/workflows/utility/chain_registry.mjs
@@ -291,6 +291,20 @@ export function getAssetPropertyWithTrace(chainName, baseDenom, property) {
   return value;
 }
 
+export function getAssetPropertyWithTraceCustom(chainName, baseDenom, property, types) {
+  let value = getAssetProperty(chainName, baseDenom, property);
+  if (value) { return value; }
+  if (property === "traces") { return; }
+  let traces = getAssetProperty(chainName, baseDenom, "traces");
+  if (!traces) { return; }
+  if (!types.includes(traces[traces.length - 1].type)) { return; }
+  let originAsset = {
+    chainName: traces[traces.length - 1].counterparty.chain_name,
+    baseDenom: traces[traces.length - 1].counterparty.base_denom
+  }
+  return getAssetPropertyWithTraceCustom(originAsset.chainName, originAsset.baseDenom, property, types);
+}
+
 export function getAssetPropertyWithTraceIBC(chainName, baseDenom, property) {
   let value = getAssetProperty(chainName, baseDenom, property);
   if (!value) {

--- a/osmo-test-5/generated/frontend/assetlist.json
+++ b/osmo-test-5/generated/frontend/assetlist.json
@@ -469,6 +469,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.svg"
       },
+      "coingeckoId": "kyve-network",
       "price": {
         "poolId": "4",
         "denom": "uosmo"
@@ -579,7 +580,6 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/chain4energytestnet/images/c4e.png"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "40",
         "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE"
@@ -802,6 +802,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.svg"
       },
+      "coingeckoId": "ixo",
       "price": {
         "poolId": "254",
         "denom": "uosmo"

--- a/osmosis-1/generated/chain_registry/assetlist.json
+++ b/osmosis-1/generated/chain_registry/assetlist.json
@@ -13576,7 +13576,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png",
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
         }
-      ]
+      ],
+      "coingecko_id": "wrapped-bitcoin"
     },
     {
       "description": "Baddest coin on Cosmos",
@@ -14051,11 +14052,13 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/astro.png"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.svg"
       },
       "images": [
         {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/astro.png"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.svg"
         }
       ]
     },

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -543,7 +543,7 @@
       },
       "coingeckoId": "cosmos",
       "price": {
-        "poolId": "1265",
+        "poolId": "1135",
         "denom": "uosmo"
       },
       "categories": [
@@ -8196,7 +8196,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.svg"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "950",
         "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
@@ -9141,7 +9140,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/8ball/images/8ball.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/8ball/images/8ball.svg"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "935",
         "denom": "uosmo"
@@ -12303,8 +12301,8 @@
       },
       "coingeckoId": "archway",
       "price": {
-        "poolId": "1298",
-        "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
+        "poolId": "1375",
+        "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
       },
       "categories": [
         "defi"
@@ -12684,10 +12682,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qsomm.svg"
       },
-      "price": {
-        "poolId": "1087",
-        "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
-      },
       "categories": [
         "liquid_staking",
         "defi"
@@ -12801,10 +12795,6 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stsomm.svg"
       },
       "coingeckoId": "stride-staked-sommelier",
-      "price": {
-        "poolId": "1120",
-        "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
-      },
       "categories": [
         "liquid_staking",
         "defi"
@@ -13694,7 +13684,6 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/oin.png"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "1210",
         "denom": "uosmo"
@@ -14034,7 +14023,6 @@
       "logoURIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stafihub/images/ratom.svg"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "1227",
         "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -14091,7 +14079,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/dust.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/dust.svg"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "1234",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
@@ -14629,7 +14616,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/brnch.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/brnch.svg"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "1288",
         "denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B"
@@ -15804,7 +15790,6 @@
           "symbol": "PURSE",
           "decimals": 18,
           "logoURIs": {
-            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pundix/images/purse-token-logo.png",
             "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pundix/images/purse-token-logo.svg"
           }
         },
@@ -15817,6 +15802,7 @@
           "symbol": "PURSE",
           "decimals": 18,
           "logoURIs": {
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pundix/images/purse-token-logo.png",
             "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/pundix/images/purse-token-logo.svg"
           }
         }
@@ -15953,7 +15939,6 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nyx.png"
       },
-      "coingeckoId": "",
       "categories": [
         "defi"
       ],
@@ -16039,7 +16024,8 @@
           "symbol": "NYM",
           "decimals": 6,
           "logoURIs": {
-            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nym_token_light.png"
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nym_token_light.png",
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nym_token_light.svg"
           }
         }
       ],
@@ -16278,7 +16264,6 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/sneaky.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/sneaky.svg"
       },
-      "coingeckoId": "",
       "price": {
         "poolId": "1403",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
@@ -16336,6 +16321,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.svg"
       },
+      "coingeckoId": "wrapped-bitcoin",
       "price": {
         "poolId": "1436",
         "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
@@ -16888,7 +16874,8 @@
       "symbol": "ASTRO",
       "decimals": 6,
       "logoURIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/astro.png"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.svg"
       },
       "coingeckoId": "astroport-fi",
       "categories": [
@@ -16927,7 +16914,8 @@
           "symbol": "ASTRO",
           "decimals": 6,
           "logoURIs": {
-            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/astro.png"
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.png",
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/astro.svg"
           }
         }
       ],
@@ -17232,7 +17220,6 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
       },
-      "coingeckoId": "",
       "categories": [
         "defi"
       ],
@@ -17545,10 +17532,6 @@
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.svg"
       },
       "coingeckoId": "aioz-network",
-      "price": {
-        "poolId": "1565",
-        "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
-      },
       "categories": [
         "defi"
       ],


### PR DESCRIPTION
## Description

Fix conditions for Fetching CoinGecko ID

Now pulls from additional-mintage traces, since they are allowed to share a CoinGecko ID.
This fixes Osmosis' native WBTC's CoinGecko ID