### PR TITLE
Fix NSTK unstake.fi IBC Path

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2291,7 +2291,7 @@
     {
       "chain_name": "kujira",
       "base_denom": "factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk",
-      "path": "transfer/channel-259/factory/kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh/unstk",
+      "path": "transfer/channel-259/factory:kujira1aaudpfr9y23lt9d45hrmskphpdfaq9ajxd3ukh:unstk",
       "osmosis_verified": false
     },
     {


### PR DESCRIPTION
## Description

Fix NSTK unstake.fi IBC Path.
Should be using colons instead of / for tokens from Kujira

![image](https://github.com/osmosis-labs/assetlists/assets/95667791/583cf231-2df7-43d7-9f8d-758e326a4800)
![image](https://github.com/osmosis-labs/assetlists/assets/95667791/b726d4e3-75ce-4bb7-87cb-2874521fc871)
