### PR TITLE
relist RAI Reflex Index

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -4219,8 +4219,7 @@
       "coingecko_id": "rai",
       "keywords": [
         "osmosis-info",
-        "osmosis-price:ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4:1604",
-        "osmosis-unlisted"
+        "osmosis-price:ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4:1604"
       ]
     },
     {


### PR DESCRIPTION
relist (Axelar) RAI due to sufficient RAI.axl liquidity in pools 1603 and 1604

## Description

remove osmosis-unlisted tag to relist RAI in Osmosis swap list

## Checklist

<!-- The following checklist can be ticked after Creating the PR -->

### On-chain liquidity

For each new asset, please provide the plan for on-chain liquidity of the asset (See: [Pool Setup Guilde](https://docs.osmosis.zone/overview/integrate/pool-setup).): (choose one)
- [x] Ready -- A liquidity pool(s) has been created and has liquidity. The pool ID is: 1604 (RAI.axl / USDC.noble 0.1%)
- [ ] Soon -- A pool will be created soon. Do not merge this PR until liquidity is ready. 
  - [ ] (optional) A preview of the Osmosis Zone app with the new asset added is requested for creating the pool. (Note: This method is not recommended because the Supercharged Liquidity pool type cannot be created via the Osmosis Zone app)
- [ ] StreamSwap -- The token is, or will be, going through a StreamSwap stream; thus, the token should be listed without requiring on-chain liquidity. A Pool ID will be provided in this PR following the stream's completion once the team has had a chance to create a pool using the earned funds. The StreamSwap Bootstrapping phase begins (when?): ______ 
