### PR TITLE
chore(osmosis-1): add $rstk

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -15378,7 +15378,7 @@
       ]
     },
     {
-      "description": "ReStake Token is the governance token of ReStake DAO on Migaloo.",
+      "description": "Restake DAO Token",
       "denom_units": [
         {
           "denom": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
@@ -15394,8 +15394,8 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
-      "name": "ReStake Token",
-      "display": "RSTK",
+      "name": "RESTAKE",
+      "display": "rstk",
       "symbol": "RSTK",
       "traces": [
         {
@@ -15415,8 +15415,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
       },
       "keywords": [
-        "osmosis-main",
-        "osmosis-unlisted"
+        "osmosis-main"
       ]
     }
   ]

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -15376,6 +15376,48 @@
         "osmosis-main",
         "osmosis-unlisted"
       ]
+    },
+    {
+      "description": "ReStake Token is the governance token of ReStake DAO on Migaloo.",
+      "denom_units": [
+        {
+          "denom": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
+          "exponent": 0,
+          "aliases": [
+            "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+          ]
+        },
+        {
+          "denom": "RSTK",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
+      "name": "ReStake Token",
+      "display": "RSTK",
+      "symbol": "RSTK",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "migaloo",
+            "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
+            "channel_id": "channel-5"
+          },
+          "chain": {
+            "channel_id": "channel-642",
+            "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
+      },
+      "keywords": [
+        "osmosis-main",
+        "osmosis-unlisted"
+      ]
     }
   ]
 }

--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -15376,47 +15376,6 @@
         "osmosis-main",
         "osmosis-unlisted"
       ]
-    },
-    {
-      "description": "Restake DAO Token",
-      "denom_units": [
-        {
-          "denom": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
-          "exponent": 0,
-          "aliases": [
-            "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
-          ]
-        },
-        {
-          "denom": "RSTK",
-          "exponent": 6
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
-      "name": "RESTAKE",
-      "display": "rstk",
-      "symbol": "RSTK",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "migaloo",
-            "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
-            "channel_id": "channel-5"
-          },
-          "chain": {
-            "channel_id": "channel-642",
-            "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk"
-          }
-        }
-      ],
-      "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/rstk.svg"
-      },
-      "keywords": [
-        "osmosis-main"
-      ]
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3168,7 +3168,7 @@
       "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
       "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
       "osmosis_verified": false,
-      "listing_date_time_utc": "2024-04-15T17:00:00Z",
+      "listing_date_time_utc": "2024-04-14T01:25:00Z",
       "_comment": "ReStake DAO $RSTK"
     }
   ]

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3165,7 +3165,7 @@
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
       "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
-      "osmosis_verified": true,
+      "osmosis_verified": false,
       "listing_date_time_utc": "2024-04-15T17:00:00Z",
       "_comment": "ReStake DAO $RSTK"
     }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3160,6 +3160,14 @@
       "listing_date_time_utc": "2024-04-13T17:50:00Z",
       "osmosis_unlisted": true,
       "_comment": "Staked Astroport $xASTRO"
+    },
+    {
+      "chain_name": "migaloo",
+      "base_denom": "factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
+      "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
+      "osmosis_verified": true,
+      "listing_date_time_utc": "2024-04-15T17:00:00Z",
+      "_comment": "ReStake DAO $RSTK"
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding the ReStake Token (Ticker: $RSTK) from Migaloo to the osmosis-1 asset list and zone asset list. $RSTK is the governance token of ReStake DAO which controls a fraction of Migaloo's fiscal spending. The token will be used in a stream swap and afterwards made available for trading on White Whale's Osmosis market. $RSTK will be airdropped to SAIL DAO and the Mad Scientists.


## Checklist


### Adding Assets

- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - The `description` and/or `extended_description` of the asset in the Chain Registry is informative.
- [x] Add asset to bottom of `zone_assets.json`.
   - The IBC channel referenced in `path` must be registered to the Chain Registry.
   - `osmosis_unlisted` defaults to `true` (until the respesentation and transferring of the new asset has been validated)
   - Note that it is recommended to include an X (fka, Twitter) profile URL with each asset.

### On-chain liquidity
- [x] StreamSwap -- The token is, or will be, going through a StreamSwap stream; thus, the token should be listed without requiring on-chain liquidity. A Pool ID will be provided in this PR following the stream's completion once the team has had a chance to create a pool using the earned funds. The StreamSwap Bootstrapping phase begins (when?): 

_**As soon as this PR is merged.**_
