### PR TITLE
Finalize HAVA listing

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3112,7 +3112,6 @@
         }
       ],
       "osmosis_verified": false,
-      "osmosis_unlisted": true,
       "_comment": "Hava Coin $HAVA"
     },
     {


### PR DESCRIPTION
## Description

Making HAVA listed as bonding is unavailable on their loaded incentives until this is in place.
