### PR TITLE
Update Picasso assets to use sub-logos

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3684,7 +3684,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "ETH.pica"
+        "symbol": "ETH.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.pica.svg"
+        }
       }
     },
     {
@@ -3703,7 +3706,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "DAI.pica"
+        "symbol": "DAI.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/dai.pica.svg"
+        }
       }
     },
     {
@@ -3722,7 +3728,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "FXS.pica"
+        "symbol": "FXS.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fxs.pica.svg"
+        }
       }
     },
     {
@@ -3741,7 +3750,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "FRAX.pica"
+        "symbol": "FRAX.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/frax.pica.svg"
+        }
       }
     },
     {
@@ -3760,7 +3772,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "USDT.pica"
+        "symbol": "USDT.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.pica.svg"
+        }
       }
     },
     {
@@ -3779,7 +3794,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "sFRAX.pica"
+        "symbol": "sFRAX.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sfrax.pica.svg"
+        }
       }
     },
     {
@@ -3798,7 +3816,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "frxETH.pica"
+        "symbol": "frxETH.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/frxeth.pica.svg"
+        }
       }
     },
     {
@@ -3817,7 +3838,10 @@
         }
       ],
       "override_properties": {
-        "symbol": "sfrxETH.pica"
+        "symbol": "sfrxETH.pica",
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sfrxeth.pica.svg"
+        }
       }
     },
     {


### PR DESCRIPTION
## Description
Update Picasso assets to use sub-logos:
eth, dai, usdt, dot, frax, fxs, sfrax, frxeth, sfrxeth