### PR TITLE
Update Counterparty Image Fetching Code

### DIFF
--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -759,11 +759,14 @@ export function setCounterparty(asset_data) {
       "symbol"
     );
     counterpartyAsset.decimals = getAssetDecimals(traces[i].counterparty);
-    counterpartyAsset.logoURIs = chain_reg.getAssetProperty(
+    let counterpartyImage = chain_reg.getAssetProperty(
       traces[i].counterparty.chain_name,
       traces[i].counterparty.base_denom,
-      "logo_URIs"
-    );
+      "images"
+    )?.[0];
+    counterpartyAsset.logoURIs = {};
+    counterpartyAsset.logoURIs.png = counterpartyImage.png;
+    counterpartyAsset.logoURIs.svg = counterpartyImage.svg;
 
     asset_data.frontend.counterparty.push(counterpartyAsset);
 

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -19865,7 +19865,11 @@
           "chainType": "cosmos",
           "chainId": "dymension_1100-1",
           "symbol": "NIM",
-          "decimals": 18
+          "decimals": 18,
+          "logoURIs": {
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/nim.png",
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/nim.svg"
+          }
         }
       ],
       "variantGroupKey": "NIM",


### PR DESCRIPTION
## Description

Update Counterparty Image Fetching Code.
Now looks at `images`, which is required, instead of just assigning `logo_URIs`, which is a legacy property (no longer required)
