### PR TITLE
Upgrading PHMN Asset to Verified

### DIFF
--- a/osmo-test-5/query_responses/all-pools.json
+++ b/osmo-test-5/query_responses/all-pools.json
@@ -12,20 +12,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1",
-        "amount": "31892656891518809153429"
+        "amount": "31892656897369811238402"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "uion",
-            "amount": "5232825515"
+            "amount": "5232825452"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6534422028626"
+            "amount": "6534422050808"
           },
           "weight": "4294967296"
         }
@@ -146,14 +146,14 @@
         {
           "token": {
             "denom": "ibc/6F34E1BD664C36CE49ACC28E60D62559A5F96C4F9A6CCE4FC5A67B2852E24CFE",
-            "amount": "101331958415"
+            "amount": "101332182348"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "522962748484"
+            "amount": "522961596384"
           },
           "weight": "1073741824"
         }
@@ -7320,14 +7320,14 @@
         {
           "token": {
             "denom": "ibc/1587E7B54FC9EFDA2350DC690EC2F9B9ECEB6FC31CF11884F9C0C5207ABE3921",
-            "amount": "81852360669"
+            "amount": "81852748127"
           },
           "weight": "2147483648"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "225749766528"
+            "amount": "225747629530"
           },
           "weight": "1073741824"
         }
@@ -7350,11 +7350,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/1587E7B54FC9EFDA2350DC690EC2F9B9ECEB6FC31CF11884F9C0C5207ABE3921",
-          "amount": "716484466"
+          "amount": "716097008"
         },
         {
           "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
-          "amount": "134623366"
+          "amount": "134823366"
         }
       ],
       "scaling_factors": [
@@ -7381,14 +7381,14 @@
         {
           "token": {
             "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
-            "amount": "302717208"
+            "amount": "348573523"
           },
           "weight": "2147483648"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1779820392"
+            "amount": "1342373678"
           },
           "weight": "1073741824"
         }
@@ -8234,7 +8234,7 @@
         {
           "token": {
             "denom": "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
-            "amount": "9997184"
+            "amount": "10085201"
           },
           "weight": "53687091200000"
         },
@@ -8248,7 +8248,7 @@
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1897873166"
+            "amount": "1896834300"
           },
           "weight": "858993459200000"
         }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1472,7 +1472,7 @@
       "chain_name": "juno",
       "base_denom": "cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
       "path": "transfer/channel-169/cw20:juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
-      "osmosis_verified": false
+      "osmosis_verified": true
     },
     {
       "chain_name": "secretnetwork",

--- a/osmosis-1/query_responses/all-pools.json
+++ b/osmosis-1/query_responses/all-pools.json
@@ -12,20 +12,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1",
-        "amount": "52964096828840978783852546"
+        "amount": "52868073479929080726574176"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "659511327417"
+            "amount": "662291175175"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6614875210155"
+            "amount": "6565492973510"
           },
           "weight": "536870912000000"
         }
@@ -50,14 +50,14 @@
         {
           "token": {
             "denom": "uion",
-            "amount": "370707290"
+            "amount": "369838143"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "31930236043"
+            "amount": "32237399002"
           },
           "weight": "214748364800000"
         }
@@ -76,20 +76,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/3",
-        "amount": "8185980218960228515971147"
+        "amount": "8186047742302612473264461"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "65826081216"
+            "amount": "66337636867"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "449829159620"
+            "amount": "446782893966"
           },
           "weight": "536870912000000"
         }
@@ -108,20 +108,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/4",
-        "amount": "3464690224002001464796601"
+        "amount": "3464545258422189700817923"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "162062411633"
+            "amount": "162162529964"
           },
           "weight": "708669603840000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "56880422738"
+            "amount": "56870129006"
           },
           "weight": "365072220160000"
         }
@@ -140,20 +140,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/5",
-        "amount": "3822381126117263528963902652"
+        "amount": "3821854811917988054510381677"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "124480032310010"
+            "amount": "125649683178988"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "176350484257"
+            "amount": "174734627837"
           },
           "weight": "536870912000000"
         }
@@ -178,14 +178,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "9837217580"
+            "amount": "9847882815"
           },
           "weight": "322122547200000"
         },
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "163656799868930"
+            "amount": "163606846994557"
           },
           "weight": "751619276800000"
         }
@@ -204,20 +204,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/7",
-        "amount": "51699380009812906317824348"
+        "amount": "51705019432283444241084760"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
-            "amount": "984994536275"
+            "amount": "1013060641296"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "28246787387"
+            "amount": "27478458624"
           },
           "weight": "536870912000000"
         }
@@ -242,14 +242,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "9464096008"
+            "amount": "9324294347"
           },
           "weight": "644245094400000"
         },
         {
           "token": {
             "denom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
-            "amount": "2218549901501"
+            "amount": "2269441916952"
           },
           "weight": "429496729600000"
         }
@@ -268,20 +268,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/9",
-        "amount": "271367603251638673849338442"
+        "amount": "271335040217574678804013090"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
-            "amount": "253970072189432"
+            "amount": "257655252497630"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "377375757411"
+            "amount": "371956620878"
           },
           "weight": "536870912000000"
         }
@@ -300,20 +300,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/10",
-        "amount": "95563740221303104834033258"
+        "amount": "95491383066452133906269969"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "12837343565"
+            "amount": "12691997695"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
-            "amount": "86851263658756"
+            "amount": "87722959751479"
           },
           "weight": "536870912000000"
         }
@@ -402,14 +402,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2985583718"
+            "amount": "2963126372"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-            "amount": "100839368743"
+            "amount": "101680175131"
           },
           "weight": "536870912000000"
         }
@@ -434,14 +434,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1100960"
+            "amount": "1127928"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uion",
-            "amount": "32472"
+            "amount": "31696"
           },
           "weight": "536870912000000"
         }
@@ -460,20 +460,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/15",
-        "amount": "9351280532762617900517954"
+        "amount": "9360266090509114627774522"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-            "amount": "113409328839"
+            "amount": "114884933783"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "33648730208"
+            "amount": "33336587674"
           },
           "weight": "536870912000000"
         }
@@ -690,14 +690,14 @@
         {
           "token": {
             "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-            "amount": "155135205883"
+            "amount": "154548996976"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1056518965"
+            "amount": "1060797074"
           },
           "weight": "536870912000000"
         }
@@ -1276,14 +1276,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "731561"
+            "amount": "751804"
           },
           "weight": "53687091200000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "143155729"
+            "amount": "142994105"
           },
           "weight": "1020054732800000"
         }
@@ -1380,20 +1380,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/42",
-        "amount": "26646587516095864947840"
+        "amount": "26643045086005790646262"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-            "amount": "750446866530"
+            "amount": "753451537969"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "51544605786"
+            "amount": "51333943851"
           },
           "weight": "536870912000000"
         }
@@ -1599,7 +1599,7 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "646668"
+            "amount": "654522"
           },
           "weight": "805306368000000"
         },
@@ -1613,7 +1613,7 @@
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2152626"
+            "amount": "2073711"
           },
           "weight": "257698037760000"
         }
@@ -2913,14 +2913,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "549759"
+            "amount": "554203"
           },
           "weight": "805306368000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1871346"
+            "amount": "1827129"
           },
           "weight": "268435456000000"
         }
@@ -3708,7 +3708,7 @@
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "92005"
+            "amount": "98930"
           },
           "weight": "134217728000000"
         },
@@ -3729,7 +3729,7 @@
         {
           "token": {
             "denom": "uosmo",
-            "amount": "283"
+            "amount": "264"
           },
           "weight": "134217728000000"
         }
@@ -3956,14 +3956,14 @@
         {
           "token": {
             "denom": "gamm/pool/1",
-            "amount": "254116356982683528"
+            "amount": "635889646851132765"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "273799"
+            "amount": "109417"
           },
           "weight": "536870912000000"
         }
@@ -4286,14 +4286,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2841851"
+            "amount": "2863476"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7399629"
+            "amount": "7178626"
           },
           "weight": "214748364800000"
         }
@@ -6234,14 +6234,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "74105887"
+            "amount": "74516240"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
-            "amount": "681273548772"
+            "amount": "677579161469"
           },
           "weight": "536870912000000"
         }
@@ -6682,14 +6682,14 @@
         {
           "token": {
             "denom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
-            "amount": "1865813489926"
+            "amount": "1869508093505"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2053471269"
+            "amount": "2049475708"
           },
           "weight": "536870912000000"
         }
@@ -7727,14 +7727,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "828477"
+            "amount": "846859"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8701806"
+            "amount": "8512937"
           },
           "weight": "536870912000000"
         }
@@ -9437,14 +9437,14 @@
         {
           "token": {
             "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
-            "amount": "23696638134"
+            "amount": "24583383765"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "36722249"
+            "amount": "35397646"
           },
           "weight": "536870912000000"
         }
@@ -10080,14 +10080,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "361242"
+            "amount": "344613"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
-            "amount": "78643811"
+            "amount": "82438872"
           },
           "weight": "536870912000000"
         }
@@ -10272,14 +10272,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "372348"
+            "amount": "378260"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3897719"
+            "amount": "3836809"
           },
           "weight": "536870912000000"
         }
@@ -11253,14 +11253,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "631218"
+            "amount": "645298"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6650407"
+            "amount": "6505305"
           },
           "weight": "536870912000000"
         }
@@ -12920,14 +12920,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1923180"
+            "amount": "1931287"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "19525138"
+            "amount": "19445393"
           },
           "weight": "536870912000000"
         }
@@ -13208,14 +13208,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "6954823"
+            "amount": "6936278"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "46455833"
+            "amount": "46580049"
           },
           "weight": "536870912000000"
         }
@@ -13240,14 +13240,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "691622"
+            "amount": "666571"
           },
           "weight": "354334801920000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "447635"
+            "amount": "464029"
           },
           "weight": "365072220160000"
         },
@@ -14228,14 +14228,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "833020"
+            "amount": "851159"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8724118"
+            "amount": "8539040"
           },
           "weight": "536870912000000"
         }
@@ -14356,14 +14356,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1283686"
+            "amount": "1305107"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13371373"
+            "amount": "13151912"
           },
           "weight": "536870912000000"
         }
@@ -15305,14 +15305,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "139461019225"
+            "amount": "141010456714"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "1459881025"
+            "amount": "1443958221"
           },
           "weight": "536870912000000"
         }
@@ -15363,20 +15363,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/463",
-        "amount": "8261818735704014587438"
+        "amount": "8279542589533375459903"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "1409111901296"
+            "amount": "1435989082333"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "11211006782"
+            "amount": "11049622172"
           },
           "weight": "536870912000000"
         }
@@ -15401,14 +15401,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "308748586959"
+            "amount": "311652102661"
           },
           "weight": "644245094400000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "162371475"
+            "amount": "160142461"
           },
           "weight": "429496729600000"
         }
@@ -15785,14 +15785,14 @@
         {
           "token": {
             "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
-            "amount": "214452694"
+            "amount": "249417694"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uion",
-            "amount": "1858"
+            "amount": "1607"
           },
           "weight": "536870912000000"
         }
@@ -15939,20 +15939,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/481",
-        "amount": "278833432049016182209"
+        "amount": "278786099006649570027"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "58805082947"
+            "amount": "59136381600"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "44391700490"
+            "amount": "44129924391"
           },
           "weight": "536870912000000"
         }
@@ -15977,14 +15977,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "3776246352"
+            "amount": "3787944143"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "50446936068"
+            "amount": "50293230771"
           },
           "weight": "536870912000000"
         }
@@ -16471,14 +16471,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "655014748589"
+            "amount": "682379027168"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "137434618883"
+            "amount": "132053580838"
           },
           "weight": "536870912000000"
         }
@@ -16503,14 +16503,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "12128230659"
+            "amount": "11713266834"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "580076116049"
+            "amount": "601050962466"
           },
           "weight": "536870912000000"
         }
@@ -16951,14 +16951,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "621057"
+            "amount": "713018"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "146990"
+            "amount": "128033"
           },
           "weight": "536870912000000"
         }
@@ -17303,14 +17303,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2551162"
+            "amount": "2583659"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "25932676"
+            "amount": "25606515"
           },
           "weight": "536870912000000"
         }
@@ -17655,14 +17655,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "16454670"
+            "amount": "17206012"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3709316"
+            "amount": "3547340"
           },
           "weight": "536870912000000"
         }
@@ -18071,14 +18071,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "259507276"
+            "amount": "258395826"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
-            "amount": "15012887451"
+            "amount": "15077612309"
           },
           "weight": "536870912000000"
         }
@@ -18103,14 +18103,14 @@
         {
           "token": {
             "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-            "amount": "4306342681"
+            "amount": "4277796638"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "389007051"
+            "amount": "391626824"
           },
           "weight": "536870912000000"
         }
@@ -18135,14 +18135,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "558543537"
+            "amount": "574112926"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "152657443"
+            "amount": "148568062"
           },
           "weight": "536870912000000"
         }
@@ -18257,20 +18257,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/553",
-        "amount": "27866540888128522932258140107477"
+        "amount": "27867101298867317033708727950220"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
-            "amount": "4451979153337803"
+            "amount": "4199865942401940"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6237846598"
+            "amount": "6614517352"
           },
           "weight": "5368709120"
         }
@@ -18327,14 +18327,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "523895390"
+            "amount": "561156994"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
-            "amount": "3780086774477186"
+            "amount": "3530404987568160"
           },
           "weight": "5368709120"
         }
@@ -18391,14 +18391,14 @@
         {
           "token": {
             "denom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
-            "amount": "90789516651"
+            "amount": "90903610346"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4262365335"
+            "amount": "4257309144"
           },
           "weight": "536870912000000"
         }
@@ -18423,14 +18423,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1036796029"
+            "amount": "1043910499"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
-            "amount": "221810331970"
+            "amount": "220307005485"
           },
           "weight": "536870912000000"
         }
@@ -18455,14 +18455,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "1684838"
+            "amount": "1753954"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
-            "amount": "7894971477850"
+            "amount": "7585145914457"
           },
           "weight": "536870912000000"
         }
@@ -18481,20 +18481,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/560",
-        "amount": "83274422701199193844306"
+        "amount": "83266271068380643228428"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "6836907092270"
+            "amount": "7013151868527"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "183178831363"
+            "amount": "178603677154"
           },
           "weight": "536870912000000"
         }
@@ -18513,20 +18513,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/561",
-        "amount": "392189414105665808341698"
+        "amount": "392225427752006598856349"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-            "amount": "104322249941534"
+            "amount": "106009283718845"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13432501491"
+            "amount": "13228860211"
           },
           "weight": "536870912000000"
         }
@@ -18545,20 +18545,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/562",
-        "amount": "7382300223653803289502387"
+        "amount": "7380734060396548420002005"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-            "amount": "131177780247174"
+            "amount": "129664986559032"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "633784485646"
+            "amount": "641277449650"
           },
           "weight": "536870912000000"
         }
@@ -18647,14 +18647,14 @@
         {
           "token": {
             "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-            "amount": "18810281232562"
+            "amount": "19018858506139"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "241321856"
+            "amount": "238782013"
           },
           "weight": "536870912000000"
         }
@@ -18711,14 +18711,14 @@
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "5942134188"
+            "amount": "5814418098"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "167794332368"
+            "amount": "171512322367"
           },
           "weight": "536870912000000"
         }
@@ -18775,14 +18775,14 @@
         {
           "token": {
             "denom": "uion",
-            "amount": "115394"
+            "amount": "114502"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "39131613"
+            "amount": "39441798"
           },
           "weight": "536870912000000"
         }
@@ -18839,14 +18839,14 @@
         {
           "token": {
             "denom": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
-            "amount": "6561660900548"
+            "amount": "6594900287511"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "51234131055"
+            "amount": "50980618086"
           },
           "weight": "536870912000000"
         }
@@ -18871,14 +18871,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "6373685591"
+            "amount": "6389117994"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
-            "amount": "8252284867796"
+            "amount": "8233018432569"
           },
           "weight": "536870912000000"
         }
@@ -18903,14 +18903,14 @@
         {
           "token": {
             "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
-            "amount": "866738052685"
+            "amount": "864775028591"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "9000001684"
+            "amount": "9020769309"
           },
           "weight": "536870912000000"
         }
@@ -18935,14 +18935,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2465211029"
+            "amount": "2495529693"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
-            "amount": "2400765930500"
+            "amount": "2371967926689"
           },
           "weight": "536870912000000"
         }
@@ -18999,14 +18999,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1259750"
+            "amount": "1287657"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13079341"
+            "amount": "12799939"
           },
           "weight": "536870912000000"
         }
@@ -19025,20 +19025,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/577",
-        "amount": "295138706743119276333"
+        "amount": "295192477958656286111"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
-            "amount": "3187161570588"
+            "amount": "3268910142937"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "19013113608"
+            "amount": "18558474264"
           },
           "weight": "536870912000000"
         }
@@ -19063,14 +19063,14 @@
         {
           "token": {
             "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
-            "amount": "110248752419"
+            "amount": "110544878582"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "24626077961"
+            "amount": "24575560108"
           },
           "weight": "536870912000000"
         }
@@ -19095,14 +19095,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "131728582"
+            "amount": "131529157"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
-            "amount": "4568241988"
+            "amount": "4578560449"
           },
           "weight": "536870912000000"
         }
@@ -19127,14 +19127,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "825006288"
+            "amount": "843054260"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "6457972448"
+            "amount": "6323668698"
           },
           "weight": "536870912000000"
         }
@@ -19249,20 +19249,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/584",
-        "amount": "29612566069045076035894"
+        "amount": "29605017906984340234241"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
-            "amount": "481911863216"
+            "amount": "498640359490"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "222961744526"
+            "amount": "215505591759"
           },
           "weight": "536870912000000"
         }
@@ -19287,14 +19287,14 @@
         {
           "token": {
             "denom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
-            "amount": "229925518964"
+            "amount": "236624689669"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "10626883520"
+            "amount": "10331627365"
           },
           "weight": "536870912000000"
         }
@@ -19319,14 +19319,14 @@
         {
           "token": {
             "denom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
-            "amount": "12265597331490"
+            "amount": "12390617055599"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "174166406496"
+            "amount": "172430815234"
           },
           "weight": "536870912000000"
         }
@@ -19351,14 +19351,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "18697239206"
+            "amount": "18641320592"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
-            "amount": "13276756444520"
+            "amount": "13318865168597"
           },
           "weight": "536870912000000"
         }
@@ -19539,14 +19539,14 @@
         {
           "token": {
             "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
-            "amount": "107861868907"
+            "amount": "104642523379"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "41779596149"
+            "amount": "43074448077"
           },
           "weight": "536870912000000"
         }
@@ -19667,14 +19667,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1141508565"
+            "amount": "1122945631"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "439215643749"
+            "amount": "446651119831"
           },
           "weight": "536870912000000"
         }
@@ -19693,20 +19693,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/597",
-        "amount": "83297499450319274977991"
+        "amount": "83298410797654759520544"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "1118117948334"
+            "amount": "1145256037127"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "29317509142"
+            "amount": "28634463519"
           },
           "weight": "536870912000000"
         }
@@ -19763,14 +19763,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "22775376"
+            "amount": "22797520"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "162835998014"
+            "amount": "162677836482"
           },
           "weight": "536870912000000"
         }
@@ -19795,14 +19795,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2507660481"
+            "amount": "2522674224"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
-            "amount": "886227444564"
+            "amount": "881566553362"
           },
           "weight": "1073741824"
         }
@@ -19827,14 +19827,14 @@
         {
           "token": {
             "denom": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
-            "amount": "959620913133"
+            "amount": "956932444433"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "27190191094"
+            "amount": "27291773486"
           },
           "weight": "536870912000000"
         }
@@ -19853,20 +19853,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/602",
-        "amount": "1673848486442339600039"
+        "amount": "1673742377257734312074"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
-            "amount": "671492955586959"
+            "amount": "688172162361603"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "47047043973"
+            "amount": "45947756285"
           },
           "weight": "536870912000000"
         }
@@ -19917,20 +19917,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/604",
-        "amount": "27825568843969679648"
+        "amount": "27819817725588800365"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-            "amount": "6819316365469"
+            "amount": "6847802875622"
           },
           "weight": "21474836480"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "159604789885"
+            "amount": "159054494298"
           },
           "weight": "21474836480"
         }
@@ -19949,20 +19949,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/605",
-        "amount": "119495689205538264406856764"
+        "amount": "120090259202427383068860135"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "503676707019786"
+            "amount": "470211126033834"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "59594489195"
+            "amount": "64577239817"
           },
           "weight": "536870912000000"
         }
@@ -19987,14 +19987,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "4761112204"
+            "amount": "5190092489"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "405817454202105"
+            "amount": "372820547693805"
           },
           "weight": "536870912000000"
         }
@@ -20019,14 +20019,14 @@
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "7697129325"
+            "amount": "7058065243"
           },
           "weight": "107374182400000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8431212"
+            "amount": "8516296"
           },
           "weight": "966367641600000"
         }
@@ -20051,14 +20051,14 @@
         {
           "token": {
             "denom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
-            "amount": "410275609657140"
+            "amount": "411032670137038"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "89841501428"
+            "amount": "89678650700"
           },
           "weight": "53687091200"
         }
@@ -20141,20 +20141,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/611",
-        "amount": "256067770621566989327157"
+        "amount": "253879424035169508074596"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "18950238782"
+            "amount": "18782419407"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-            "amount": "8102616957089"
+            "amount": "8040679022999"
           },
           "weight": "536870912000000"
         }
@@ -20179,14 +20179,14 @@
         {
           "token": {
             "denom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-            "amount": "10177148666"
+            "amount": "10109827193"
           },
           "weight": "751619276800000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "48630632182"
+            "amount": "49417601182"
           },
           "weight": "322122547200000"
         }
@@ -20211,14 +20211,14 @@
         {
           "token": {
             "denom": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
-            "amount": "131200966437"
+            "amount": "140184663197"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1723276029"
+            "amount": "1613252787"
           },
           "weight": "536870912000000"
         }
@@ -20275,14 +20275,14 @@
         {
           "token": {
             "denom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
-            "amount": "21291539480232"
+            "amount": "20660528008016"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "173182710592"
+            "amount": "178510721313"
           },
           "weight": "53687091200"
         }
@@ -20307,14 +20307,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1482723740"
+            "amount": "1494363137"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
-            "amount": "68480154168985"
+            "amount": "67957778464825"
           },
           "weight": "53687091200"
         }
@@ -20339,14 +20339,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1809582613"
+            "amount": "1781396832"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
-            "amount": "260159334541268"
+            "amount": "264495216337755"
           },
           "weight": "536870912000000"
         }
@@ -20371,14 +20371,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1357435903"
+            "amount": "1421774544"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
-            "amount": "831262944556"
+            "amount": "793986395396"
           },
           "weight": "536870912000000"
         }
@@ -20397,20 +20397,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/619",
-        "amount": "67605737605441834781368"
+        "amount": "64592427579159845002580"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
-            "amount": "1288152427875"
+            "amount": "1183146452418"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "21244636193"
+            "amount": "21120025063"
           },
           "weight": "536870912000000"
         }
@@ -20461,20 +20461,20 @@
       "future_pool_governor": "168h",
       "total_shares": {
         "denom": "gamm/pool/621",
-        "amount": "3254298903069984029947"
+        "amount": "3254046622916841412414"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
-            "amount": "35765434778442"
+            "amount": "35746877087542"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3920155243"
+            "amount": "3921587479"
           },
           "weight": "5368709120"
         }
@@ -20563,14 +20563,14 @@
         {
           "token": {
             "denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
-            "amount": "209393267"
+            "amount": "213016667"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "36686010"
+            "amount": "36064509"
           },
           "weight": "536870912000000"
         }
@@ -20595,14 +20595,14 @@
         {
           "token": {
             "denom": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
-            "amount": "10700404744391"
+            "amount": "10694144723724"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "21362014197"
+            "amount": "21377611464"
           },
           "weight": "536870912000000"
         }
@@ -20627,14 +20627,14 @@
         {
           "token": {
             "denom": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
-            "amount": "26359321851"
+            "amount": "26348990838"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "45800905718"
+            "amount": "45842625684"
           },
           "weight": "536870912000000"
         }
@@ -20659,14 +20659,14 @@
         {
           "token": {
             "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
-            "amount": "346282563354"
+            "amount": "337871847923"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "30589502608"
+            "amount": "31435129071"
           },
           "weight": "536870912000000"
         }
@@ -20717,20 +20717,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/629",
-        "amount": "112178284842322589884"
+        "amount": "112197421663597386102"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-            "amount": "262204833402332288392346304"
+            "amount": "288259452032477018309942930"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "5068378472"
+            "amount": "4668432509"
           },
           "weight": "536870912000000"
         }
@@ -20755,14 +20755,14 @@
         {
           "token": {
             "denom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
-            "amount": "538428"
+            "amount": "554405"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uion",
-            "amount": "17524"
+            "amount": "17037"
           },
           "weight": "536870912000000"
         }
@@ -20787,14 +20787,14 @@
         {
           "token": {
             "denom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
-            "amount": "1137699508"
+            "amount": "1146573783"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3005234655"
+            "amount": "2916715937"
           },
           "weight": "214748364800000"
         }
@@ -20819,14 +20819,14 @@
         {
           "token": {
             "denom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
-            "amount": "696481"
+            "amount": "688420"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "9038211"
+            "amount": "9474528"
           },
           "weight": "214748364800000"
         }
@@ -20851,14 +20851,14 @@
         {
           "token": {
             "denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-            "amount": "2512318695"
+            "amount": "2577782863"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2998214291"
+            "amount": "2922649722"
           },
           "weight": "536870912000000"
         }
@@ -20883,14 +20883,14 @@
         {
           "token": {
             "denom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
-            "amount": "634945522520433551"
+            "amount": "642598608480684148"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2281962195"
+            "amount": "2255135347"
           },
           "weight": "536870912000000"
         }
@@ -20986,14 +20986,14 @@
         {
           "token": {
             "denom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
-            "amount": "4976050967900"
+            "amount": "4986699787643"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7839136885"
+            "amount": "7822607235"
           },
           "weight": "536870912000000"
         }
@@ -21018,14 +21018,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "336926902"
+            "amount": "338629033"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
-            "amount": "2161352642008"
+            "amount": "2150690538289"
           },
           "weight": "536870912000000"
         }
@@ -21114,14 +21114,14 @@
         {
           "token": {
             "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
-            "amount": "5977114244524"
+            "amount": "6084032003565"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "19417908287"
+            "amount": "19081738047"
           },
           "weight": "536870912000000"
         }
@@ -21146,14 +21146,14 @@
         {
           "token": {
             "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
-            "amount": "90844460905"
+            "amount": "90525774142"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "11005909425"
+            "amount": "11045927739"
           },
           "weight": "536870912000000"
         }
@@ -21178,14 +21178,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "731009638"
+            "amount": "725837989"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
-            "amount": "2273082388024"
+            "amount": "2289798717955"
           },
           "weight": "536870912000000"
         }
@@ -21210,14 +21210,14 @@
         {
           "token": {
             "denom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
-            "amount": "2333706065754"
+            "amount": "2360419484500"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "18258259949"
+            "amount": "18062839687"
           },
           "weight": "536870912000000"
         }
@@ -21236,20 +21236,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/645",
-        "amount": "885209419236634389469"
+        "amount": "857392973583252989301"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "5468288"
+            "amount": "5301680"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
-            "amount": "7106347536"
+            "amount": "6879858554"
           },
           "weight": "536870912000000"
         }
@@ -21338,14 +21338,14 @@
         {
           "token": {
             "denom": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
-            "amount": "291461428480691747014984"
+            "amount": "277613377628702811561148"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "31251461830"
+            "amount": "32908391912"
           },
           "weight": "536870912000000"
         }
@@ -21428,20 +21428,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/651",
-        "amount": "387460212883065315505"
+        "amount": "387399628436392447002"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
-            "amount": "295865950515451"
+            "amount": "300402548738748"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "18997182227"
+            "amount": "18708958060"
           },
           "weight": "536870912000000"
         }
@@ -21658,14 +21658,14 @@
         {
           "token": {
             "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-            "amount": "11860207575302"
+            "amount": "13035362888897"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "996237675032"
+            "amount": "906765380608"
           },
           "weight": "5368709120"
         }
@@ -21780,20 +21780,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/662",
-        "amount": "9122372107057972800048"
+        "amount": "9122371777169223820518"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-            "amount": "1114816163580253"
+            "amount": "1133496170512668"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "11054662450"
+            "amount": "10873146726"
           },
           "weight": "536870912000000"
         }
@@ -21818,14 +21818,14 @@
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "243770369106"
+            "amount": "224156880207"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "1113516372"
+            "amount": "1211795312"
           },
           "weight": "536870912000000"
         }
@@ -21850,14 +21850,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "10332899"
+            "amount": "10195599"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-            "amount": "10559569917436"
+            "amount": "10702888746319"
           },
           "weight": "536870912000000"
         }
@@ -22010,14 +22010,14 @@
         {
           "token": {
             "denom": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
-            "amount": "1393327138"
+            "amount": "1427656366"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "451019354"
+            "amount": "440220407"
           },
           "weight": "536870912000000"
         }
@@ -22042,14 +22042,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "212856413"
+            "amount": "210049343"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-            "amount": "1802121736"
+            "amount": "1826292925"
           },
           "weight": "536870912000000"
         }
@@ -22170,14 +22170,14 @@
         {
           "token": {
             "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-            "amount": "63675834030846952727315"
+            "amount": "64826925142737504178854"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "75413541297"
+            "amount": "74106040763"
           },
           "weight": "536870912000000"
         }
@@ -22299,20 +22299,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/678",
-        "amount": "117245206995927114233719"
+        "amount": "116997157135712563391697"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "639651029632"
+            "amount": "650367600793"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "759426359971"
+            "amount": "745043808292"
           },
           "weight": "536870912000000"
         }
@@ -22337,28 +22337,28 @@
         {
           "token": {
             "denom": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
-            "amount": "4120398345496124595449"
+            "amount": "4115578188808383324592"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-            "amount": "4121743842"
+            "amount": "4118661371"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-            "amount": "184097690675"
+            "amount": "185147797855"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "4134155813"
+            "amount": "4119107014"
           },
           "weight": "268435456000000"
         }
@@ -22409,20 +22409,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/681",
-        "amount": "7803113039090939017392784"
+        "amount": "7794362034306032585007325"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-            "amount": "256459561646565882997417"
+            "amount": "256117175708433597575337"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "690851762348"
+            "amount": "690869498193"
           },
           "weight": "5368709120"
         }
@@ -22575,14 +22575,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2783848561"
+            "amount": "2803222280"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
-            "amount": "23730161848912"
+            "amount": "23575769839630"
           },
           "weight": "536870912000000"
         }
@@ -22697,20 +22697,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/690",
-        "amount": "141575656447306914020904"
+        "amount": "141557748907783419066498"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
-            "amount": "2484557969482"
+            "amount": "2481936568705"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2930830815"
+            "amount": "2934793527"
           },
           "weight": "536870912000000"
         }
@@ -22767,14 +22767,14 @@
         {
           "token": {
             "denom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
-            "amount": "16557210371"
+            "amount": "10631419783"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "173853"
+            "amount": "273753"
           },
           "weight": "5368709120"
         }
@@ -22793,20 +22793,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/693",
-        "amount": "403614478285006341653"
+        "amount": "403686096702130538217"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
-            "amount": "461774552436541"
+            "amount": "445994449633210"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "10646397802"
+            "amount": "11098228203"
           },
           "weight": "536870912000000"
         }
@@ -22927,14 +22927,14 @@
         {
           "token": {
             "denom": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
-            "amount": "65010028119"
+            "amount": "62153876697"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "12780838"
+            "amount": "13369933"
           },
           "weight": "5368709120"
         }
@@ -23023,14 +23023,14 @@
         {
           "token": {
             "denom": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
-            "amount": "340315032141"
+            "amount": "340315077840"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "17263096"
+            "amount": "17263094"
           },
           "weight": "536870912000000"
         }
@@ -23055,14 +23055,14 @@
         {
           "token": {
             "denom": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
-            "amount": "118623048420975"
+            "amount": "127855810194005"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4694111123"
+            "amount": "4367722075"
           },
           "weight": "536870912000000"
         }
@@ -23154,14 +23154,14 @@
         {
           "token": {
             "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-            "amount": "222325267303174"
+            "amount": "228500646063902"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "825910"
+            "amount": "803738"
           },
           "weight": "536870912000000"
         }
@@ -23180,20 +23180,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/704",
-        "amount": "54037980794432375958624"
+        "amount": "54037100917616778996449"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-            "amount": "287878194845859867102"
+            "amount": "290621146682289597625"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1037662859773"
+            "amount": "1028186927224"
           },
           "weight": "536870912000000"
         }
@@ -23250,14 +23250,14 @@
         {
           "token": {
             "denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-            "amount": "2068066360"
+            "amount": "2035103160"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "1310611533"
+            "amount": "1332072827"
           },
           "weight": "536870912000000"
         }
@@ -23353,14 +23353,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "8590"
+            "amount": "9205"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "78685"
+            "amount": "73438"
           },
           "weight": "536870912000000"
         }
@@ -23443,20 +23443,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/712",
-        "amount": "91544998316231194813745"
+        "amount": "91540036688064056738939"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-            "amount": "1471206847"
+            "amount": "1490891318"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1157770624695"
+            "amount": "1142818080197"
           },
           "weight": "536870912000000"
         }
@@ -23577,14 +23577,14 @@
         {
           "token": {
             "denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-            "amount": "80894175750624417145385"
+            "amount": "84085966381815255445963"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
-            "amount": "157640795"
+            "amount": "151800313"
           },
           "weight": "536870912000000"
         }
@@ -23641,14 +23641,14 @@
         {
           "token": {
             "denom": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
-            "amount": "363676033413"
+            "amount": "364082738067"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2807116029"
+            "amount": "2803989691"
           },
           "weight": "536870912000000"
         }
@@ -23673,14 +23673,14 @@
         {
           "token": {
             "denom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-            "amount": "27543105718"
+            "amount": "27402884851"
           },
           "weight": "751619276800000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "2954827485"
+            "amount": "2992986018"
           },
           "weight": "322122547200000"
         }
@@ -23763,20 +23763,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/722",
-        "amount": "5578627731449930292162539"
+        "amount": "5583707257540507745438732"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-            "amount": "4377086715328592497678407"
+            "amount": "4219790888744328129602501"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "231330825501"
+            "amount": "240784747981"
           },
           "weight": "1073741824"
         }
@@ -23859,20 +23859,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/725",
-        "amount": "2115864043968630764999674"
+        "amount": "2070937538120588016569165"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-            "amount": "11524972008674427423668"
+            "amount": "11245161642206960500970"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "323957638390"
+            "amount": "318780685825"
           },
           "weight": "536870912000000"
         }
@@ -23891,20 +23891,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/726",
-        "amount": "4405120388217006637407"
+        "amount": "4401898538072579695488"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
-            "amount": "9439393220"
+            "amount": "9586112102"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6596733488"
+            "amount": "6493353308"
           },
           "weight": "536870912000000"
         }
@@ -24025,14 +24025,14 @@
         {
           "token": {
             "denom": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
-            "amount": "7439477623"
+            "amount": "7510897967"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "5824546920"
+            "amount": "5771049596"
           },
           "weight": "536870912000000"
         }
@@ -24051,20 +24051,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/731",
-        "amount": "603573549981903930023"
+        "amount": "603675386642507481215"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
-            "amount": "197854079630125605683"
+            "amount": "185612942438693205258"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3236156732"
+            "amount": "3466030189"
           },
           "weight": "536870912000000"
         }
@@ -24083,20 +24083,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/732",
-        "amount": "107436249127387284293"
+        "amount": "107435048775014714009"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
-            "amount": "649875471571976113693113"
+            "amount": "626810014149935881999561"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8914073390"
+            "amount": "9243205024"
           },
           "weight": "536870912000000"
         }
@@ -24121,14 +24121,14 @@
         {
           "token": {
             "denom": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
-            "amount": "2595493830891463"
+            "amount": "2658990978380329"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "9079573"
+            "amount": "8863177"
           },
           "weight": "536870912000000"
         }
@@ -24249,14 +24249,14 @@
         {
           "token": {
             "denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
-            "amount": "5044171614"
+            "amount": "5063781793"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "25208343"
+            "amount": "25120329"
           },
           "weight": "536870912000000"
         }
@@ -24281,14 +24281,14 @@
         {
           "token": {
             "denom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
-            "amount": "27089596643"
+            "amount": "26424607274"
           },
           "weight": "719407022080000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "12828974"
+            "amount": "13512207"
           },
           "weight": "354334801920000"
         }
@@ -24377,14 +24377,14 @@
         {
           "token": {
             "denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
-            "amount": "50247057"
+            "amount": "49607108"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2127929"
+            "amount": "2165685"
           },
           "weight": "1073741824"
         }
@@ -24467,20 +24467,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/744",
-        "amount": "75697688773968983924014"
+        "amount": "75072127947303823593735"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
-            "amount": "57274478308"
+            "amount": "55616297753"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "101251429388"
+            "amount": "103150313287"
           },
           "weight": "536870912000000"
         }
@@ -24569,14 +24569,14 @@
         {
           "token": {
             "denom": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
-            "amount": "6623812061125571528607560"
+            "amount": "6624923878136435602380956"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1368393793"
+            "amount": "1368164605"
           },
           "weight": "536870912000000"
         }
@@ -24601,14 +24601,14 @@
         {
           "token": {
             "denom": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
-            "amount": "46126318969025804770291"
+            "amount": "45014917594747312481973"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "7875249"
+            "amount": "8070271"
           },
           "weight": "536870912000000"
         }
@@ -24697,14 +24697,14 @@
         {
           "token": {
             "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
-            "amount": "666263317724"
+            "amount": "666032360439"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
-            "amount": "8262351246682"
+            "amount": "8265236886264"
           },
           "weight": "5368709120"
         }
@@ -24921,14 +24921,14 @@
         {
           "token": {
             "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
-            "amount": "346252298637"
+            "amount": "346594959647"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202",
-            "amount": "5089729553421"
+            "amount": "5084712677664"
           },
           "weight": "5368709120"
         }
@@ -25273,14 +25273,14 @@
         {
           "token": {
             "denom": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
-            "amount": "2181851698441"
+            "amount": "2368905020135"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7375927962"
+            "amount": "6796405382"
           },
           "weight": "536870912000000"
         }
@@ -25305,14 +25305,14 @@
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "2303496498"
+            "amount": "2259489479"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
-            "amount": "418253160"
+            "amount": "427030017"
           },
           "weight": "536870912000000"
         }
@@ -25337,14 +25337,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "5871998"
+            "amount": "5867043"
           },
           "weight": "322122547200000"
         },
         {
           "token": {
             "denom": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
-            "amount": "13426024796"
+            "amount": "13431702283"
           },
           "weight": "751619276800000"
         }
@@ -25401,14 +25401,14 @@
         {
           "token": {
             "denom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
-            "amount": "26066450607144"
+            "amount": "26214828141293"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "21688994239"
+            "amount": "21577434811"
           },
           "weight": "536870912000000"
         }
@@ -25433,14 +25433,14 @@
         {
           "token": {
             "denom": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
-            "amount": "101448283317"
+            "amount": "101656824019"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "99100389"
+            "amount": "98897702"
           },
           "weight": "536870912000000"
         }
@@ -25529,14 +25529,14 @@
         {
           "token": {
             "denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
-            "amount": "744630877262"
+            "amount": "801532852877"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "33922336115"
+            "amount": "31538155184"
           },
           "weight": "536870912000000"
         }
@@ -25555,20 +25555,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/778",
-        "amount": "240294439320138285898753"
+        "amount": "240097495882278508294212"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
-            "amount": "7879549973535"
+            "amount": "7828559007239"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "15983589613"
+            "amount": "16063931976"
           },
           "weight": "536870912000000"
         }
@@ -25811,20 +25811,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/786",
-        "amount": "330810113225634732372707"
+        "amount": "330092205039089942702163"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
-            "amount": "678298433843"
+            "amount": "676743580075"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "151826611"
+            "amount": "151515739"
           },
           "weight": "536870912000000"
         }
@@ -25849,14 +25849,14 @@
         {
           "token": {
             "denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
-            "amount": "1130819177495"
+            "amount": "1110290174024"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2767776251"
+            "amount": "2819252392"
           },
           "weight": "536870912000000"
         }
@@ -25907,20 +25907,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/789",
-        "amount": "1717066429680067895075801"
+        "amount": "1716991680389457597647065"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
-            "amount": "95627323719785650465171"
+            "amount": "95806280546020407042447"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "78155558671"
+            "amount": "78100388852"
           },
           "weight": "536870912000000"
         }
@@ -25939,20 +25939,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/790",
-        "amount": "1215453768310014960242"
+        "amount": "1214150034212920549752"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
-            "amount": "35616701"
+            "amount": "36163557"
           },
           "weight": "214748364800000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8240932515"
+            "amount": "8198699031"
           },
           "weight": "858993459200000"
         }
@@ -25977,14 +25977,14 @@
         {
           "token": {
             "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-            "amount": "7233191996277223225"
+            "amount": "7363613968587359281"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "9287006"
+            "amount": "9122518"
           },
           "weight": "536870912000000"
         }
@@ -26041,14 +26041,14 @@
         {
           "token": {
             "denom": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
-            "amount": "356758395"
+            "amount": "363424036"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "119728516"
+            "amount": "117550836"
           },
           "weight": "536870912000000"
         }
@@ -26073,14 +26073,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "98264"
+            "amount": "99263"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-            "amount": "19835201587215823959"
+            "amount": "19655358180272457448"
           },
           "weight": "536870912000000"
         }
@@ -26105,14 +26105,14 @@
         {
           "token": {
             "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
-            "amount": "65996779766"
+            "amount": "65938635753"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7867303620"
+            "amount": "7906387978"
           },
           "weight": "536870912000000"
         }
@@ -26137,14 +26137,14 @@
         {
           "token": {
             "denom": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
-            "amount": "33355554792361485959126559"
+            "amount": "35662913438564319463835938"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "616270448455"
+            "amount": "576595763575"
           },
           "weight": "5368709120"
         }
@@ -26227,20 +26227,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/799",
-        "amount": "3671975170295601440146"
+        "amount": "3672118592809623831808"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
-            "amount": "8420320440"
+            "amount": "8277402206"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "126226774722"
+            "amount": "128621237765"
           },
           "weight": "536870912000000"
         }
@@ -26259,20 +26259,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/800",
-        "amount": "63950567549636188721"
+        "amount": "63927406259740537201"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-            "amount": "259481439971017"
+            "amount": "259379945499864"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "33992314753"
+            "amount": "33981328593"
           },
           "weight": "536870912000000"
         }
@@ -26329,14 +26329,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "16470785"
+            "amount": "16480261"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-            "amount": "12675208"
+            "amount": "12668139"
           },
           "weight": "1073741824"
         }
@@ -26355,20 +26355,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/803",
-        "amount": "61846506241594741941724"
+        "amount": "61717516203543142598630"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "73098339465"
+            "amount": "72882434091"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-            "amount": "54470816027"
+            "amount": "54406859905"
           },
           "weight": "536870912000000"
         }
@@ -26451,20 +26451,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/806",
-        "amount": "118870771532774577114"
+        "amount": "118858380689924937492"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
-            "amount": "131564873130"
+            "amount": "136085977607"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "294076992513"
+            "amount": "284450236371"
           },
           "weight": "536870912000000"
         }
@@ -26489,14 +26489,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "682007358"
+            "amount": "692881718"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
-            "amount": "428193840"
+            "amount": "421529594"
           },
           "weight": "536870912000000"
         }
@@ -26592,16 +26592,16 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/810",
-        "amount": "1156946856149445993310"
+        "amount": "1156934036780372482345"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
-          "amount": "7576265537550"
+          "amount": "7576181611741"
         },
         {
           "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-          "amount": "8083578158824"
+          "amount": "8083488557953"
         }
       ],
       "scaling_factors": [
@@ -26654,20 +26654,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/812",
-        "amount": "62239641124795778197563"
+        "amount": "62300749199209312524798"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-            "amount": "863135438386"
+            "amount": "894132612916"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1087760681705"
+            "amount": "1052751466819"
           },
           "weight": "5368709120"
         }
@@ -26686,20 +26686,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/813",
-        "amount": "396852302393140187192954"
+        "amount": "396897685875314475252551"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
-            "amount": "1736895462177848836360814"
+            "amount": "1849695491655227544271508"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4118551492"
+            "amount": "3870967772"
           },
           "weight": "1073741824"
         }
@@ -26782,20 +26782,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/816",
-        "amount": "180495078040123218083819094"
+        "amount": "180482374401712726276804970"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
-            "amount": "11974560199951"
+            "amount": "12281316132414"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "116623135885"
+            "amount": "113737331096"
           },
           "weight": "5368709120"
         }
@@ -26813,16 +26813,16 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/817",
-        "amount": "5100706480341924014171"
+        "amount": "5100664688226866708576"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-          "amount": "1340033116485"
+          "amount": "1329172579889"
         },
         {
           "denom": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
-          "amount": "1373827894940"
+          "amount": "1381379876207"
         }
       ],
       "scaling_factors": [
@@ -26849,14 +26849,14 @@
         {
           "token": {
             "denom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
-            "amount": "156812655"
+            "amount": "161240973"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "189408573"
+            "amount": "184255527"
           },
           "weight": "536870912000000"
         }
@@ -27041,14 +27041,14 @@
         {
           "token": {
             "denom": "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
-            "amount": "505132143688"
+            "amount": "507112190212"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "428081724"
+            "amount": "426415252"
           },
           "weight": "5368709120"
         }
@@ -27099,20 +27099,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/826",
-        "amount": "5357698961898294504335"
+        "amount": "1020550887445027310212"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
-            "amount": "1775099500805419413583220"
+            "amount": "361750423545649948979846"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13798890228"
+            "amount": "2458449686"
           },
           "weight": "5368709120"
         }
@@ -27137,14 +27137,14 @@
         {
           "token": {
             "denom": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
-            "amount": "29487071"
+            "amount": "30043839"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "35204489"
+            "amount": "34555750"
           },
           "weight": "536870912000000"
         }
@@ -27169,21 +27169,21 @@
         {
           "token": {
             "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-            "amount": "3437383307472132511"
+            "amount": "3433560128956468957"
           },
           "weight": "354334801920000"
         },
         {
           "token": {
             "denom": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
-            "amount": "3430153"
+            "amount": "3427311"
           },
           "weight": "354334801920000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "3526075"
+            "amount": "3532918"
           },
           "weight": "365072220160000"
         }
@@ -27208,14 +27208,14 @@
         {
           "token": {
             "denom": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
-            "amount": "6060320575"
+            "amount": "5851711032"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "4781980"
+            "amount": "4952625"
           },
           "weight": "536870912000000"
         }
@@ -27240,14 +27240,14 @@
         {
           "token": {
             "denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
-            "amount": "18392188902"
+            "amount": "19472209128"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2972064"
+            "amount": "2807531"
           },
           "weight": "1073741824"
         }
@@ -27266,20 +27266,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/831",
-        "amount": "30094822933748805999884"
+        "amount": "30094999451051099690570"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-            "amount": "7174227448"
+            "amount": "7330642459"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8558022646"
+            "amount": "8377717366"
           },
           "weight": "536870912000000"
         }
@@ -27298,20 +27298,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/832",
-        "amount": "141698133674363168789"
+        "amount": "141691828595357376617"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
-            "amount": "783869620746"
+            "amount": "747636102633"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "327568664766"
+            "amount": "344157935243"
           },
           "weight": "536870912000000"
         }
@@ -27329,21 +27329,21 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/833",
-        "amount": "9230583168909862463757"
+        "amount": "9237349260315417372698"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
-          "amount": "6459677441938"
+          "amount": "6481427256366"
         },
         {
           "denom": "uosmo",
-          "amount": "6026092700327"
+          "amount": "6009633101890"
         }
       ],
       "scaling_factors": [
         "100000",
-        "123874"
+        "123941"
       ],
       "scaling_factor_controller": "osmo12yvjuy69ynnts95ensss4q6480wkvkpnq2z2ntxmfa2qp860xsmq9mzlpn"
     },
@@ -27397,14 +27397,14 @@
         {
           "token": {
             "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-            "amount": "645855"
+            "amount": "659589"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
-            "amount": "7290121"
+            "amount": "7138626"
           },
           "weight": "536870912000000"
         }
@@ -27461,14 +27461,14 @@
         {
           "token": {
             "denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
-            "amount": "11126012454"
+            "amount": "11362978513"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13263366265"
+            "amount": "12992273570"
           },
           "weight": "536870912000000"
         }
@@ -27557,14 +27557,14 @@
         {
           "token": {
             "denom": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
-            "amount": "376529220116821840957"
+            "amount": "384995798463623521258"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "261331426281"
+            "amount": "255650894933"
           },
           "weight": "536870912000000"
         }
@@ -27621,14 +27621,14 @@
         {
           "token": {
             "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
-            "amount": "2481165652"
+            "amount": "2455074255"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
-            "amount": "61973936"
+            "amount": "65370771"
           },
           "weight": "214748364800000"
         }
@@ -27813,14 +27813,14 @@
         {
           "token": {
             "denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
-            "amount": "6995276318116343394256684"
+            "amount": "7026472969834207626071969"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "271845480"
+            "amount": "270642508"
           },
           "weight": "536870912000000"
         }
@@ -27845,14 +27845,14 @@
         {
           "token": {
             "denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
-            "amount": "986070476261541674702276"
+            "amount": "965322672878154450121459"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "31724320"
+            "amount": "32408902"
           },
           "weight": "536870912000000"
         }
@@ -27877,14 +27877,14 @@
         {
           "token": {
             "denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
-            "amount": "1109936707885984088986106"
+            "amount": "1099484508287890523648302"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "8830443"
+            "amount": "9171729"
           },
           "weight": "214748364800000"
         }
@@ -28070,20 +28070,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/856",
-        "amount": "878039288648097742937"
+        "amount": "643047627569803589335"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
-            "amount": "16670035514927"
+            "amount": "12271967808437"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4368507552"
+            "amount": "3183078667"
           },
           "weight": "536870912000000"
         }
@@ -28108,14 +28108,14 @@
         {
           "token": {
             "denom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
-            "amount": "3598325004"
+            "amount": "3628297004"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2841781384"
+            "amount": "2818339299"
           },
           "weight": "536870912000000"
         }
@@ -28140,14 +28140,14 @@
         {
           "token": {
             "denom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
-            "amount": "7967126114099582984301868"
+            "amount": "7298946427846749553130054"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1067401039"
+            "amount": "1165422312"
           },
           "weight": "5368709120"
         }
@@ -28172,14 +28172,14 @@
         {
           "token": {
             "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-            "amount": "179548973714"
+            "amount": "182742057878"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "318400769"
+            "amount": "312940633"
           },
           "weight": "5368709120"
         }
@@ -28424,14 +28424,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "8275621"
+            "amount": "8050484"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
-            "amount": "4938661"
+            "amount": "5077193"
           },
           "weight": "5368709120"
         }
@@ -28485,14 +28485,14 @@
         {
           "token": {
             "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-            "amount": "160948997275"
+            "amount": "160630603359"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "28035369"
+            "amount": "28094422"
           },
           "weight": "536870912000000"
         }
@@ -28586,11 +28586,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-          "amount": "5365719358"
+          "amount": "5655628265"
         },
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-          "amount": "4456131347"
+          "amount": "4168325286"
         }
       ],
       "scaling_factors": [
@@ -28615,11 +28615,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
-          "amount": "10596626"
+          "amount": "8503796"
         },
         {
           "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-          "amount": "8379485"
+          "amount": "10473903"
         }
       ],
       "scaling_factors": [
@@ -28680,14 +28680,14 @@
         {
           "token": {
             "denom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
-            "amount": "203382438709371756592813"
+            "amount": "182380720765105867559164"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "22190905"
+            "amount": "24758103"
           },
           "weight": "5368709120"
         }
@@ -28710,19 +28710,19 @@
       "pool_liquidity": [
         {
           "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-          "amount": "167541491343134350790"
+          "amount": "170498292439045127967"
         },
         {
           "denom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
-          "amount": "581736827"
+          "amount": "568024510"
         },
         {
           "denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
-          "amount": "166856952"
+          "amount": "169887814"
         },
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-          "amount": "167244569"
+          "amount": "170429008"
         }
       ],
       "scaling_factors": [
@@ -28749,15 +28749,15 @@
       "pool_liquidity": [
         {
           "denom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
-          "amount": "19902493351956132930517"
+          "amount": "20011265809944665511747"
         },
         {
           "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-          "amount": "19377535034"
+          "amount": "19367912659"
         },
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-          "amount": "19706358750"
+          "amount": "19607705480"
         }
       ],
       "scaling_factors": [
@@ -28817,14 +28817,14 @@
         {
           "token": {
             "denom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
-            "amount": "1400667353236261329398"
+            "amount": "1434211277519851681759"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1673216006"
+            "amount": "1634454148"
           },
           "weight": "536870912000000"
         }
@@ -28849,14 +28849,14 @@
         {
           "token": {
             "denom": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
-            "amount": "155732453109076285396096"
+            "amount": "257984214569086907983403"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7725576"
+            "amount": "4667315"
           },
           "weight": "536870912000000"
         }
@@ -28907,20 +28907,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/882",
-        "amount": "5137776207984325242908"
+        "amount": "5141696586930991747352"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
-            "amount": "51584871334866591441999"
+            "amount": "53930547146242389472286"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8132543565"
+            "amount": "7805871007"
           },
           "weight": "1073741824"
         }
@@ -28945,14 +28945,14 @@
         {
           "token": {
             "denom": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
-            "amount": "1535045"
+            "amount": "1555987"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "62284487"
+            "amount": "61448683"
           },
           "weight": "1073741824"
         }
@@ -29006,14 +29006,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "597475"
+            "amount": "576571"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
-            "amount": "37913317472934498735"
+            "amount": "39377641148753119178"
           },
           "weight": "53687091200"
         }
@@ -29031,16 +29031,16 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/886",
-        "amount": "4758046777382943618855"
+        "amount": "4757696768351497629902"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-          "amount": "2294212545"
+          "amount": "2345623239"
         },
         {
           "denom": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
-          "amount": "2755286106"
+          "amount": "2714115699"
         }
       ],
       "scaling_factors": [
@@ -29174,14 +29174,14 @@
         {
           "token": {
             "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-            "amount": "83435558707"
+            "amount": "81607762835"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "8689963"
+            "amount": "8884985"
           },
           "weight": "536870912000000"
         }
@@ -29329,7 +29329,7 @@
       "pool_liquidity": [
         {
           "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-          "amount": "134042398776416034920"
+          "amount": "133187487691522607289"
         },
         {
           "denom": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
@@ -29337,7 +29337,7 @@
         },
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-          "amount": "132879553"
+          "amount": "133733000"
         }
       ],
       "scaling_factors": [
@@ -29429,14 +29429,14 @@
         {
           "token": {
             "denom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
-            "amount": "280944719322844882867698"
+            "amount": "285145225013412092692438"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "10864210796"
+            "amount": "10708205956"
           },
           "weight": "5368709120"
         }
@@ -29455,20 +29455,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/899",
-        "amount": "1623713392803414783314"
+        "amount": "1623912933685672179274"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
-            "amount": "1467607390928005801044"
+            "amount": "1460894433947792190344"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "60581057387"
+            "amount": "60898607174"
           },
           "weight": "536870912000000"
         }
@@ -29493,14 +29493,14 @@
         {
           "token": {
             "denom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
-            "amount": "30332964277550150655504"
+            "amount": "30390259268023021114521"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "27431586138"
+            "amount": "27416310086"
           },
           "weight": "536870912000000"
         }
@@ -29525,14 +29525,14 @@
         {
           "token": {
             "denom": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
-            "amount": "1428186753300799562149"
+            "amount": "1474074544128250800437"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "295867568"
+            "amount": "287201519"
           },
           "weight": "5368709120"
         }
@@ -29551,20 +29551,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/902",
-        "amount": "89336996651262671402644"
+        "amount": "91621539591063736028391"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
-            "amount": "782693648472"
+            "amount": "824928350762"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2682755659"
+            "amount": "2678738182"
           },
           "weight": "536870912000000"
         }
@@ -29650,14 +29650,14 @@
         {
           "token": {
             "denom": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
-            "amount": "20590010"
+            "amount": "21018161"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "838106758"
+            "amount": "821152094"
           },
           "weight": "1073741824"
         }
@@ -29711,14 +29711,14 @@
         {
           "token": {
             "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-            "amount": "599933659564"
+            "amount": "631567883461"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "53838563143"
+            "amount": "51189976194"
           },
           "weight": "5368709120"
         }
@@ -29741,15 +29741,15 @@
       "pool_liquidity": [
         {
           "denom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-          "amount": "228359396997715015142"
+          "amount": "234132686091978200745"
         },
         {
           "denom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
-          "amount": "840840015"
+          "amount": "824299183"
         },
         {
           "denom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
-          "amount": "227363298"
+          "amount": "232652955"
         }
       ],
       "scaling_factors": [
@@ -29777,14 +29777,14 @@
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "1838022414"
+            "amount": "1692364765"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5",
-            "amount": "10656178291486805357277"
+            "amount": "11575167178133630417502"
           },
           "weight": "5368709120"
         }
@@ -29809,14 +29809,14 @@
         {
           "token": {
             "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-            "amount": "882050425785"
+            "amount": "892504491314"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "1110184799414"
+            "amount": "1097268194620"
           },
           "weight": "536870912000000"
         }
@@ -29867,20 +29867,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/912",
-        "amount": "1216556893497603066933"
+        "amount": "1216481828334170667055"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-            "amount": "7713700332917701835"
+            "amount": "7620733550992693025"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "1059591811324"
+            "amount": "1072893278903"
           },
           "weight": "536870912000000"
         }
@@ -29934,14 +29934,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "22790766693"
+            "amount": "23047807206"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "18000241"
+            "amount": "17800974"
           },
           "weight": "536870912000000"
         }
@@ -29966,14 +29966,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "3914500683"
+            "amount": "3807286491"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-            "amount": "24262315"
+            "amount": "24950310"
           },
           "weight": "536870912000000"
         }
@@ -29998,14 +29998,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "2017593579"
+            "amount": "1973119980"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-            "amount": "179635704"
+            "amount": "183804036"
           },
           "weight": "536870912000000"
         }
@@ -30030,14 +30030,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "2997057269"
+            "amount": "3032341114"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
-            "amount": "565211868077005460"
+            "amount": "558743278898985488"
           },
           "weight": "536870912000000"
         }
@@ -30062,14 +30062,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "5627615876"
+            "amount": "5946968738"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
-            "amount": "512983123"
+            "amount": "486040748"
           },
           "weight": "536870912000000"
         }
@@ -30094,14 +30094,14 @@
         {
           "token": {
             "denom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
-            "amount": "4454025113946"
+            "amount": "4395480681779"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "142768059989"
+            "amount": "144719262420"
           },
           "weight": "536870912000000"
         }
@@ -30180,16 +30180,16 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/922",
-        "amount": "2415819769831287804801720"
+        "amount": "2416216449336926773278435"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-          "amount": "173861262458300918891792"
+          "amount": "156669551936559906413752"
         },
         {
           "denom": "ibc/C5579A9595790017C600DD726276D978B9BF314CF82406CE342720A9C7911A01",
-          "amount": "130189226715970128969001"
+          "amount": "141583422351481193335750"
         }
       ],
       "scaling_factors": [
@@ -30411,14 +30411,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "7083687179"
+            "amount": "7220629198"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-            "amount": "15958263723985305"
+            "amount": "15658157621934615"
           },
           "weight": "536870912000000"
         }
@@ -30443,14 +30443,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "3381256647"
+            "amount": "3345534734"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-            "amount": "33932"
+            "amount": "34297"
           },
           "weight": "536870912000000"
         }
@@ -30475,14 +30475,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "70889508"
+            "amount": "70071245"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "60485093373"
+            "amount": "61208352852"
           },
           "weight": "536870912000000"
         }
@@ -30507,14 +30507,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "38150569441"
+            "amount": "38069533074"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
-            "amount": "203051019659"
+            "amount": "203495993279"
           },
           "weight": "536870912000000"
         }
@@ -30661,14 +30661,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "8612150468"
+            "amount": "8490549074"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "328534884"
+            "amount": "333376357"
           },
           "weight": "536870912000000"
         }
@@ -30693,14 +30693,14 @@
         {
           "token": {
             "denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-            "amount": "10987515161"
+            "amount": "11642692122"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-            "amount": "1665814597759532554764"
+            "amount": "1573429623087815258301"
           },
           "weight": "536870912000000"
         }
@@ -30718,20 +30718,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/938",
-        "amount": "244512028448976271450"
+        "amount": "117641683415452789199"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
-          "amount": "639001042"
+          "amount": "307441556"
         },
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-          "amount": "633840246"
+          "amount": "304958550"
         },
         {
           "denom": "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
-          "amount": "645177026"
+          "amount": "310412997"
         }
       ],
       "scaling_factors": [
@@ -30757,11 +30757,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-          "amount": "1169832836"
+          "amount": "1180518344"
         },
         {
           "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-          "amount": "1478498700"
+          "amount": "1467794182"
         }
       ],
       "scaling_factors": [
@@ -30814,20 +30814,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/941",
-        "amount": "46125303195983026704728"
+        "amount": "46129053104355082288431"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
-            "amount": "2490798112201"
+            "amount": "2478731682959"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3750036099"
+            "amount": "3768971042"
           },
           "weight": "536870912000000"
         }
@@ -30921,11 +30921,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-          "amount": "28052333612"
+          "amount": "27997731730"
         },
         {
           "denom": "ibc/FA602364BEC305A696CBDF987058E99D8B479F0318E47314C49173E8838C5BAC",
-          "amount": "33522837562"
+          "amount": "33567702019"
         }
       ],
       "scaling_factors": [
@@ -31053,11 +31053,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-          "amount": "280112613541"
+          "amount": "279708062587"
         },
         {
           "denom": "ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206",
-          "amount": "151996901530"
+          "amount": "152310370970"
         }
       ],
       "scaling_factors": [
@@ -31084,14 +31084,14 @@
         {
           "token": {
             "denom": "ibc/4F24D904BAB5FFBD3524F2DE3EC3C7A9E687A2408D9A985E57B356D9FA9201C6",
-            "amount": "1241717907248"
+            "amount": "1252077804037"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "214066038"
+            "amount": "212307529"
           },
           "weight": "536870912000000"
         }
@@ -31116,14 +31116,14 @@
         {
           "token": {
             "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-            "amount": "4681152"
+            "amount": "4645485"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
-            "amount": "91363391"
+            "amount": "92076094"
           },
           "weight": "1073741824"
         }
@@ -31148,14 +31148,14 @@
         {
           "token": {
             "denom": "ibc/AD4DEA52408EA07C0C9E19444EC8DA84A274A70AD2687A710EFDDEB28BB2986A",
-            "amount": "688820965"
+            "amount": "126913256"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "85129"
+            "amount": "466186"
           },
           "weight": "536870912000000"
         }
@@ -31174,20 +31174,20 @@
       "future_pool_governor": "168h",
       "total_shares": {
         "denom": "gamm/pool/952",
-        "amount": "23906603373210642027785"
+        "amount": "23940832331215566565726"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
-            "amount": "210814282766"
+            "amount": "217837723366"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7295632972"
+            "amount": "7087164484"
           },
           "weight": "1073741824"
         }
@@ -31238,20 +31238,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/954",
-        "amount": "13670937983214665417871"
+        "amount": "13669884462165152765003"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/0F91EE8B98AAE3CF393D94CD7F89A10F8D7758C5EC707E721899DFE65C164C28",
-            "amount": "15803413325"
+            "amount": "15802195470"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "118262786"
+            "amount": "118253673"
           },
           "weight": "536870912000000"
         }
@@ -31344,14 +31344,14 @@
         {
           "token": {
             "denom": "ibc/4F24D904BAB5FFBD3524F2DE3EC3C7A9E687A2408D9A985E57B356D9FA9201C6",
-            "amount": "298484897272"
+            "amount": "288124525202"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "42145731"
+            "amount": "43672330"
           },
           "weight": "536870912000000"
         }
@@ -31440,14 +31440,14 @@
         {
           "token": {
             "denom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
-            "amount": "603810108584"
+            "amount": "604139973963"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13072964192"
+            "amount": "13093158837"
           },
           "weight": "536870912000000"
         }
@@ -31658,14 +31658,14 @@
         {
           "token": {
             "denom": "ibc/AD4DEA52408EA07C0C9E19444EC8DA84A274A70AD2687A710EFDDEB28BB2986A",
-            "amount": "1437055607"
+            "amount": "515412207"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "697928"
+            "amount": "1991005"
           },
           "weight": "536870912000000"
         }
@@ -31754,14 +31754,14 @@
         {
           "token": {
             "denom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
-            "amount": "1905049"
+            "amount": "2033708"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1789136"
+            "amount": "1678073"
           },
           "weight": "1073741824"
         }
@@ -31786,14 +31786,14 @@
         {
           "token": {
             "denom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
-            "amount": "525551026"
+            "amount": "546894942"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "473044360"
+            "amount": "454681426"
           },
           "weight": "1073741824"
         }
@@ -31812,20 +31812,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/972",
-        "amount": "100042159160063401596"
+        "amount": "100042185748191867865"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-            "amount": "747733033512"
+            "amount": "721347879091"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
-            "amount": "57434763666"
+            "amount": "59551997113"
           },
           "weight": "1073741824"
         }
@@ -31882,14 +31882,14 @@
         {
           "token": {
             "denom": "ibc/0E4FA664327BD40B32803EE84A77F145834C0281B7F82B65521333B3669FA0BA",
-            "amount": "9289932423714846517"
+            "amount": "9242478538750062875"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "19405290"
+            "amount": "19505123"
           },
           "weight": "536870912000000"
         }
@@ -31972,7 +31972,7 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/977",
-        "amount": "80192608834648352958"
+        "amount": "61752843305755015327"
       },
       "pool_assets": [
         {
@@ -31985,7 +31985,7 @@
         {
           "token": {
             "denom": "uosmo",
-            "amount": "5541607"
+            "amount": "3288316"
           },
           "weight": "536870912000000"
         }
@@ -32074,14 +32074,14 @@
         {
           "token": {
             "denom": "ibc/0E4FA664327BD40B32803EE84A77F145834C0281B7F82B65521333B3669FA0BA",
-            "amount": "76742572704247944"
+            "amount": "124180787387904853"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "709374"
+            "amount": "438890"
           },
           "weight": "536870912000000"
         }
@@ -32234,14 +32234,14 @@
         {
           "token": {
             "denom": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
-            "amount": "289406660"
+            "amount": "265921648"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2557408"
+            "amount": "2785597"
           },
           "weight": "536870912000000"
         }
@@ -32394,14 +32394,14 @@
         {
           "token": {
             "denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-            "amount": "251244036"
+            "amount": "234871099"
           },
           "weight": "429496729600000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "63918701"
+            "amount": "67046501"
           },
           "weight": "644245094400000"
         }
@@ -32452,20 +32452,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/992",
-        "amount": "279632783100623056610010"
+        "amount": "279604738948899002957085"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-            "amount": "658032467850"
+            "amount": "629788215645"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "106886222369"
+            "amount": "111866164380"
           },
           "weight": "536870912000000"
         }
@@ -32874,14 +32874,14 @@
         {
           "token": {
             "denom": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
-            "amount": "3476160"
+            "amount": "3724108"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4723925"
+            "amount": "4410008"
           },
           "weight": "536870912000000"
         }
@@ -32906,14 +32906,14 @@
         {
           "token": {
             "denom": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
-            "amount": "2900710392063375881"
+            "amount": "3102491684350998106"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "22546721"
+            "amount": "21086926"
           },
           "weight": "536870912000000"
         }
@@ -32938,14 +32938,14 @@
         {
           "token": {
             "denom": "ibc/63CDD51098FD99E04E5F5610A3882CBE7614C441607BA6FCD7F3A3C1CD5325F8",
-            "amount": "140601505471"
+            "amount": "139032695069"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "35866103089"
+            "amount": "36293803648"
           },
           "weight": "536870912000000"
         }
@@ -32993,20 +32993,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1009",
-        "amount": "69216737633509608227"
+        "amount": "74048077839392898052"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/3DC08BDF2689978DBCEE28C7ADC2932AA658B2F64B372760FBC5A0058669AD29",
-            "amount": "22437421781785"
+            "amount": "21887302598306"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "10420048"
+            "amount": "12227624"
           },
           "weight": "536870912000000"
         }
@@ -33031,14 +33031,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "216301"
+            "amount": "214438"
           },
           "weight": "354334801920000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "1798891"
+            "amount": "1814553"
           },
           "weight": "354334801920000"
         },
@@ -33064,20 +33064,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1011",
-        "amount": "1047203786144084473526"
+        "amount": "1028365690411382887008"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
-            "amount": "8849345650107910118635"
+            "amount": "8744203058012153534406"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "10513037187"
+            "amount": "10279485844"
           },
           "weight": "536870912000000"
         }
@@ -33096,20 +33096,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1012",
-        "amount": "194085744338641274012"
+        "amount": "194042263533377408898"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1021452096"
+            "amount": "1007409859"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/7FA7EC64490E3BDE5A1A28CBE73CC0AD22522794957BC891C46321E3A6074DB9",
-            "amount": "2689749"
+            "amount": "2727639"
           },
           "weight": "536870912000000"
         }
@@ -33128,20 +33128,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1013",
-        "amount": "840578221334854357692722288"
+        "amount": "838874722439583464235762772"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "uion",
-            "amount": "23306691"
+            "amount": "23073636"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8011326361"
+            "amount": "8060632235"
           },
           "weight": "536870912000000"
         }
@@ -33288,20 +33288,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1018",
-        "amount": "79796257641330352714"
+        "amount": "116827505490690853518"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
-            "amount": "139914485034318054392254304"
+            "amount": "211827477593849256019942828"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1769130852"
+            "amount": "2512287409"
           },
           "weight": "536870912000000"
         }
@@ -33320,20 +33320,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1019",
-        "amount": "1188259562142435081798883"
+        "amount": "1188227042833450439855470"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "4744081000"
+            "amount": "5007231341"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-            "amount": "294443666259"
+            "amount": "279358720703"
           },
           "weight": "536870912000000"
         }
@@ -33358,14 +33358,14 @@
         {
           "token": {
             "denom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
-            "amount": "83590362436"
+            "amount": "83942102959"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "66365379503"
+            "amount": "66099147918"
           },
           "weight": "536870912000000"
         }
@@ -33608,20 +33608,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1028",
-        "amount": "80987965446213122187039"
+        "amount": "386515560031478973966020"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/2F5C084037D951B24D100F15CC013A131DF786DCE1B1DBDC48F018A9B9A138DE",
-            "amount": "94093481079388287"
+            "amount": "449061713482168681"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "13253789"
+            "amount": "63253789"
           },
           "weight": "536870912000000"
         }
@@ -33714,14 +33714,14 @@
         {
           "token": {
             "denom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
-            "amount": "101930"
+            "amount": "105518"
           },
           "weight": "1073741824000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "10099508"
+            "amount": "9760374"
           },
           "weight": "1073741824000000"
         }
@@ -33840,11 +33840,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/02F196DA6FD0917DD5FEA249EE61880F4D941EE9059E7964C5C9B50AF103800F",
-          "amount": "5346395649279"
+          "amount": "5342882866570"
         },
         {
           "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
-          "amount": "13022563936003"
+          "amount": "13026647556552"
         }
       ],
       "scaling_factors": [
@@ -33871,14 +33871,14 @@
         {
           "token": {
             "denom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
-            "amount": "2961149894122"
+            "amount": "3025158468450"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "63965733721"
+            "amount": "62616756019"
           },
           "weight": "536870912000000"
         }
@@ -33967,14 +33967,14 @@
         {
           "token": {
             "denom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
-            "amount": "56571634"
+            "amount": "56559254"
           },
           "weight": "107374182400"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4843062938"
+            "amount": "4844126313"
           },
           "weight": "107374182400"
         }
@@ -34028,14 +34028,14 @@
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "216938317417"
+            "amount": "213890882814"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/D9AFCECDD361D38302AA66EB3BAC23B95234832C51D12489DC451FA2B7C72782",
-            "amount": "5887466915828"
+            "amount": "5972284228668"
           },
           "weight": "53687091200"
         }
@@ -34124,7 +34124,7 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "18557"
+            "amount": "17293"
           },
           "weight": "45171244793856"
         },
@@ -34138,7 +34138,7 @@
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "121384"
+            "amount": "130274"
           },
           "weight": "45171244793856"
         },
@@ -34170,14 +34170,14 @@
         {
           "token": {
             "denom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
-            "amount": "68556"
+            "amount": "67006"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-            "amount": "424676"
+            "amount": "434563"
           },
           "weight": "53687091200"
         }
@@ -34196,20 +34196,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1046",
-        "amount": "33631266868584761104611"
+        "amount": "32670496348529009000263"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
-            "amount": "64401846046"
+            "amount": "62396351310"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "50411027786"
+            "amount": "49219466028"
           },
           "weight": "5368709120"
         }
@@ -34234,14 +34234,14 @@
         {
           "token": {
             "denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
-            "amount": "1721893"
+            "amount": "1679088"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "132811"
+            "amount": "136207"
           },
           "weight": "53687091200"
         }
@@ -34266,14 +34266,14 @@
         {
           "token": {
             "denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
-            "amount": "2394271"
+            "amount": "2264326"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "1481827"
+            "amount": "1567207"
           },
           "weight": "53687091200"
         }
@@ -34539,20 +34539,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1057",
-        "amount": "32168889478172217778311"
+        "amount": "32399926194221305456190"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
-            "amount": "108816306162243786437"
+            "amount": "115420912885605784443"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "657177093173"
+            "amount": "629370404016"
           },
           "weight": "5368709120"
         }
@@ -34571,20 +34571,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1058",
-        "amount": "35455322516848383706"
+        "amount": "35450337355002771678"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
-            "amount": "8888597586555"
+            "amount": "8983364675371"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "311319960"
+            "amount": "307961382"
           },
           "weight": "5368709120"
         }
@@ -34641,14 +34641,14 @@
         {
           "token": {
             "denom": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
-            "amount": "2906447283"
+            "amount": "2954453263"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "522602691"
+            "amount": "514137030"
           },
           "weight": "1073741824"
         }
@@ -34673,14 +34673,14 @@
         {
           "token": {
             "denom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
-            "amount": "36269457791784547440275"
+            "amount": "36269417597688208180363"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4752687071"
+            "amount": "4773760365"
           },
           "weight": "1073741824"
         }
@@ -34734,14 +34734,14 @@
         {
           "token": {
             "denom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
-            "amount": "85297680961124915571"
+            "amount": "80769766844232921688"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "9003424"
+            "amount": "9513624"
           },
           "weight": "53687091200"
         }
@@ -34792,20 +34792,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1065",
-        "amount": "107344161753909455083795138"
+        "amount": "107344197255442174919014184"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
-            "amount": "1474389402982"
+            "amount": "1500846542696"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "15889612617"
+            "amount": "15610901412"
           },
           "weight": "5368709120"
         }
@@ -34818,15 +34818,15 @@
       "incentives_address": "osmo1h2mhtj3wmsdt3uacev9pgpg38hkcxhsmyyn9ums0ya6eddrsafjsxs9j03",
       "spread_rewards_address": "osmo16j5sssw32xuk8a0kjj8n54g25ye6kr339nz5axf8lzyeajk0k22stsm36c",
       "id": "1066",
-      "current_tick_liquidity": "61345550420789351.447744838828656508",
+      "current_tick_liquidity": "61251492791551165.431222069335746644",
       "token0": "uosmo",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "918402.962298619436692271908439909325613854",
-      "current_tick": "106434640",
+      "current_sqrt_price": "935580.060874566354631499615872733683303006",
+      "current_tick": "106753100",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:20.998175537Z"
+      "last_liquidity_update": "2024-05-18T00:07:10.235829690Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -34853,7 +34853,7 @@
       ],
       "scaling_factors": [
         "10000",
-        "10973"
+        "10980"
       ],
       "scaling_factor_controller": "osmo16r0c97w2w9u894mcgee2c0wysjkve6cvwhr6kesrtzf3vy80v3gszdcesp"
     },
@@ -34907,14 +34907,14 @@
         {
           "token": {
             "denom": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
-            "amount": "210969453628"
+            "amount": "215171268409"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "175608218"
+            "amount": "172210750"
           },
           "weight": "5368709120"
         }
@@ -34971,14 +34971,14 @@
         {
           "token": {
             "denom": "ibc/AABCB14ACAFD53A5C455BAC01EA0CA5AE18714895846681A52BFF1E3B960B44E",
-            "amount": "4447257318130"
+            "amount": "9951177266497"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "179698107"
+            "amount": "81714921"
           },
           "weight": "536870912000000"
         }
@@ -35099,14 +35099,14 @@
         {
           "token": {
             "denom": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
-            "amount": "1412217704581"
+            "amount": "1500639318222"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "96420412378"
+            "amount": "90773750551"
           },
           "weight": "536870912000000"
         }
@@ -35122,12 +35122,12 @@
       "current_tick_liquidity": "741615601.120997982822127078",
       "token0": "uosmo",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.915201417376735378994493552162413936",
-      "current_tick": "-1624064",
+      "current_sqrt_price": "0.935103932551336700497723143178205034",
+      "current_tick": "-1255807",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35135,15 +35135,15 @@
       "incentives_address": "osmo1mvnsayk8y4hvnvkyn3qhcuxhpmypdentdfaaprnxet0r9xs3hphs08fwj4",
       "spread_rewards_address": "osmo17t4zncp7dugus3hvksv25mlpam4j69mng8u22yu48uz48qtm88qsdvkg84",
       "id": "1077",
-      "current_tick_liquidity": "345515297697732.331164474226518940",
+      "current_tick_liquidity": "769399349224621.958194129014543647",
       "token0": "uosmo",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.917958611685872348417497952680310075",
-      "current_tick": "-1573520",
+      "current_sqrt_price": "0.934034828728257377026612139975418537",
+      "current_tick": "-1275790",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:30.726005451Z"
+      "last_liquidity_update": "2024-05-18T00:09:07.262351453Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35151,15 +35151,15 @@
       "incentives_address": "osmo1z2jrvqes7wadneqss49ly3znngqc6tux0h0v4dlfygcegcf5te0sn6pf97",
       "spread_rewards_address": "osmo1rw257dwqugxvn5a2q8dq9wrqw76y970l3xp8z0ndy8xrgecygrkqf5zq9r",
       "id": "1078",
-      "current_tick_liquidity": "5990754121600.762758562072871171",
+      "current_tick_liquidity": "38217459497.754033372201211140",
       "token0": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "2.904685791347070281731388739740563477",
-      "current_tick": "7437199",
+      "current_sqrt_price": "2.944435573875055521664916275207952029",
+      "current_tick": "7669700",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:05:37.612453509Z"
+      "last_liquidity_update": "2024-05-18T00:05:31.170617208Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35167,15 +35167,15 @@
       "incentives_address": "osmo1l69ezdupyq5num5mz2l3c9ua7ydh8xws5m0h679ys28snk85wmfq6qwawt",
       "spread_rewards_address": "osmo1aqv29v4fune50dxu4twccutd7pfc9qy2kg32d77qxpacwz6l4ptq3mg06d",
       "id": "1079",
-      "current_tick_liquidity": "184508236.217002355567684018",
+      "current_tick_liquidity": "3950934580.944977468358499701",
       "token0": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "2.904540459472146147558034371652568556",
-      "current_tick": "7436355",
+      "current_sqrt_price": "2.942835092618152445085652906935872369",
+      "current_tick": "7660278",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T21:54:06.339047698Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35199,15 +35199,15 @@
       "incentives_address": "osmo1pr3kq3snjp50vdstg6gu603ce28wu3f2nx3sx55znupvqzalvk2swdyvlu",
       "spread_rewards_address": "osmo1fsydxn2x328re95yvgw34y5h8s7ztpfzlf3ysexczd7xdae33wpqsy6krc",
       "id": "1081",
-      "current_tick_liquidity": "12019535211534.109273001658902844",
+      "current_tick_liquidity": "11943930593005.222487110439722393",
       "token0": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.999954983811954642243313755086468049",
-      "current_tick": "-901",
+      "current_sqrt_price": "0.999834674617994230704019018869991261",
+      "current_tick": "-3307",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-16T00:03:06.711163663Z"
+      "last_liquidity_update": "2024-05-17T22:51:43.144525629Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -35357,14 +35357,14 @@
         {
           "token": {
             "denom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
-            "amount": "150487324"
+            "amount": "148132278"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "93577074"
+            "amount": "95118895"
           },
           "weight": "536870912000000"
         }
@@ -35409,8 +35409,8 @@
       "current_tick_liquidity": "29517596588.033502199899337533",
       "token0": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "token1": "uosmo",
-      "current_sqrt_price": "1.091824830453887381602876351672731033",
-      "current_tick": "192081",
+      "current_sqrt_price": "1.069498597597906392021190141373787489",
+      "current_tick": "143827",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -35438,15 +35438,15 @@
       "incentives_address": "osmo16xr6sjfs5sqxc49dnhk4cs5vsnw5trhg3l5hywpdvg4rvmayxq2q9tk4r7",
       "spread_rewards_address": "osmo1hayskh43xqcwegraw5q8nu2vnamf20vlc9pygk99agq88q6hhprszm3j2c",
       "id": "1090",
-      "current_tick_liquidity": "59078410373.139687742059099858",
+      "current_tick_liquidity": "60957241956.088585268628419931",
       "token0": "uosmo",
       "token1": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-      "current_sqrt_price": "0.035679516884182012833694576804895411",
-      "current_tick": "-26726973",
+      "current_sqrt_price": "0.036121221900643097269368856687992620",
+      "current_tick": "-26695258",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:50:18.029685899Z"
+      "last_liquidity_update": "2024-05-17T16:40:21.415278533Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35457,12 +35457,12 @@
       "current_tick_liquidity": "832238139867.507790629846583162",
       "token0": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "token1": "uosmo",
-      "current_sqrt_price": "0.028902592115399968176445026624618844",
-      "current_tick": "-28646402",
+      "current_sqrt_price": "0.028706055276386855458031451729422824",
+      "current_tick": "-28759624",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T02:17:26.945249791Z"
+      "last_liquidity_update": "2024-05-16T14:18:59.258472571Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35470,15 +35470,15 @@
       "incentives_address": "osmo1f7hew09pfzk6zzw47lhendwr9pwhxy226nszht72j0vj2mav4h3q0gnsec",
       "spread_rewards_address": "osmo12qdqtacalad6wr6f3w8dqsjkjdpkl5c7ajwt3ahs3e4crrylvz5q3uujua",
       "id": "1092",
-      "current_tick_liquidity": "11085110582740.090232042085588914",
+      "current_tick_liquidity": "11038127907433.191601495238040263",
       "token0": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "token1": "uosmo",
-      "current_sqrt_price": "0.038548157780022169115296523887120511",
-      "current_tick": "-26514040",
+      "current_sqrt_price": "0.037919393355275636493037853199391053",
+      "current_tick": "-26562120",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:27:18.805261222Z"
+      "last_liquidity_update": "2024-05-17T21:38:10.525035558Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35486,15 +35486,15 @@
       "incentives_address": "osmo16hyfl0klnhqwudu4xdaw3wcy9pmu0zv8m9tlcfzyqmn280jwtwqsd5u023",
       "spread_rewards_address": "osmo1m6v52t5u8usxrse6wev20end6vgn4sl4yqm6php7ez6806qk08vsjjaatp",
       "id": "1093",
-      "current_tick_liquidity": "943724562242.578712622603454547",
+      "current_tick_liquidity": "980902238313.982090545869910498",
       "token0": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "token1": "uosmo",
-      "current_sqrt_price": "2.615013708976466663056700169037036950",
-      "current_tick": "5838296",
+      "current_sqrt_price": "2.593678425479203839405848231993537577",
+      "current_tick": "5727167",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:03.308250681Z"
+      "last_liquidity_update": "2024-05-17T23:44:20.891868502Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35502,15 +35502,15 @@
       "incentives_address": "osmo1ra5er4lutaypglaae3s0ddtkrmca0em3k68w7xtlzmckfw74w8kqrmrt5z",
       "spread_rewards_address": "osmo1k6jxxjueautg03f7nruhejrdnxyy5628df8r7n0v6rc033pmtz4svc0c9p",
       "id": "1094",
-      "current_tick_liquidity": "2046095175225.618422708454091205",
+      "current_tick_liquidity": "1040347945709.662758982707309345",
       "token0": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
       "token1": "uosmo",
-      "current_sqrt_price": "1.122696336312264189825788583911649247",
-      "current_tick": "260447",
+      "current_sqrt_price": "1.084210368422660373133994019844773054",
+      "current_tick": "175512",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:18:55.764826539Z"
+      "last_liquidity_update": "2024-05-17T19:31:28.585785801Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35518,15 +35518,15 @@
       "incentives_address": "osmo1q6mwcej2hwr9y8uswjzuhzxqt6qamjjtskxv9d97txyx0xh04gas8ns9wr",
       "spread_rewards_address": "osmo15qhcyq5vwwghk525rufj6mv3rd64y6zf8vc8wukelgjdqx9zmeuq3n7hhl",
       "id": "1095",
-      "current_tick_liquidity": "959948093681.671159935844666986",
+      "current_tick_liquidity": "826625922694.178836581836448460",
       "token0": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "token1": "uosmo",
-      "current_sqrt_price": "0.680343052218432504397456373325928735",
-      "current_tick": "-5371334",
+      "current_sqrt_price": "0.657511657314830474471391547437817076",
+      "current_tick": "-5676785",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:19:02.754587858Z"
+      "last_liquidity_update": "2024-05-17T22:50:26.828017286Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35534,15 +35534,15 @@
       "incentives_address": "osmo17vrdduamkeuwsk38arpgw837adh0x0atx5x4rk5dy0xddd5u4lhqkxnzx3",
       "spread_rewards_address": "osmo1lwfj55cku27nr5j6tjawma9pjgy26p9j2cy73m4qqwarcvp76pfq8camyk",
       "id": "1096",
-      "current_tick_liquidity": "6515047532456.716408903671927695",
+      "current_tick_liquidity": "5762730668230.430347002415276191",
       "token0": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
       "token1": "uosmo",
-      "current_sqrt_price": "0.153429454083946237751026135670000329",
-      "current_tick": "-16645941",
+      "current_sqrt_price": "0.152466126347904975144917022559321347",
+      "current_tick": "-16675409",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.003000000000000000",
-      "last_liquidity_update": "2024-05-15T23:49:56.632639961Z"
+      "last_liquidity_update": "2024-05-17T22:28:31.647819795Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35550,15 +35550,15 @@
       "incentives_address": "osmo1458yw4vdzk3pm06t83mqt5vur36rrhgefyes5ffra6j4wm4c050smrs0fd",
       "spread_rewards_address": "osmo1q43pd7pcmt3fepgwv6x7el4j93haxvha2nn2t3nk33lcttqs5l7syp7jfq",
       "id": "1097",
-      "current_tick_liquidity": "406301432477.307422884295653547",
+      "current_tick_liquidity": "401622630860.419778045465691931",
       "token0": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "token1": "uosmo",
-      "current_sqrt_price": "0.458245392204501160189238150963825611",
-      "current_tick": "-7900112",
+      "current_sqrt_price": "0.438739116764507890676712606488942400",
+      "current_tick": "-8075080",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.003000000000000000",
-      "last_liquidity_update": "2024-05-15T18:54:20.534980329Z"
+      "last_liquidity_update": "2024-05-17T22:56:05.023520246Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35566,15 +35566,15 @@
       "incentives_address": "osmo130pft3q5pukgk9ygxwqc7pepeq2p8n4h8f48d5vtv3v5jkpd5yqqtkup3y",
       "spread_rewards_address": "osmo1hp5wm2gkhyzzqy05585k6d387sgze5yt4x2rt76llzrhjc308ytqc6ftpg",
       "id": "1098",
-      "current_tick_liquidity": "322006501535.448225429782316640",
+      "current_tick_liquidity": "255815355199.895826326843809477",
       "token0": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
       "token1": "uosmo",
-      "current_sqrt_price": "1.495933565657773708790311902432563770",
-      "current_tick": "1237817",
+      "current_sqrt_price": "1.444471088516668426166571912163788147",
+      "current_tick": "1086496",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:06:05.691097620Z"
+      "last_liquidity_update": "2024-05-17T22:44:21.448717999Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35582,15 +35582,15 @@
       "incentives_address": "osmo17e07gjw092r5ssvmzfg7wkz608kfmwy3aauu4mjrjedtmyrzy9zswa3w48",
       "spread_rewards_address": "osmo1fsfpwekv8q0vw6l2t5v7uxth8cswduk2mcyefuqns30sldqh7zvq4te2j8",
       "id": "1099",
-      "current_tick_liquidity": "319189894200.356839925972113005",
+      "current_tick_liquidity": "231252451124.889436339965784116",
       "token0": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
       "token1": "uosmo",
-      "current_sqrt_price": "0.299495850314794102229545924572263917",
-      "current_tick": "-10030224",
+      "current_sqrt_price": "0.284128212165888666694412877859604467",
+      "current_tick": "-10927116",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T22:35:21.028565645Z"
+      "last_liquidity_update": "2024-05-17T23:56:15.072912900Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35598,15 +35598,15 @@
       "incentives_address": "osmo1uzde9cszmufdltx7pr25rl7jcm75h46takmzsclnrdpjy38x6eqsgczrme",
       "spread_rewards_address": "osmo1tkqvf4v5ykuafwetdncwtd0fk8u05reyaklp8v0pdv3jecu26xcszq253n",
       "id": "1100",
-      "current_tick_liquidity": "3909119425.031763240828776292",
+      "current_tick_liquidity": "3921614001.719708885558807708",
       "token0": "uion",
       "token1": "uosmo",
-      "current_sqrt_price": "18.554617465208772040746568343583664745",
-      "current_tick": "20442738",
+      "current_sqrt_price": "18.665481955622313711217517485936418450",
+      "current_tick": "20484002",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-15T22:33:04.272090506Z"
+      "last_liquidity_update": "2024-05-16T22:09:14.413938789Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35614,15 +35614,15 @@
       "incentives_address": "osmo1lyglnau80ngsyekx6wvwaw6dpmfs6l9x96497vmwlv3tzqw6mzwqwep8gz",
       "spread_rewards_address": "osmo1tnp0axdehrv6dug79j5mjsyvmdkm9mtaqn30c8vnddgqf06c7weqzvg2t2",
       "id": "1101",
-      "current_tick_liquidity": "110349159781.652134688233187812",
+      "current_tick_liquidity": "111175588570.566484562808965399",
       "token0": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "token1": "uosmo",
-      "current_sqrt_price": "0.544748039820756826619650277286432444",
-      "current_tick": "-7032496",
+      "current_sqrt_price": "0.538099559852967721319355183497666841",
+      "current_tick": "-7104489",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T21:02:55.961888036Z"
+      "last_liquidity_update": "2024-05-17T21:20:16.006015746Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35633,8 +35633,8 @@
       "current_tick_liquidity": "5504735055.893617401396917883",
       "token0": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
       "token1": "uosmo",
-      "current_sqrt_price": "0.119026188334590991792598315033719244",
-      "current_tick": "-17583277",
+      "current_sqrt_price": "0.118078261269049628316979638294857021",
+      "current_tick": "-17605753",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -35646,15 +35646,15 @@
       "incentives_address": "osmo1fq6cytv3vy6pxxy0vg32esx4zdemen8zwrl909kyfadmqm37kwvsd6ujfu",
       "spread_rewards_address": "osmo1h0zyl0ln2ufurkxsakvlgcz83thg3vdcrtffcnazpd35pl0gg7vs7lxl8a",
       "id": "1103",
-      "current_tick_liquidity": "165204472622.292185500688673368",
+      "current_tick_liquidity": "173603646619.141614172403713811",
       "token0": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
       "token1": "uosmo",
-      "current_sqrt_price": "0.297185198764161102674842025361450144",
-      "current_tick": "-10168096",
+      "current_sqrt_price": "0.305198660380404089941664118347142502",
+      "current_tick": "-9685378",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:15:44.453452772Z"
+      "last_liquidity_update": "2024-05-17T23:20:51.455244703Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35662,15 +35662,15 @@
       "incentives_address": "osmo1h4jj2rqwnnnxpyt4dsxd7gf5cga0lvdumc5tu5ka6n73wlfu89dqa708cp",
       "spread_rewards_address": "osmo109yzlrgp5ch69ewkxx7hny72x45xyeu8v6r5kxatstkgngzzgytqgn5ev2",
       "id": "1104",
-      "current_tick_liquidity": "529316344881.442083368471600617",
+      "current_tick_liquidity": "529006727176.811229710219954306",
       "token0": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
       "token1": "uosmo",
-      "current_sqrt_price": "0.345368428216395735305861690373538254",
-      "current_tick": "-8807207",
+      "current_sqrt_price": "0.346833444758338572122780195316862501",
+      "current_tick": "-8797066",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:56:28.914921443Z"
+      "last_liquidity_update": "2024-05-17T23:15:39.375723818Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35678,15 +35678,15 @@
       "incentives_address": "osmo19vcqr9njqfeh3gtfeepssmzfvqnzcrzajseapey5z7z32pz9nths3n40jn",
       "spread_rewards_address": "osmo173p8z5etqvwpslty2eudu8kufq6v6npetvfrtcc2nvdwdah6gvsqasghlr",
       "id": "1105",
-      "current_tick_liquidity": "155556137032.369715488819207554",
+      "current_tick_liquidity": "154428486357.141399143637833041",
       "token0": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
       "token1": "uosmo",
-      "current_sqrt_price": "0.883133432902801678049994253177320619",
-      "current_tick": "-2200754",
+      "current_sqrt_price": "0.876257775630205786923326943730831920",
+      "current_tick": "-2321724",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T20:15:49.482301670Z"
+      "last_liquidity_update": "2024-05-17T21:50:30.885786244Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35697,8 +35697,8 @@
       "current_tick_liquidity": "94877406423.626017325830356955",
       "token0": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "token1": "uosmo",
-      "current_sqrt_price": "0.169364818777726421900837407757353867",
-      "current_tick": "-16131556",
+      "current_sqrt_price": "0.164635233480535336782792054547976207",
+      "current_tick": "-16289524",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -35710,15 +35710,15 @@
       "incentives_address": "osmo16j4swylreem7e4yzkgqrhzcq5j47dc6k05kn3pjh9nwfpd6c74pqqjw0l0",
       "spread_rewards_address": "osmo13mewqndyxdf6cq7s8kyhe5c5sne5u2m7u3629xvd0traw2p2846qwgqh0v",
       "id": "1107",
-      "current_tick_liquidity": "373140568.375341662575897288",
+      "current_tick_liquidity": "850596497.565590336969931982",
       "token0": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
       "token1": "uosmo",
-      "current_sqrt_price": "9.282903359381545120236302199819012451",
-      "current_tick": "16617229",
+      "current_sqrt_price": "9.281201109762102447356909905762652423",
+      "current_tick": "16614069",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.003000000000000000",
-      "last_liquidity_update": "2024-05-15T23:47:45.995781898Z"
+      "last_liquidity_update": "2024-05-16T15:54:14.364603995Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35726,15 +35726,15 @@
       "incentives_address": "osmo1fzy3h8rpdn39ngx3gpjlzh3894kpfnpkechwj6p3mmuymqf3hhtqle0a2a",
       "spread_rewards_address": "osmo1eyg2m2dfa5uuasg2suq49q3mlv5y873jhv9fwvse8r036c3p0v2q94apmg",
       "id": "1108",
-      "current_tick_liquidity": "1165063222802.073128720688566827",
+      "current_tick_liquidity": "1165129392187.313994706888640997",
       "token0": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "token1": "uosmo",
-      "current_sqrt_price": "0.037642844319057103551604197256110700",
-      "current_tick": "-26583017",
+      "current_sqrt_price": "0.037315628972787160494377916681220347",
+      "current_tick": "-26607544",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T08:39:14.898281918Z"
+      "last_liquidity_update": "2024-05-17T23:45:41.365845425Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35745,8 +35745,8 @@
       "current_tick_liquidity": "1034625182608.489115832509650745",
       "token0": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "token1": "uosmo",
-      "current_sqrt_price": "0.101895623519864211090597363105119870",
-      "current_tick": "-17961729",
+      "current_sqrt_price": "0.101856547311111698997111801290285890",
+      "current_tick": "-17962525",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -35758,15 +35758,15 @@
       "incentives_address": "osmo1ac5kh9kqcxmvklw4rqxupxec30w9f79rstwnzy30ucmamakdftcsyfc233",
       "spread_rewards_address": "osmo19wm32vnmr89v2g9nuqgqz4edday5xx55kvrwd3354t2w0e4vzqls04vtgx",
       "id": "1110",
-      "current_tick_liquidity": "5966863084243.668877921305065809",
+      "current_tick_liquidity": "5966772584462.671560254007412247",
       "token0": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "token1": "uosmo",
-      "current_sqrt_price": "0.056910098106817053558320962045340836",
-      "current_tick": "-24761241",
+      "current_sqrt_price": "0.055950749118661391402514468442949323",
+      "current_tick": "-24869514",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T22:26:29.610034775Z"
+      "last_liquidity_update": "2024-05-16T00:55:05.929984816Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35774,15 +35774,15 @@
       "incentives_address": "osmo10wz6z83ka7jz5w6ygmmwm39ttwf2rul3hl8zjyzzrnudcck679nqefye6r",
       "spread_rewards_address": "osmo1c32q5smvudllrlxf5wkv0me859zq0pc39z8wgde94rc4h9weyzgsrp4934",
       "id": "1111",
-      "current_tick_liquidity": "8216908724205.371329986937592975",
+      "current_tick_liquidity": "8830954198566.691678775766923369",
       "token0": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "token1": "uosmo",
-      "current_sqrt_price": "0.010873424592301824518432205195740174",
-      "current_tick": "-35817687",
+      "current_sqrt_price": "0.011721922112741206343894179335029599",
+      "current_tick": "-35625966",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:49:25.624071625Z"
+      "last_liquidity_update": "2024-05-17T23:33:50.311060965Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35790,15 +35790,15 @@
       "incentives_address": "osmo102ygrdl0u33z32wsh64du7xhurj3ku9vv89npex9q87q9z43v6ys9ddf9x",
       "spread_rewards_address": "osmo1vulpzgycv6q7ms2jxlvu5gzvpwzdwdeuckjlcxt250u9xvfqeqfqh7egpr",
       "id": "1112",
-      "current_tick_liquidity": "9370564362.909140147749610897",
+      "current_tick_liquidity": "8978574377.388195663759927602",
       "token0": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
       "token1": "uosmo",
-      "current_sqrt_price": "0.949645000319684072022367053180510766",
-      "current_tick": "-981744",
+      "current_sqrt_price": "0.913003696298067571251474316076486210",
+      "current_tick": "-1664243",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T10:05:16.301026767Z"
+      "last_liquidity_update": "2024-05-16T04:34:49.646874522Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35806,15 +35806,15 @@
       "incentives_address": "osmo15fsmgrfehh2gs6nagwyfj7f8xktnm0zqqcstks0t7r8l77k4efeqe9ztu8",
       "spread_rewards_address": "osmo1kaw9598a734tgpylhe4jk4e0zzfcyfvqwhxyh8nzagkfqgsrdwfqmtuv32",
       "id": "1113",
-      "current_tick_liquidity": "726379526732.788713721266914089",
+      "current_tick_liquidity": "726667371271.637796065578646047",
       "token0": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
       "token1": "uosmo",
-      "current_sqrt_price": "0.044768187896624390352503503404302801",
-      "current_tick": "-25995810",
+      "current_sqrt_price": "0.044799658496040927287894612665732775",
+      "current_tick": "-25992991",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T22:01:46.842755285Z"
+      "last_liquidity_update": "2024-05-17T21:36:01.364458233Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35822,15 +35822,15 @@
       "incentives_address": "osmo1xr3r942kkpmmq2s6az5mjk2d8vh3fv99ewcmq0s3pjzct2d28n0qyg56cu",
       "spread_rewards_address": "osmo1x5ahhr33ttmnhc5ex07lextq3ccj8ka0usdwrydj097exjs390ysxjqyp5",
       "id": "1114",
-      "current_tick_liquidity": "1067988758887.773576482870604669",
+      "current_tick_liquidity": "804090882193.221222357766947092",
       "token0": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
       "token1": "uosmo",
-      "current_sqrt_price": "0.791015289749097403789318451791721343",
-      "current_tick": "-3742949",
+      "current_sqrt_price": "0.801903790577039876179030783941125088",
+      "current_tick": "-3569504",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:55:45.775063561Z"
+      "last_liquidity_update": "2024-05-17T23:05:27.597813296Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35854,15 +35854,15 @@
       "incentives_address": "osmo1d62wdmcqqd45yfnvlh8y4p362p96sfxzlp4dv64rtjw0gcexl3ksqkcvlt",
       "spread_rewards_address": "osmo1fj282uc9538fdrcmdddq38d2vfqrffejmzzefwr7r9daetplupuqlkdg3v",
       "id": "1116",
-      "current_tick_liquidity": "325917137.124140921431232948",
+      "current_tick_liquidity": "1741341325.549632030783941960",
       "token0": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.730089702049869532422412271701285511",
-      "current_tick": "-4669691",
+      "current_sqrt_price": "0.750131397169786853342170528940297795",
+      "current_tick": "-4373029",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T21:43:30.090889182Z"
+      "last_liquidity_update": "2024-05-17T15:55:43.323141357Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -35960,11 +35960,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/5A0060579D24FBE5268BEA74C3281E7FE533D361C41A99307B4998FEC611E46B",
-          "amount": "388818478083"
+          "amount": "387998726820"
         },
         {
           "denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
-          "amount": "385554299411"
+          "amount": "386376590483"
         }
       ],
       "scaling_factors": [
@@ -35991,14 +35991,14 @@
         {
           "token": {
             "denom": "ibc/DEE262653B9DE39BCEF0493D47E0DFC4FE62F7F046CF38B9FDEFEBE98D149A71",
-            "amount": "39041081825994327791092"
+            "amount": "38833929501600917280385"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "38286026372"
+            "amount": "38490758142"
           },
           "weight": "5368709120"
         }
@@ -36046,8 +36046,8 @@
       "current_tick_liquidity": "39047673.103451343628103070",
       "token0": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "1.261244955194192161499787575605740936",
-      "current_tick": "590738",
+      "current_sqrt_price": "1.309057090044168251189995781383727648",
+      "current_tick": "713630",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36126,12 +36126,12 @@
       "current_tick_liquidity": "0.000000000000000000",
       "token0": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.117404111164756841527410468768350016",
-      "current_tick": "-17621628",
+      "current_sqrt_price": "0.000000000000000000000000000000000000",
+      "current_tick": "0",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-03-29T09:22:59.085353377Z"
+      "last_liquidity_update": "2024-05-17T03:14:04.105361721Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36142,8 +36142,8 @@
       "current_tick_liquidity": "1216824106.455154535703930303",
       "token0": "ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.014335194073468591895827614154384643",
-      "current_tick": "-34945023",
+      "current_sqrt_price": "0.017969172418031383022700954999558788",
+      "current_tick": "-33771089",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36171,15 +36171,15 @@
       "incentives_address": "osmo1rxpaqaeddy86n7vluutyp3546pehhk24jk4452e59rpm42t4nxyqrsftnt",
       "spread_rewards_address": "osmo10hsrgvpfannfjs7ttezxaln8sgkd3x69fkf68xzj9a3d2nv7tens5u25ay",
       "id": "1131",
-      "current_tick_liquidity": "230373822355.514791804812831006",
+      "current_tick_liquidity": "172782870996.160109142852742192",
       "token0": "ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.997080244529024198083558221410731102",
-      "current_tick": "-58310",
+      "current_sqrt_price": "0.995438936215926230456694463724131128",
+      "current_tick": "-91014",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-04-17T10:00:37.499865230Z"
+      "last_liquidity_update": "2024-05-17T12:16:40.149827065Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -36219,15 +36219,15 @@
       "incentives_address": "osmo1mpr03ag48mjswtwsllwmxx0jen2x0xq4nc54dvvxxvcucy97ue9qg66nf8",
       "spread_rewards_address": "osmo1k85clpg9v86h3jlt6fxkfu5jc3lgw4hyug6jmhuut44nj2w4k0ws57wqgm",
       "id": "1133",
-      "current_tick_liquidity": "1746514841172.658585203863086082",
+      "current_tick_liquidity": "1708239822357.755894508480944814",
       "token0": "uosmo",
       "token1": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-      "current_sqrt_price": "0.917592733946612265148660679976389838",
-      "current_tick": "-1580236",
+      "current_sqrt_price": "0.935065781716745877628531733832461399",
+      "current_tick": "-1256520",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:49:02.450421496Z"
+      "last_liquidity_update": "2024-05-17T19:21:19.431675530Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36235,15 +36235,15 @@
       "incentives_address": "osmo1faws2dw7v7htacwsggnl7azzg4lercgs533ajqa7rnvgxzm2fd0suxsa0a",
       "spread_rewards_address": "osmo1w0engrwdr6kuxjtmpyygm4pevufjg940kf2ya6s78gtpgrt60s7s4gzk6v",
       "id": "1134",
-      "current_tick_liquidity": "8188105175907012411.588564934499360363",
+      "current_tick_liquidity": "4712259025719480502.994151362526933932",
       "token0": "uosmo",
       "token1": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "current_sqrt_price": "16665.750773645328438958260095176504380944",
-      "current_tick": "73777472",
+      "current_sqrt_price": "16827.097756953298594579801570010784401887",
+      "current_tick": "73831512",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:59:00.425345139Z"
+      "last_liquidity_update": "2024-05-18T00:13:08.113336124Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36251,15 +36251,15 @@
       "incentives_address": "osmo195e7qr4l7z9rtnc8cwm9646pk9slu8ve8c0pjmvt6hzqsmy04uzqe530fs",
       "spread_rewards_address": "osmo1y53uxff98xn2xftdxk2du85j88r8cxg6hndldl0uxln52ds4ukvs8zt345",
       "id": "1135",
-      "current_tick_liquidity": "25387860692516.041884489283163954",
+      "current_tick_liquidity": "2802127223128.905965117778189479",
       "token0": "uosmo",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "0.315676463655273721497113889268768182",
-      "current_tick": "-9034838",
+      "current_sqrt_price": "0.317797977802448478354803421658597859",
+      "current_tick": "-8990045",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:59.507423245Z"
+      "last_liquidity_update": "2024-05-18T00:13:08.113336124Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36267,15 +36267,15 @@
       "incentives_address": "osmo1h9qzx4rgzdexg39usx59h9plnn606mdgfk8aymk667s96hvte5tshp00xr",
       "spread_rewards_address": "osmo1awtgwnc5wqqz6q2538ljyea5840c5c80pmy829klhqjkjaletnnqc53xpx",
       "id": "1136",
-      "current_tick_liquidity": "5898174856316.580041710272563785",
+      "current_tick_liquidity": "1117737232132.575319495550821319",
       "token0": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "1.156794170559974024806344730761661895",
-      "current_tick": "338172",
+      "current_sqrt_price": "1.156737583085564939153187661465060840",
+      "current_tick": "338041",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.003000000000000000",
-      "last_liquidity_update": "2024-05-15T21:33:13.600921343Z"
+      "last_liquidity_update": "2024-05-18T00:03:27.409895713Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -36289,20 +36289,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1137",
-        "amount": "41748345133163637866026"
+        "amount": "41796062672569087453431"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
-            "amount": "1879031324729"
+            "amount": "1843288400870"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "51122834338"
+            "amount": "52277843091"
           },
           "weight": "536870912000000"
         }
@@ -36423,14 +36423,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "6096656"
+            "amount": "6240357"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "63480658"
+            "amount": "62023594"
           },
           "weight": "536870912000000"
         }
@@ -36455,14 +36455,14 @@
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "3646850"
+            "amount": "3841872"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uion",
-            "amount": "13561"
+            "amount": "12876"
           },
           "weight": "536870912000000"
         }
@@ -36487,14 +36487,14 @@
         {
           "token": {
             "denom": "ibc/D69F6D787EC649F4E998161A9F0646F4C2DCC64748A2AB982F14CAFBA7CC0EC9",
-            "amount": "4688698518733"
+            "amount": "4664443084358"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "37446945"
+            "amount": "37642062"
           },
           "weight": "536870912000000"
         }
@@ -36507,15 +36507,15 @@
       "incentives_address": "osmo1lqapuk5m5p2x2xwvsc28rajsmwwhryp6yksvmm9rwypkca04xnuqx0clsj",
       "spread_rewards_address": "osmo1lyqznq6na3hysggfheczln3rgurckqt3c6wzzmcl0ry803ykhxxq3482xa",
       "id": "1144",
-      "current_tick_liquidity": "48274817611.485625661157181161",
+      "current_tick_liquidity": "317396860785.804958283299144385",
       "token0": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.026437581370814636857280410682274790",
-      "current_tick": "-30010543",
+      "current_sqrt_price": "0.026603468427094400393036017647191305",
+      "current_tick": "-29922555",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T13:37:14.528577787Z"
+      "last_liquidity_update": "2024-05-16T13:18:52.160062592Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36523,15 +36523,15 @@
       "incentives_address": "osmo1uqxknn59sl7qw48x9hut5gssl6qhhr0ldclpwamlrwauggnxagxq896dcy",
       "spread_rewards_address": "osmo1hs8qwm0wumjup8qr4n47d70ek2esqajg2jcr2v53gswg94xperdsncazv0",
       "id": "1145",
-      "current_tick_liquidity": "327318950040.828253391065909472",
+      "current_tick_liquidity": "1943698279045.511554138334352708",
       "token0": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
       "token1": "uosmo",
-      "current_sqrt_price": "0.028849809209068717220043206212415677",
-      "current_tick": "-28676886",
+      "current_sqrt_price": "0.028414859039863744517607797549048732",
+      "current_tick": "-28925958",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:51:50.210047895Z"
+      "last_liquidity_update": "2024-05-17T23:51:54.097430263Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36542,8 +36542,8 @@
       "current_tick_liquidity": "620334406.096505028531076311",
       "token0": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "1.060722164078654752719074165233247616",
-      "current_tick": "125131",
+      "current_sqrt_price": "1.057836996321355670414064324733270219",
+      "current_tick": "119019",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -36603,15 +36603,15 @@
       "incentives_address": "osmo1dd50atpzwd7mpxrsznxtk2dhwpxxxn3kser2dd0zz8ld78e32l6qcccu7r",
       "spread_rewards_address": "osmo1qh3kuusrwatfz4h77xzxptc42dh9tt6j5lzup6wmxndx3s3mhqcqgphmhp",
       "id": "1150",
-      "current_tick_liquidity": "441116937202109.691070156075363550",
+      "current_tick_liquidity": "441385852336956.090975773688291279",
       "token0": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "1.001121923546788413347393516114756703",
-      "current_tick": "2245",
+      "current_sqrt_price": "1.001114882144374183436083673873777511",
+      "current_tick": "2231",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:08:59.139908844Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36622,8 +36622,8 @@
       "current_tick_liquidity": "1937893393814.136819842419686942",
       "token0": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
       "token1": "uosmo",
-      "current_sqrt_price": "0.005941363936690338557440456453107843",
-      "current_tick": "-42470020",
+      "current_sqrt_price": "0.005848802424982326813728686650163998",
+      "current_tick": "-42579152",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36638,8 +36638,8 @@
       "current_tick_liquidity": "115140452530.125993148006315706",
       "token0": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.005429743901806696433056113398468134",
-      "current_tick": "-43051789",
+      "current_sqrt_price": "0.005474376974022166796336760113482190",
+      "current_tick": "-43003120",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36651,15 +36651,15 @@
       "incentives_address": "osmo1e490qd980zrl76xlagwrvaq92v3gjnfgrgdutaa0lpw570ygvq2qd94ram",
       "spread_rewards_address": "osmo1n4vlgayle5vnngkaq6juwd3w3tq276xx5mkltqyqtycm2nwu0qxqycvas9",
       "id": "1153",
-      "current_tick_liquidity": "10080878690.422412352854645101",
+      "current_tick_liquidity": "4077042299.459276602083589388",
       "token0": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.163870624238303204696144419749025403",
-      "current_tick": "-16314642",
+      "current_sqrt_price": "0.167856187790191830485489050034722284",
+      "current_tick": "-16182431",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-13T22:37:28.983504340Z"
+      "last_liquidity_update": "2024-05-17T23:49:52.629155201Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36734,8 +36734,8 @@
       "current_tick_liquidity": "225212428704.646375274375646491",
       "token0": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.134659605185561529465101660137807392",
-      "current_tick": "-17186680",
+      "current_sqrt_price": "0.134652703378462325325512872326005016",
+      "current_tick": "-17186865",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36747,15 +36747,15 @@
       "incentives_address": "osmo1u0tv66jw0w06gkph70a2ud5dtygxfgxl7qs89apvtzdvvtqxnvus7f2jgn",
       "spread_rewards_address": "osmo16038k3zcjv5xscm7casj0flvfavdry90gc78xs5870tu2k3p9n0s5fqn4x",
       "id": "1159",
-      "current_tick_liquidity": "4423430872.817757847412221838",
+      "current_tick_liquidity": "4419384138.777825427069877982",
       "token0": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.370575498128400108458126197770081940",
-      "current_tick": "-8626739",
+      "current_sqrt_price": "0.394015463810785228368083191706143223",
+      "current_tick": "-8447519",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-12T23:54:02.601721654Z"
+      "last_liquidity_update": "2024-05-17T13:08:21.906620912Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36779,15 +36779,15 @@
       "incentives_address": "osmo16fsm9rwvg50lmq7ajkvyn38z4y6m4mtk0c9e3gac569fe0uq7wtsqwgk0y",
       "spread_rewards_address": "osmo1rckac6wpsyxxaldyfxdw7nzkudrngpvga4cxe5l3reyyc8sracwsyg4epa",
       "id": "1161",
-      "current_tick_liquidity": "26071727381.393518052217458040",
+      "current_tick_liquidity": "40564650891.309636087610850099",
       "token0": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "1.219694639540188433279743911689174287",
-      "current_tick": "487655",
+      "current_sqrt_price": "1.271782699172828169733113881553176262",
+      "current_tick": "617431",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:16:18.878807440Z"
+      "last_liquidity_update": "2024-05-18T00:09:02.030212418Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36811,15 +36811,15 @@
       "incentives_address": "osmo19kg5y79eezp4fuv3ednhysk8l0vfmu95gp0ylpavs8709vunzqesh7jz7t",
       "spread_rewards_address": "osmo1uf4gxzl25ry9uk0mld9we3jpvjan9n6sfkgn7fjxx2c8tu5dudtqsxthet",
       "id": "1163",
-      "current_tick_liquidity": "107737969041.405683269600730901",
+      "current_tick_liquidity": "113360181248.517570767903574507",
       "token0": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.768099451338638047480735272363187158",
-      "current_tick": "-4100233",
+      "current_sqrt_price": "0.769772740182813589400320976536515821",
+      "current_tick": "-4074500",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:46:09.052978164Z"
+      "last_liquidity_update": "2024-05-17T13:54:15.794955412Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -36926,8 +36926,8 @@
       "current_tick_liquidity": "3853345778.198427688834961903",
       "token0": "ibc/0B3D528E74E3DEAADF8A68F393887AC7E06028904D02173561B0D27F6E751D0A",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.182649137111189021223392084430127778",
-      "current_tick": "-15663930",
+      "current_sqrt_price": "0.182076012335178019024911299186012432",
+      "current_tick": "-15684833",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36958,8 +36958,8 @@
       "current_tick_liquidity": "950360829.428334884907112858",
       "token0": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.134499937353533897564971628849587216",
-      "current_tick": "-17190977",
+      "current_sqrt_price": "0.137161431723482929515713597693122581",
+      "current_tick": "-17118675",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -36983,14 +36983,14 @@
         {
           "token": {
             "denom": "ibc/95C9B5870F95E21A242E6AF9ADCB1F212EE4A8855087226C36FBE43FC41A77B8",
-            "amount": "173069430909744679947621"
+            "amount": "175445565849140071748260"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "29096954524"
+            "amount": "28707825131"
           },
           "weight": "536870912000000"
         }
@@ -37119,20 +37119,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1179",
-        "amount": "100502831904610867613452"
+        "amount": "100458613761337321964779"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1CDF9C7D073DD59ED06F15DB08CC0901F2A24759BE70463570E8896F9A444ADF",
-            "amount": "860146126608082100491"
+            "amount": "848016739526484670343"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1586742553"
+            "amount": "1610596804"
           },
           "weight": "536870912000000"
         }
@@ -37151,20 +37151,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1180",
-        "amount": "940036854103480266422700"
+        "amount": "942363664573193187375300"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1CDF9C7D073DD59ED06F15DB08CC0901F2A24759BE70463570E8896F9A444ADF",
-            "amount": "32725192713775911091069"
+            "amount": "31907095949350315619061"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "5980962373"
+            "amount": "6169214038"
           },
           "weight": "536870912000000"
         }
@@ -37305,15 +37305,15 @@
       "incentives_address": "osmo103jatcwfcgqpamwd3977a36qs89adylnz8vzvsx7rh67fn3q7qusfhmza0",
       "spread_rewards_address": "osmo1jl3u8v3hvm9a50uns356ld22vfs4wnqcsjkqca2syfzqd49nwkfqfgjm44",
       "id": "1189",
-      "current_tick_liquidity": "84107560753.288734155968859006",
+      "current_tick_liquidity": "84233346671.313283889317827829",
       "token0": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "1.030524330131611520775240817365077949",
-      "current_tick": "61980",
+      "current_sqrt_price": "1.014489527643674987228878308066333001",
+      "current_tick": "29189",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T12:43:54.827465806Z"
+      "last_liquidity_update": "2024-05-17T08:01:51.865404921Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -37564,8 +37564,8 @@
       "current_tick_liquidity": "5026284778385.679309712445080792",
       "token0": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.052187609521561287592427797555911301",
-      "current_tick": "-25276454",
+      "current_sqrt_price": "0.052365855616893019539324558170490638",
+      "current_tick": "-25257818",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -37690,12 +37690,12 @@
       "current_tick_liquidity": "1542090406216485321094.638813075035520260",
       "token0": "ibc/FBB3FEF80ED2344D821D4F95C31DBFD33E4E31D5324CAD94EF756E67B749F668",
       "token1": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "current_sqrt_price": "1.023408720746002295119498887777230829",
-      "current_tick": "47365",
+      "current_sqrt_price": "1.023523521354224288808883458047457151",
+      "current_tick": "47600",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:39:36.372371440Z"
+      "last_liquidity_update": "2024-05-17T17:39:07.186182460Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -37722,8 +37722,8 @@
       "current_tick_liquidity": "201577243428.013233297060702390",
       "token0": "ibc/51D893F870B7675E507E91DA8DB0B22EA66333207E4F5C0708757F08EE059B0B",
       "token1": "uosmo",
-      "current_sqrt_price": "0.575091162700422254073703989768205230",
-      "current_tick": "-6692702",
+      "current_sqrt_price": "0.571698132729397358576883765392029188",
+      "current_tick": "-6731613",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -37786,20 +37786,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1218",
-        "amount": "134440518189831008659"
+        "amount": "132962443483124019913"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "8495558625"
+            "amount": "8441550248"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
-            "amount": "261256006831064478536403"
+            "amount": "257245415224741158989356"
           },
           "weight": "536870912000000"
         }
@@ -37824,14 +37824,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "228027691"
+            "amount": "242974492"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-            "amount": "1664177785"
+            "amount": "1563179491"
           },
           "weight": "536870912000000"
         }
@@ -37844,15 +37844,15 @@
       "incentives_address": "osmo18wpppl3e0z9u45psrjkv4rjh5ete7y8lsfz9uk02tg5mzex7sgdqzudl50",
       "spread_rewards_address": "osmo1apreqcw0g68t8lyhkcw537k5q6c6aa5nand85u8nhlkyu8wqvqssxttqj9",
       "id": "1220",
-      "current_tick_liquidity": "1804504789242670.394373051026701164",
+      "current_tick_liquidity": "3285005348069026.766708892883621080",
       "token0": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.000116574207412492248692638934682954",
-      "current_tick": "233",
+      "current_sqrt_price": "1.000212901099136998440274395466885062",
+      "current_tick": "425",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-16T00:02:03.463458654Z"
+      "last_liquidity_update": "2024-05-18T00:07:12.897130366Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -37860,15 +37860,15 @@
       "incentives_address": "osmo16audzujeqr3psjzp682vnjn56lemrn4xmgqd2ar7zq5p9vzalwwsera3rc",
       "spread_rewards_address": "osmo1upen9pnhnut483425xccv2rnhxnmxfe90rcn9nr6m98au8xgsr6sm0z45q",
       "id": "1221",
-      "current_tick_liquidity": "12153672012643.758691203810763506",
+      "current_tick_liquidity": "47879203483733.076376974658759892",
       "token0": "uosmo",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.917650522089850628648803322616810885",
-      "current_tick": "-1579176",
+      "current_sqrt_price": "0.934864682130765298883646521466615039",
+      "current_tick": "-1260281",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:20.281464467Z"
+      "last_liquidity_update": "2024-05-17T23:55:42.163168657Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -37908,15 +37908,15 @@
       "incentives_address": "osmo12nd5stwgqkpxdycxx6gpg6ydqnwe2x2clkgy59ghfw5h305je96sjzy8gn",
       "spread_rewards_address": "osmo1plu4s37ra3v4k9l5w4twl92lxhu5gywe0yz5033p27wj3mk6j67s4r5jre",
       "id": "1223",
-      "current_tick_liquidity": "1385916679388212.614467679500261958",
+      "current_tick_liquidity": "1308412852419539.749753160132812717",
       "token0": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.000053003531221058657695531837044592",
-      "current_tick": "106",
+      "current_sqrt_price": "1.000195714540687563140647217248283699",
+      "current_tick": "391",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T23:58:52.803138187Z"
+      "last_liquidity_update": "2024-05-17T23:33:16.996981160Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -37924,15 +37924,15 @@
       "incentives_address": "osmo1jmxqykswpe0tg2yl4x2ywekmhxnqggnd60dxe8gxccrler9r9d8slh4zcq",
       "spread_rewards_address": "osmo15w2kdkydzxzgh4werus0lfat9w2a7965pv8t9pa2yhc8sghs9ufq43nqvv",
       "id": "1224",
-      "current_tick_liquidity": "9099842400343.345406033707590694",
+      "current_tick_liquidity": "9098756953232.944543769370786813",
       "token0": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.000231097613848932783050893298735301",
-      "current_tick": "462",
+      "current_sqrt_price": "1.000415550561412350454627511806063463",
+      "current_tick": "831",
       "tick_spacing": "1000",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T23:45:54.772300557Z"
+      "last_liquidity_update": "2024-05-17T21:40:31.036706931Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -37952,14 +37952,14 @@
         {
           "token": {
             "denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
-            "amount": "2618585783702"
+            "amount": "2614866242470"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "84864989805"
+            "amount": "84985779355"
           },
           "weight": "53687091200"
         }
@@ -37978,20 +37978,20 @@
       "future_pool_governor": "osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd",
       "total_shares": {
         "denom": "gamm/pool/1226",
-        "amount": "4369155049880228347480335"
+        "amount": "4439460970806317769425754"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
-            "amount": "40073413479"
+            "amount": "41499792503"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "47704299869"
+            "amount": "47559502088"
           },
           "weight": "53687091200"
         }
@@ -38012,7 +38012,7 @@
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38020,15 +38020,15 @@
       "incentives_address": "osmo1jjk72qasewxnwcgn36hwu7dwj7hsh99mpa45flpm0hppq0tha4kqy7n2mh",
       "spread_rewards_address": "osmo1cw7xwlum473g3wv9jg7vtwftmuaw940g2s4ptry0uhfv7u9fmsjqev4tfq",
       "id": "1228",
-      "current_tick_liquidity": "402350481117.549909645486576205",
+      "current_tick_liquidity": "15695619468.954783611718673809",
       "token0": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.140378408061099606847594411961055572",
-      "current_tick": "-17029391",
+      "current_sqrt_price": "0.142787923787850229623325183003857543",
+      "current_tick": "-16961161",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T20:31:18.518814744Z"
+      "last_liquidity_update": "2024-05-17T19:03:10.386837270Z"
     },
     {
       "@type": "/osmosis.cosmwasmpool.v1beta1.CosmWasmPool",
@@ -38046,8 +38046,8 @@
       "current_tick_liquidity": "36335875118.794024028956955943",
       "token0": "ibc/01D2F0C4739C871BFBEE7E786709E6904A55559DC1483DD92ED392EF12247862",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "0.239114446230359397479984062752474442",
-      "current_tick": "-13282429",
+      "current_sqrt_price": "0.242534851153150717039691815720781376",
+      "current_tick": "-13117685",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -38100,14 +38100,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "10950374817"
+            "amount": "10942587184"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
-            "amount": "603918003070"
+            "amount": "604356117195"
           },
           "weight": "536870912000000"
         }
@@ -38132,14 +38132,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "19921141815"
+            "amount": "19869929843"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/A1830DECC0B742F0B2044FF74BE727B5CF92C9A28A9235C3BACE4D24A23504FA",
-            "amount": "1003120862922"
+            "amount": "1005747848577"
           },
           "weight": "536870912000000"
         }
@@ -38158,20 +38158,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1234",
-        "amount": "30392902050965533611466"
+        "amount": "30360333659663027990164"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "6687184838"
+            "amount": "6681229852"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B",
-            "amount": "727005105456"
+            "amount": "726102287646"
           },
           "weight": "536870912000000"
         }
@@ -38289,14 +38289,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "654609816"
+            "amount": "658699307"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/672406ADE4EDFD8C5EA7A0D0DD0C37E431DA7BD8393A15CD2CFDE3364917EB2A",
-            "amount": "166036419447604671678912"
+            "amount": "165020884317260446009590"
           },
           "weight": "536870912000000"
         }
@@ -38321,14 +38321,14 @@
         {
           "token": {
             "denom": "ibc/672406ADE4EDFD8C5EA7A0D0DD0C37E431DA7BD8393A15CD2CFDE3364917EB2A",
-            "amount": "203679098417247006266501"
+            "amount": "204110752709035383261934"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8123562056"
+            "amount": "8106849344"
           },
           "weight": "536870912000000"
         }
@@ -38353,14 +38353,14 @@
         {
           "token": {
             "denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
-            "amount": "7985090735222"
+            "amount": "8111274031501"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1183235987"
+            "amount": "1165427125"
           },
           "weight": "536870912000000"
         }
@@ -38385,14 +38385,14 @@
         {
           "token": {
             "denom": "ibc/2B30802A0B03F91E4E16D6175C9B70F2911377C1CAE9E50FF011C821465463F9",
-            "amount": "1505368461531830975069854"
+            "amount": "1532251817982630139916757"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "264630443731"
+            "amount": "260008975814"
           },
           "weight": "536870912000000"
         }
@@ -38417,14 +38417,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "3947282254"
+            "amount": "4285124866"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
-            "amount": "3376175105626694"
+            "amount": "3111549142500667"
           },
           "weight": "536870912000000"
         }
@@ -38437,15 +38437,15 @@
       "incentives_address": "osmo1r6ed7j34ulem4pm0qeegc2dry5zt784rgk0h0gqnl9q2mc6v5q7qjg3u04",
       "spread_rewards_address": "osmo1g8rg8kjn2wvle893en0qvwq93kldr7gwxntxavu7043mv8rd67jscwkgsq",
       "id": "1243",
-      "current_tick_liquidity": "967657847.289456287513647668",
+      "current_tick_liquidity": "5328830545.035197818512652457",
       "token0": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.414214738860630824072363932676937319",
-      "current_tick": "1000003",
+      "current_sqrt_price": "1.352488570497392719937574873507745245",
+      "current_tick": "829225",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T18:19:57.115694957Z"
+      "last_liquidity_update": "2024-05-17T15:05:04.558307381Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -38465,14 +38465,14 @@
         {
           "token": {
             "denom": "ibc/F3166F4D31D6BA1EC6C9F5536F5DDDD4CC93DBA430F7419E7CDC41C497944A65",
-            "amount": "755690001015"
+            "amount": "756676057147"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "81924103855"
+            "amount": "81856662270"
           },
           "weight": "536870912000000"
         }
@@ -38485,15 +38485,15 @@
       "incentives_address": "osmo19rkvx5xzx8xzpj7950v5v28lsle9m7rlrgxk6mue6wfxg77d0djst297ue",
       "spread_rewards_address": "osmo1l647zzkm7qdz7grwmumdgdxu547xsk2zc83yxsa82eph6q0qfmysy09cux",
       "id": "1245",
-      "current_tick_liquidity": "638650427002139870.867502221375928089",
+      "current_tick_liquidity": "632579223354911856.441970466732325546",
       "token0": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
       "token1": "uosmo",
-      "current_sqrt_price": "0.000001561635881535453320585489046833",
-      "current_tick": "-106561294",
+      "current_sqrt_price": "0.000001536793330457537287684825633765",
+      "current_tick": "-106638267",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:05:33.620278110Z"
+      "last_liquidity_update": "2024-05-17T15:26:47.192531090Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38501,15 +38501,15 @@
       "incentives_address": "osmo1y25nwfch5rp3fyawkqjvvfpc8qe3tjywjs2hv6xfdg292umpl50qfk8aj7",
       "spread_rewards_address": "osmo1u9ktz95vadadeve0l6qcfyj47mtd32v93xnz3ru4j33z326rjlhs4skgac",
       "id": "1246",
-      "current_tick_liquidity": "395896875168716783.731680265153757617",
+      "current_tick_liquidity": "417169443405924662.300643779459934667",
       "token0": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000001430252021297548820612085309814",
-      "current_tick": "-106954380",
+      "current_sqrt_price": "0.000001436818624087459966838909524624",
+      "current_tick": "-106935553",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:44:28.618373255Z"
+      "last_liquidity_update": "2024-05-17T23:50:43.725490044Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38517,15 +38517,15 @@
       "incentives_address": "osmo175dck737jmvr9mw34pqs7y5fv0umnak3vrsj3mjxg75cnkmyulfs0c3sxr",
       "spread_rewards_address": "osmo1sztcvwfec7lk766vn4wxny2s5rzh9ggglmhaaycrgqxmvxduuwvsg0rvcx",
       "id": "1247",
-      "current_tick_liquidity": "221238850153.403524807372428472",
+      "current_tick_liquidity": "85480578525251.869396500858580359",
       "token0": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.988825071114188623383719304105477918",
-      "current_tick": "7933075",
+      "current_sqrt_price": "3.078700714787053648945039958358707306",
+      "current_tick": "8478398",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:01:47.219686441Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38533,15 +38533,15 @@
       "incentives_address": "osmo1y3excgs02765nzvxv5lqlvullva2w2uxapq5nyjnzg30yglge03sem7azc",
       "spread_rewards_address": "osmo1uv76jtxlyvdkg5hqdkzlwlvsknzhfw5xazqc549g8g60kmtkxr3sfgd5lx",
       "id": "1248",
-      "current_tick_liquidity": "3086095024443.877009703027907074",
+      "current_tick_liquidity": "29044023777898.504364129525728431",
       "token0": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
       "token1": "uosmo",
-      "current_sqrt_price": "3.257215418635833059787704335845766101",
-      "current_tick": "9060945",
+      "current_sqrt_price": "3.294165599123836203424270495281130424",
+      "current_tick": "9085152",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:07:10.235829690Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -38555,20 +38555,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1249",
-        "amount": "556890316781586399848"
+        "amount": "554484012951193636710"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-            "amount": "2507475471"
+            "amount": "2471211804"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "26617101335"
+            "amount": "26813759134"
           },
           "weight": "536870912000000"
         }
@@ -38593,14 +38593,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "176826246"
+            "amount": "182546345"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-            "amount": "19743223"
+            "amount": "19132587"
           },
           "weight": "536870912000000"
         }
@@ -38613,15 +38613,15 @@
       "incentives_address": "osmo1vhw7cjhv5w4ckkr49d8f4tg99m2ar5x377ku9540mfnrdpptw00qe9rd5g",
       "spread_rewards_address": "osmo15zn4jn8dwyj709jvzuev74m55cf9w89wcmqemp34kr82yn2mr0kqtnhxqw",
       "id": "1251",
-      "current_tick_liquidity": "287640817176375.659328221619158480",
+      "current_tick_liquidity": "366466125896748.939271804472237849",
       "token0": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.905234745917633420866973094517420671",
-      "current_tick": "7440388",
+      "current_sqrt_price": "2.944639668341999692910349878631644461",
+      "current_tick": "7670902",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:48.413961101Z"
+      "last_liquidity_update": "2024-05-17T23:47:47.024193908Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38629,15 +38629,15 @@
       "incentives_address": "osmo138yk97avuf8grytppeyzvatrkm62a0nv3zg0zftua8xnqsggqc5qswmf3v",
       "spread_rewards_address": "osmo140yq3t0svapxs8dgkpy67xny0a4n26qkhkhe6q04qz7scwqcgvhskuz9nx",
       "id": "1252",
-      "current_tick_liquidity": "298284157042173.157253964473818271",
+      "current_tick_liquidity": "298282494168059.133841460144957803",
       "token0": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
       "token1": "uosmo",
-      "current_sqrt_price": "1.108105006933601221994337585095896638",
-      "current_tick": "227896",
+      "current_sqrt_price": "1.108301874475644261941007899327972340",
+      "current_tick": "228333",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-14T20:18:02.236662214Z"
+      "last_liquidity_update": "2024-05-17T18:45:55.225082130Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38645,15 +38645,15 @@
       "incentives_address": "osmo1qnzzxuhqfnkcrq7ukveswn6ayrxunnuhzakdcdzlrfvxjme042esqngv43",
       "spread_rewards_address": "osmo1kzrvezzacqp59xt4fgc3mcvwescka345z0tlehg7fvwphagrepaqgh59ng",
       "id": "1253",
-      "current_tick_liquidity": "1021377643355.795204773898423373",
+      "current_tick_liquidity": "977810619394.626845701417520959",
       "token0": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.025672466836551110476177987744091012",
-      "current_tick": "-30409245",
+      "current_sqrt_price": "0.025873000462896330646183591765030394",
+      "current_tick": "-30305879",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T20:42:41.724574392Z"
+      "last_liquidity_update": "2024-05-17T16:18:46.769676912Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -38673,14 +38673,14 @@
         {
           "token": {
             "denom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
-            "amount": "415919980"
+            "amount": "402766276"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
-            "amount": "2420099990"
+            "amount": "2500052356"
           },
           "weight": "536870912000000"
         }
@@ -38705,14 +38705,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "3744853144"
+            "amount": "3637477511"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
-            "amount": "2261180842"
+            "amount": "2331219434"
           },
           "weight": "536870912000000"
         }
@@ -38769,14 +38769,14 @@
         {
           "token": {
             "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-            "amount": "1001084164096063493"
+            "amount": "973915394238615875"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "23189995"
+            "amount": "23842507"
           },
           "weight": "536870912000000"
         }
@@ -38792,8 +38792,8 @@
       "current_tick_liquidity": "51000000.000000000000000000",
       "token0": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.811550493461958894756528250874859462",
-      "current_tick": "-3413858",
+      "current_sqrt_price": "0.826372029555978360509609715866008956",
+      "current_tick": "-3171093",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
@@ -38824,12 +38824,12 @@
       "current_tick_liquidity": "18731027624334272878.832645705004691430",
       "token0": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "1000407.953712134099975086321438092464602969",
-      "current_tick": "108000816",
+      "current_sqrt_price": "1000406.760215866877823476864743119445565682",
+      "current_tick": "108000813",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T19:21:28.505013594Z"
+      "last_liquidity_update": "2024-05-17T21:36:06.299152040Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38837,15 +38837,15 @@
       "incentives_address": "osmo17cgjl0l5wf3dwqyp0pjg70acfwcdnvju3trt4pm7045lya3fz7jqxxvps3",
       "spread_rewards_address": "osmo1868pk4hefes2usxlarl07nr25p4radg5rmkdqmu7cv8e8373jr4sx78pyf",
       "id": "1261",
-      "current_tick_liquidity": "8746434377709883648.070779634760331999",
+      "current_tick_liquidity": "8751244238664011915.277056375541246958",
       "token0": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "1000359.440036862761532656285466534823679765",
-      "current_tick": "108000719",
+      "current_sqrt_price": "1000528.718673243125911068061980304275501083",
+      "current_tick": "108001057",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T18:30:19.356772208Z"
+      "last_liquidity_update": "2024-05-17T21:38:24.389072778Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38869,15 +38869,15 @@
       "incentives_address": "osmo1glw62sxnarqlte4g4kxh7z5pje0x0llfwe53jfec7uydc9xygv7srmknr9",
       "spread_rewards_address": "osmo15qle4t0azwg8etdn48n8lrvvwwut2wfe6lmkn5hk2faycs5gyalsf7eqgv",
       "id": "1263",
-      "current_tick_liquidity": "3058527566013.791543731860050093",
+      "current_tick_liquidity": "4291704180152200.899550502285406444",
       "token0": "uosmo",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.918213525479336726636610665871628388",
-      "current_tick": "-1568840",
+      "current_sqrt_price": "0.934372116133350658140500958371780154",
+      "current_tick": "-1269488",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:28.345961647Z"
+      "last_liquidity_update": "2024-05-18T00:10:29.443106839Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38885,15 +38885,15 @@
       "incentives_address": "osmo1hqjfk0hjyhzlnf6tzgqgh7gj42x77hgstqy44k7zvgpremyrlags4j9hfk",
       "spread_rewards_address": "osmo165qlqpwpwr7pzwxe0yywk8ud7zf05yj6taw2k76wzdpjeqrkdzfsz2muhz",
       "id": "1264",
-      "current_tick_liquidity": "6557669618463824659.820811936395152273",
+      "current_tick_liquidity": "7164433110882218630.945716813588075551",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000055062224346648864727507093898442",
-      "current_tick": "-78968152",
+      "current_sqrt_price": "0.000055567785070228244081839178997273",
+      "current_tick": "-78912222",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:53:33.701596850Z"
+      "last_liquidity_update": "2024-05-17T23:43:35.233483631Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38901,15 +38901,15 @@
       "incentives_address": "osmo1nldrmuq5qa9k49m0dmm4k3399k778jvh962qgg7qqamsdt05qmussf888k",
       "spread_rewards_address": "osmo1s0qpx3kk2vyrw368m727rgdkzvq3u2vhhlaz82aehlu5wtc3d2tqc6gzlc",
       "id": "1265",
-      "current_tick_liquidity": "100629380763388.241918073912524072",
+      "current_tick_liquidity": "40801566576468.708876462870673062",
       "token0": "uosmo",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "0.315907906182810273795944551410985730",
-      "current_tick": "-9020220",
+      "current_sqrt_price": "0.317543756180695038531738475869246312",
+      "current_tick": "-8991660",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:54.222849713Z"
+      "last_liquidity_update": "2024-05-18T00:10:17.015173770Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -38929,14 +38929,14 @@
         {
           "token": {
             "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-            "amount": "337055015996"
+            "amount": "323832810122"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-            "amount": "6588443814"
+            "amount": "6859013416"
           },
           "weight": "536870912000000"
         }
@@ -38949,15 +38949,15 @@
       "incentives_address": "osmo1r0nv4tfmlgmvmrtuhjlsacn0mk2t29auzuz3433q0agu8vrq7d0s7lv2rf",
       "spread_rewards_address": "osmo1echnpyryndwjfswamrnqqulm7lt6xug7vj7ma6j0fhf3vr78992s5prys2",
       "id": "1267",
-      "current_tick_liquidity": "3438766470340.816314468825966569",
+      "current_tick_liquidity": "3439813390836.942705953539369842",
       "token0": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
       "token1": "uosmo",
-      "current_sqrt_price": "0.002723320268772250474612301915545732",
-      "current_tick": "-47583527",
+      "current_sqrt_price": "0.002714653886202735091255758332221054",
+      "current_tick": "-47630655",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:41:53.622463893Z"
+      "last_liquidity_update": "2024-05-16T18:24:23.078282101Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -38965,15 +38965,15 @@
       "incentives_address": "osmo1xt73tjayvnps8n0ptpcnqjyeaxum9pjk5shf9hlje085lg6xcgysqel2cv",
       "spread_rewards_address": "osmo1zk8vls43mjjvsgy622naqzslpuv5x4mvrv9aq7pvyl9yl2s834zseg27lr",
       "id": "1268",
-      "current_tick_liquidity": "13007668618074.377672471348198911",
+      "current_tick_liquidity": "8360851342064.956683004640099148",
       "token0": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.000743669644343656851043515930588092",
-      "current_tick": "1487",
+      "current_sqrt_price": "1.000799513451072091649869030802209134",
+      "current_tick": "1599",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T20:30:55.956830224Z"
+      "last_liquidity_update": "2024-05-18T00:10:48.919799024Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -38993,7 +38993,7 @@
         {
           "token": {
             "denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
-            "amount": "3662461"
+            "amount": "3842521"
           },
           "weight": "268435456000000"
         },
@@ -39014,7 +39014,7 @@
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4682423"
+            "amount": "4464052"
           },
           "weight": "268435456000000"
         }
@@ -39076,8 +39076,8 @@
       "current_tick_liquidity": "5672333887.752016567381430341",
       "token0": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.117537450100148194679076204537819418",
-      "current_tick": "-17618495",
+      "current_sqrt_price": "0.125359966077183335571734586026885161",
+      "current_tick": "-17428488",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -39108,12 +39108,12 @@
       "current_tick_liquidity": "17641818305931.136446129936891672",
       "token0": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.007655331127015853289951418532034237",
-      "current_tick": "-40139591",
+      "current_sqrt_price": "0.007659508109583915263981292524089144",
+      "current_tick": "-40133194",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-14T14:04:12.417262645Z"
+      "last_liquidity_update": "2024-05-16T02:15:25.051789571Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39124,12 +39124,12 @@
       "current_tick_liquidity": "210750112561.124905969359417769",
       "token0": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.999901662172972054867452301824404753",
-      "current_tick": "-1967",
+      "current_sqrt_price": "1.000303848864540369671193381710358706",
+      "current_tick": "607",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39140,12 +39140,12 @@
       "current_tick_liquidity": "150238269203480578.017253767296549135",
       "token0": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "1000143.363784633376085701626731410481036775",
-      "current_tick": "108000286",
+      "current_sqrt_price": "1000051.139983539786980438295109515903679881",
+      "current_tick": "108000102",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T21:35:56.176060709Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39161,7 +39161,7 @@
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39169,15 +39169,15 @@
       "incentives_address": "osmo1qsd8fgsgpz3y3lqdx4llpdg4ur2646khy536uj4489zx95uvxccs0c3p20",
       "spread_rewards_address": "osmo1gulf22thunjxh3rlf5kumrpyxmms07numcx2ygj8pd3j80mszlts54n6tz",
       "id": "1277",
-      "current_tick_liquidity": "3222659602.903661621466986649",
+      "current_tick_liquidity": "4597168420.150721984246193663",
       "token0": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "25.732342199289605996938774884014962525",
-      "current_tick": "23621534",
+      "current_sqrt_price": "25.866031312474325732294432875094632334",
+      "current_tick": "23690515",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:01:09.447574231Z"
+      "last_liquidity_update": "2024-05-17T21:32:10.754344305Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39185,15 +39185,15 @@
       "incentives_address": "osmo1vvlfgza07am2494cqfgca0fqcg8h4f6a6qj5cy05ynd9rh0kpx8qyjext2",
       "spread_rewards_address": "osmo160qdm572d08zu87mjeh4y3g860swsmuln09vw4p2t2y8kphqd0yshrujgw",
       "id": "1278",
-      "current_tick_liquidity": "122923477413287751.832960279848677932",
+      "current_tick_liquidity": "83001946743338079.100147656586998501",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000055100481352284899344725896814115",
-      "current_tick": "-78963937",
+      "current_sqrt_price": "0.000055579309449965547040244733626406",
+      "current_tick": "-78910941",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:54:32.986588552Z"
+      "last_liquidity_update": "2024-05-18T00:05:28.644227094Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39201,15 +39201,15 @@
       "incentives_address": "osmo13velw6pcput830aym45lvkjv00fxezy3sqnphtt4gcng9jxw769qgpv5ne",
       "spread_rewards_address": "osmo1zxute52retag3xayp8r03mlvh9u68chh82sgs45ehdax20cwqc5qamwajx",
       "id": "1279",
-      "current_tick_liquidity": "1690975784270575.187682127349563284",
+      "current_tick_liquidity": "107245053461309655.671750727577764409",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.000055082014560203820012165859866436",
-      "current_tick": "-78965972",
+      "current_sqrt_price": "0.000055547266000744273182067083103568",
+      "current_tick": "-78914502",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:33.104938739Z"
+      "last_liquidity_update": "2024-05-17T22:11:02.696801811Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39220,12 +39220,12 @@
       "current_tick_liquidity": "56124860801.610000000000315000",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.000054913593923385252705825188806977",
-      "current_tick": "-78984498",
+      "current_sqrt_price": "0.000055394643268270195114974252874861",
+      "current_tick": "-78931434",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39233,15 +39233,15 @@
       "incentives_address": "osmo1g3y6pz2rgqv20jhwhsxk0qmvwg6ucwgchzyvmyn6zwkup64uj73spw03m8",
       "spread_rewards_address": "osmo1hxemvvslfnl7j0727r953hmhhu66s3cks2jvyc2ckg9fjehnv5kswtl44c",
       "id": "1281",
-      "current_tick_liquidity": "4615912813473867577.003492063953105840",
+      "current_tick_liquidity": "5359126354606625.987220576939568451",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "uosmo",
-      "current_sqrt_price": "0.000060006034219458921015679899383997",
-      "current_tick": "-78399276",
+      "current_sqrt_price": "0.000059488825342980699696929085797080",
+      "current_tick": "-78461080",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:15.537542831Z"
+      "last_liquidity_update": "2024-05-18T00:13:15.557503681Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39249,15 +39249,15 @@
       "incentives_address": "osmo1ud56842l2t7scmdt8wttwect9us25g32h0hy4895emxjxjf8dxzqg227pl",
       "spread_rewards_address": "osmo1enrsppqmv5e3cp4m0rjmy2hkqd8xl940vptkzund25vh44fvjdes0x0v5d",
       "id": "1282",
-      "current_tick_liquidity": "684672731661.661715246321677131",
+      "current_tick_liquidity": "110763966527885.936787122991461636",
       "token0": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.907427608199572401475485368483625883",
-      "current_tick": "7453135",
+      "current_sqrt_price": "2.942921078950479632277095254274569505",
+      "current_tick": "7660784",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:12:32.250029757Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39265,15 +39265,15 @@
       "incentives_address": "osmo1j5m4gk486hp9zpvqygtquehvptmvxe4h2grant6ud262wjd5wqqq2kaqru",
       "spread_rewards_address": "osmo1q9n7uw9tgyu6wdkecxcm9cx6qp9ygj46u6umnacrrthmp6v9te3sj99tm4",
       "id": "1283",
-      "current_tick_liquidity": "263660265441154.075009493092180720",
+      "current_tick_liquidity": "31638729502025.442310599672635253",
       "token0": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "1.158234736905718909741208058120086257",
-      "current_tick": "341507",
+      "current_sqrt_price": "1.158423577438772170406480625313707361",
+      "current_tick": "341945",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:00:05.291215076Z"
+      "last_liquidity_update": "2024-05-18T00:12:35.266053119Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -39286,16 +39286,16 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1284",
-        "amount": "10796317518985359058006"
+        "amount": "5477043060129862149332"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
-          "amount": "10566150074906"
+          "amount": "5144311282032"
         },
         {
           "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-          "amount": "11356858"
+          "amount": "5977714"
         }
       ],
       "scaling_factors": [
@@ -39354,14 +39354,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "1110616212"
+            "amount": "1070922584"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
-            "amount": "32851398675690"
+            "amount": "34771311682652"
           },
           "weight": "536870912000000"
         }
@@ -39418,14 +39418,14 @@
         {
           "token": {
             "denom": "ibc/71DAA4CAFA4FE2F9803ABA0696BA5FC0EFC14305A2EA8B4E01880DB851B1EC02",
-            "amount": "56161316182"
+            "amount": "56161316183"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B",
-            "amount": "253277957903"
+            "amount": "253277957904"
           },
           "weight": "536870912000000"
         }
@@ -39539,7 +39539,7 @@
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39563,15 +39563,15 @@
       "incentives_address": "osmo12vfmexwpcl6wm9qzdsqsen00sc0kt7ul5h6rqgesfknp5aeq4jhq7y0hu0",
       "spread_rewards_address": "osmo1u6fp9z8q6pmuyp0fqnns97l3fdlu56sewyt02h0elqrxa7769ppssul8fh",
       "id": "1294",
-      "current_tick_liquidity": "1858008670916.945621442504386161",
+      "current_tick_liquidity": "1808066097319.358401993021528270",
       "token0": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.262532669580303078389129097843815787",
-      "current_tick": "593988",
+      "current_sqrt_price": "1.300006930045068914774216925861049145",
+      "current_tick": "690018",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:05:51.646730253Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -39591,14 +39591,14 @@
         {
           "token": {
             "denom": "ibc/09FAF1E04435E14C68DE7AB0D03C521C92975C792DB12B2EA390BAA2E06B3F3D",
-            "amount": "11321768211"
+            "amount": "11309697132"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "405149740"
+            "amount": "405961776"
           },
           "weight": "536870912000000"
         }
@@ -39646,8 +39646,8 @@
       "current_tick_liquidity": "5887602913825895963278.852596894580757099",
       "token0": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "token1": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "current_sqrt_price": "0.998073121701453576839709777317383814",
-      "current_tick": "-38501",
+      "current_sqrt_price": "0.997747051288064203982026760999528209",
+      "current_tick": "-45009",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -39662,12 +39662,12 @@
       "current_tick_liquidity": "74847066405006981683514.047115946479247651",
       "token0": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "0.331985449654509722431843135505718447",
-      "current_tick": "-8897857",
+      "current_sqrt_price": "0.339518692524330124921511456171149378",
+      "current_tick": "-8847271",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-15T22:21:30.525770921Z"
+      "last_liquidity_update": "2024-05-17T21:36:48.290203832Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39675,15 +39675,15 @@
       "incentives_address": "osmo1ly2qks3tf947qwvykgvwf5f2expsjqdy70jl5p8gjdcge0da2vvs3v2g5z",
       "spread_rewards_address": "osmo1mmheeuzga83s8fk45rsqkns6vn38aza8aag9qxj6rvdsmavac49q7msaxc",
       "id": "1299",
-      "current_tick_liquidity": "1522060411.836723783690789987",
+      "current_tick_liquidity": "1502088847.034121416705544430",
       "token0": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqatom",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "0.080093081569442400061759259969510383",
-      "current_tick": "-21585099",
+      "current_sqrt_price": "0.079894619637220457923354377776621539",
+      "current_tick": "-21616850",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:39:17.303812896Z"
+      "last_liquidity_update": "2024-05-17T20:01:40.609383746Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -39703,14 +39703,14 @@
         {
           "token": {
             "denom": "ibc/D9AFCECDD361D38302AA66EB3BAC23B95234832C51D12489DC451FA2B7C72782",
-            "amount": "23413818"
+            "amount": "25013905"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1039987"
+            "amount": "990116"
           },
           "weight": "536870912000000"
         }
@@ -39723,15 +39723,15 @@
       "incentives_address": "osmo198za9jtj55eyzgsfzqtpz3f56mc2zkv9xuy0sfdf072acsu9nq6s9ll8xq",
       "spread_rewards_address": "osmo1nm0vpuuud0t9umvl44jfce842zx5xh536dtgamg4zy3uqt4jpk6sce3zlx",
       "id": "1301",
-      "current_tick_liquidity": "1245901963052.032364927991469747",
+      "current_tick_liquidity": "1261150482846.842400681502455328",
       "token0": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.401023592577598176244232224950507737",
-      "current_tick": "4764914",
+      "current_sqrt_price": "2.423986525127320845760795986029810868",
+      "current_tick": "4875710",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:01.043066680Z"
+      "last_liquidity_update": "2024-05-18T00:11:29.305249751Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39739,15 +39739,15 @@
       "incentives_address": "osmo1m2kexpzwamq856te5v7kmgehh3z23t30pztt9xms3qk8rrjny7lq736vxu",
       "spread_rewards_address": "osmo1e8uy9dcsex3zuht0gh9dwwk2lme7kksqmrc3j685wxq9k2sjgjgq7z7ezj",
       "id": "1302",
-      "current_tick_liquidity": "12815448768.987045077043906345",
+      "current_tick_liquidity": "9867725171.785994920532738244",
       "token0": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "token1": "uosmo",
-      "current_sqrt_price": "0.080761914944688268800984610815438549",
-      "current_tick": "-21477514",
+      "current_sqrt_price": "0.079509736102384341998284863462058575",
+      "current_tick": "-21678202",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-14T06:41:19.109759390Z"
+      "last_liquidity_update": "2024-05-17T17:12:59.132057667Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -39790,8 +39790,8 @@
       "current_tick_liquidity": "23574309747.826081387783677130",
       "token0": "ibc/6928AFA9EA721938FED13B051F9DBF1272B16393D20C49EA5E4901BB76D94A90",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.119841813342326107578996404450542403",
-      "current_tick": "-17563794",
+      "current_sqrt_price": "0.103768457738938727113152925147795130",
+      "current_tick": "-17923211",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -39815,14 +39815,14 @@
         {
           "token": {
             "denom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
-            "amount": "17982260123109"
+            "amount": "17852459618986"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "544253919143"
+            "amount": "548303799508"
           },
           "weight": "536870912000000"
         }
@@ -39847,14 +39847,14 @@
         {
           "token": {
             "denom": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
-            "amount": "3481984571"
+            "amount": "3350347740"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "248956148942"
+            "amount": "258834098607"
           },
           "weight": "536870912000000"
         }
@@ -39873,20 +39873,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1308",
-        "amount": "3189799891305261870399"
+        "amount": "3188134293473826046329"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-            "amount": "286053641"
+            "amount": "276050639"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "116380927401"
+            "amount": "120533799627"
           },
           "weight": "536870912000000"
         }
@@ -39969,20 +39969,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1311",
-        "amount": "7684097801275910026567"
+        "amount": "7679849372822127290067"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "16254006129"
+            "amount": "17368045568"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
-            "amount": "435276459867"
+            "amount": "407326320577"
           },
           "weight": "536870912000000"
         }
@@ -40043,15 +40043,15 @@
       "incentives_address": "osmo18z09rak6t8p8c5zg73hsqhra7s33nutkch5x9m9085wcdy24hjjqhvq9aa",
       "spread_rewards_address": "osmo12sedatw5kkgkczf3rqkcuakqgqgp76my8spfq265jfr52gagwe4q9suvxk",
       "id": "1314",
-      "current_tick_liquidity": "8992675202850.944211803190890792",
+      "current_tick_liquidity": "9034194732959.982568112615192436",
       "token0": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
       "token1": "uosmo",
-      "current_sqrt_price": "0.424348383383411529914808743940664448",
-      "current_tick": "-8199285",
+      "current_sqrt_price": "0.417324220282477330827237164350708792",
+      "current_tick": "-8258405",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:40:41.014531619Z"
+      "last_liquidity_update": "2024-05-17T19:59:54.165760959Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40062,12 +40062,12 @@
       "current_tick_liquidity": "514389115.948794344787125021",
       "token0": "ibc/E42006ED917C769EDE1B474650EEA6BFE3F97958912B9206DD7010A28D01D9D5",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.683932990470222896804358025979899233",
-      "current_tick": "-5322357",
+      "current_sqrt_price": "0.668942506191065641921549918274133610",
+      "current_tick": "-5525160",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T21:14:23.334457067Z"
+      "last_liquidity_update": "2024-05-17T23:48:10.935449718Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40075,15 +40075,15 @@
       "incentives_address": "osmo12jkdeqhy8824yac7crpl3kq6ayjc8dfqjtxdjcdld07k0nyq9ldqavearr",
       "spread_rewards_address": "osmo10t452aun4shrwfhzc33l3tdfvwzmpcx6xpllttnhe4wwqea2vucs4ucdw5",
       "id": "1316",
-      "current_tick_liquidity": "16123527439208.720591960861788237",
+      "current_tick_liquidity": "15226538840321.742338215112226294",
       "token0": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.000458439334346529972435461250269367",
-      "current_tick": "917",
+      "current_sqrt_price": "1.000459106102717480164823410996608250",
+      "current_tick": "918",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-14T21:09:56.272669415Z"
+      "last_liquidity_update": "2024-05-17T21:04:36.508111574Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40091,15 +40091,15 @@
       "incentives_address": "osmo1cymv0s43mx0snq80g8jslyex7arg0ulma37dfftkfv30smqlr72s6d0gg0",
       "spread_rewards_address": "osmo1g0hx8slpfdgxd3v67hxm5utwhq59p6k8yfvm7exm4x0qlqjzf5fq6gvssd",
       "id": "1317",
-      "current_tick_liquidity": "4445772082.903777399075613664",
+      "current_tick_liquidity": "31420460380.579640833876087960",
       "token0": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.031482922072997937346251583686304015",
-      "current_tick": "-27088257",
+      "current_sqrt_price": "0.032224430678005792292787169645924283",
+      "current_tick": "-26961587",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-15T16:26:24.978277762Z"
+      "last_liquidity_update": "2024-05-17T17:56:09.040154483Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40107,15 +40107,15 @@
       "incentives_address": "osmo1qemlvp96le8aenlvy7v4rq87yhjmq7qp4ds6e08876lykh8mlx7qsewevp",
       "spread_rewards_address": "osmo108r2kyzrghp0c7qukk0jqul3umfwgfrt35qcpn8sm9ma8dw3cgssd46hph",
       "id": "1318",
-      "current_tick_liquidity": "368408887409.504426640683835658",
+      "current_tick_liquidity": "370984277456.015255854935468356",
       "token0": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
       "token1": "uosmo",
-      "current_sqrt_price": "0.147427609596157909262806562764740033",
-      "current_tick": "-16826510",
+      "current_sqrt_price": "0.146955947794309581084681130684420577",
+      "current_tick": "-16840395",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
-      "last_liquidity_update": "2024-05-15T21:01:09.711014629Z"
+      "last_liquidity_update": "2024-05-17T23:01:07.566957132Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40123,15 +40123,15 @@
       "incentives_address": "osmo13ywhmydm7qwyg8n60afqhzl4ahd65egn00266qqae2v3es4cmepqe07ztk",
       "spread_rewards_address": "osmo1qvmwex60ahcsklntxy9vr38zq54a8gup7psvnfgttfkqv6xmyssq4xglje",
       "id": "1319",
-      "current_tick_liquidity": "537097939226228634.081835212424411924",
+      "current_tick_liquidity": "472960542441359638.866022176136741891",
       "token0": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000004863032775857481789941993972032",
-      "current_tick": "-97635092",
+      "current_sqrt_price": "0.000004974107604043463979472997898478",
+      "current_tick": "-97525826",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:04:01.838651883Z"
+      "last_liquidity_update": "2024-05-17T23:41:36.758137645Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -40151,14 +40151,14 @@
         {
           "token": {
             "denom": "ibc/A1830DECC0B742F0B2044FF74BE727B5CF92C9A28A9235C3BACE4D24A23504FA",
-            "amount": "391728154644"
+            "amount": "395220508532"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "78336072780"
+            "amount": "77650255044"
           },
           "weight": "536870912000000"
         }
@@ -40171,15 +40171,15 @@
       "incentives_address": "osmo1mv42gnhqn4z8gc3m37zwt9pa5ctzerk82cwzml6c5xnna5rr4ulq327kgm",
       "spread_rewards_address": "osmo1zxvv43nxc7383pz9xc4h2hvmvzvrve0ladzt0psk495ld65qznsqmd7ldx",
       "id": "1321",
-      "current_tick_liquidity": "110199306511.903381079341058024",
+      "current_tick_liquidity": "6636988866722.751099424557439503",
       "token0": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.988210254200047285266642297406515238",
-      "current_tick": "7929400",
+      "current_sqrt_price": "3.079629071345944722126170175020089992",
+      "current_tick": "8484115",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:01:53.567629763Z"
+      "last_liquidity_update": "2024-05-18T00:06:02.215607732Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40190,12 +40190,12 @@
       "current_tick_liquidity": "6167599.065846245069492212",
       "token0": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "3.015085262157396346493933267427808506",
-      "current_tick": "8090739",
+      "current_sqrt_price": "3.112775608778544364266268613087698321",
+      "current_tick": "8689371",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40203,15 +40203,15 @@
       "incentives_address": "osmo1z6ae7saxlwnnd6whl2svw0k3zhsjdvzaap9ya2lcj8m3c0r02a6svtuzn2",
       "spread_rewards_address": "osmo1jhzypnueeg75cm8tps7srn7ujva9qe4msjmtkajwaqpj0kyvdjjqu0xule",
       "id": "1323",
-      "current_tick_liquidity": "37729218319691.272248113026567788",
+      "current_tick_liquidity": "37748867662660.351612263725648217",
       "token0": "ibc/ECBE78BF7677320A93E7BA1761D144BCBF0CBC247C290C049655E106FE5DC68E",
       "token1": "uosmo",
-      "current_sqrt_price": "1.013730597101519154185501765011103434",
-      "current_tick": "27649",
+      "current_sqrt_price": "1.012257238078428188699912134997199241",
+      "current_tick": "24664",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:44:57.066895584Z"
+      "last_liquidity_update": "2024-05-17T16:45:55.696319322Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40219,15 +40219,15 @@
       "incentives_address": "osmo1ddw0ezk3ycj87rvewt7s48twgu89440uygdkcgal8asj45ycd8xs7sye7e",
       "spread_rewards_address": "osmo19r7eucq7dkheawmpa5pkyp4332e4pdxmpaanrkqgkvra0vgudf6qrk4am4",
       "id": "1324",
-      "current_tick_liquidity": "12126468870.037530217982843791",
+      "current_tick_liquidity": "15986348819.274165771117278743",
       "token0": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.810137884147147929842404164077860373",
-      "current_tick": "-3436767",
+      "current_sqrt_price": "0.831696389896799852998563702310045934",
+      "current_tick": "-3082812",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:03:23.626140474Z"
+      "last_liquidity_update": "2024-05-17T22:37:30.945487381Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40235,15 +40235,15 @@
       "incentives_address": "osmo17jqs0pk0lug2dceva0kfs5je9hhlxuy0jdchwy3ewygf29hheuvq3xjlzf",
       "spread_rewards_address": "osmo12en4cjlzhl0l7kkam6mdqcm6hstrlpal9v4am0ks8muegrskepyszwnhsr",
       "id": "1325",
-      "current_tick_liquidity": "363527991178.762700093888525090",
+      "current_tick_liquidity": "399259451359.975639992880296830",
       "token0": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
       "token1": "uosmo",
-      "current_sqrt_price": "0.281271984923511168899481588495915983",
-      "current_tick": "-11088608",
+      "current_sqrt_price": "0.273208328096574572630415498652520944",
+      "current_tick": "-11535721",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:29.011767610Z"
+      "last_liquidity_update": "2024-05-17T23:55:53.001024830Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -40257,20 +40257,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1326",
-        "amount": "119227601540749344921"
+        "amount": "119228435990264444095"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "549005994069"
+            "amount": "547265024949"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "137758700394"
+            "amount": "138225149350"
           },
           "weight": "536870912000000"
         }
@@ -40295,14 +40295,14 @@
         {
           "token": {
             "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-            "amount": "171010660711"
+            "amount": "67397430134"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "186986"
+            "amount": "482368"
           },
           "weight": "536870912000000"
         }
@@ -40327,14 +40327,14 @@
         {
           "token": {
             "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-            "amount": "4792544572"
+            "amount": "4765499053"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "216385243851"
+            "amount": "217777066646"
           },
           "weight": "536870912000000"
         }
@@ -40359,14 +40359,14 @@
         {
           "token": {
             "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-            "amount": "281674887004"
+            "amount": "280610275093"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-            "amount": "50378775723855"
+            "amount": "50572442438188"
           },
           "weight": "536870912000000"
         }
@@ -40385,20 +40385,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1330",
-        "amount": "13650662531323179730698"
+        "amount": "13652165739854470398458"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "713499040476"
+            "amount": "727049817866"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4642549315"
+            "amount": "4566111658"
           },
           "weight": "536870912000000"
         }
@@ -40430,12 +40430,12 @@
       "current_tick_liquidity": "10616419092.825037262808075177",
       "token0": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963",
       "token1": "uosmo",
-      "current_sqrt_price": "0.156552639293907774583160054169542809",
-      "current_tick": "-16549128",
+      "current_sqrt_price": "0.162254713929925243107542779413778248",
+      "current_tick": "-16367341",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-13T04:27:43.565065208Z"
+      "last_liquidity_update": "2024-05-17T17:08:01.126838818Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -40455,14 +40455,14 @@
         {
           "token": {
             "denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-            "amount": "12520012144472"
+            "amount": "12837339933937"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963",
-            "amount": "4980429733"
+            "amount": "4863345068"
           },
           "weight": "536870912000000"
         }
@@ -40478,8 +40478,8 @@
       "current_tick_liquidity": "5802274360.685897575678657955",
       "token0": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
       "token1": "uosmo",
-      "current_sqrt_price": "0.243382457438852224022696464459430754",
-      "current_tick": "-13076498",
+      "current_sqrt_price": "0.239546266231687061470040866191754972",
+      "current_tick": "-13261759",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -40491,15 +40491,15 @@
       "incentives_address": "osmo1469w5y7t9ahtswggnnez0359yvhtad9k9c0lpepqjermctwj07tsfqf00c",
       "spread_rewards_address": "osmo1sjnefeadttkuj3y0rnp7g5kksax9vw6exxp7ce90y5cxdwnyr6pqd2wgxc",
       "id": "1335",
-      "current_tick_liquidity": "1043728925950.875609869900645257",
+      "current_tick_liquidity": "1180946013632.467483730172680551",
       "token0": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
       "token1": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-      "current_sqrt_price": "1.020288857040453863708517956522619337",
-      "current_tick": "40989",
+      "current_sqrt_price": "1.016689639517546764895238148916112795",
+      "current_tick": "33657",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T22:32:12.994986088Z"
+      "last_liquidity_update": "2024-05-17T23:54:10.420733144Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40523,15 +40523,15 @@
       "incentives_address": "osmo1n2sajar22g2w3xds9226pd9qsm7wm7jernj07r89xyuf6r06qeps3396gq",
       "spread_rewards_address": "osmo1ta4m4yla269dpfcv86n4gg4zcslp49l4wjgnz5x6clqr2ktyydesk6anzf",
       "id": "1337",
-      "current_tick_liquidity": "145741306668.943361928481381746",
+      "current_tick_liquidity": "296268576745525.577906449648810281",
       "token0": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.257578994791181112894308036873626475",
-      "current_tick": "-12365307",
+      "current_sqrt_price": "0.255565928628313468987626532456304165",
+      "current_tick": "-12468606",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:36.845037933Z"
+      "last_liquidity_update": "2024-05-17T23:04:56.751017043Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -40577,20 +40577,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1339",
-        "amount": "143565885842534397475"
+        "amount": "141080694279811710983"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "3936469593"
+            "amount": "3769265607"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "36607237637"
+            "amount": "36944651068"
           },
           "weight": "536870912000000"
         }
@@ -40679,14 +40679,14 @@
         {
           "token": {
             "denom": "ibc/42A9553A7770F3D7B62F3A82AF04E7719B4FD6EAF31BE5645092AAC4A6C2201D",
-            "amount": "14640091707317063"
+            "amount": "14262222083671894"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963",
-            "amount": "31911808429"
+            "amount": "32773601858"
           },
           "weight": "536870912000000"
         }
@@ -40711,14 +40711,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "657172285516109240285775"
+            "amount": "659781205813652829496833"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-            "amount": "32339241646"
+            "amount": "32225433183"
           },
           "weight": "536870912000000"
         }
@@ -40737,20 +40737,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1344",
-        "amount": "1567616562864645930242"
+        "amount": "1572901214846713552207"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/23A62409E4AD8133116C249B1FA38EED30E500A115D7B153109462CD82C1CD99",
-            "amount": "358977009045079"
+            "amount": "359110466296137"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6978596426"
+            "amount": "7023168304"
           },
           "weight": "536870912000000"
         }
@@ -40807,14 +40807,14 @@
         {
           "token": {
             "denom": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
-            "amount": "44991108430"
+            "amount": "45584120466"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-            "amount": "7394455"
+            "amount": "7299584"
           },
           "weight": "536870912000000"
         }
@@ -40827,15 +40827,15 @@
       "incentives_address": "osmo1ldug7wxfcf0magd49m5edke4dntaeafwea2eavwkcecd552hxquqzschuh",
       "spread_rewards_address": "osmo1hllqjmfncesd7aktkql6l4t9cyfhkswgarrn5rm8qma7xlmthueshkuxj2",
       "id": "1347",
-      "current_tick_liquidity": "97831390303.893113847978634565",
+      "current_tick_liquidity": "6174985134370.579084637418329023",
       "token0": "uosmo",
       "token1": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-      "current_sqrt_price": "0.307211970070526070778998780573859053",
-      "current_tick": "-9562081",
+      "current_sqrt_price": "0.303510873625508421754035018587548207",
+      "current_tick": "-9788115",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:51:25.545931786Z"
+      "last_liquidity_update": "2024-05-18T00:12:37.703049423Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40846,12 +40846,12 @@
       "current_tick_liquidity": "18227347.808288978616287929",
       "token0": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "2.988527950204180759372857840668222020",
-      "current_tick": "7931299",
+      "current_sqrt_price": "3.065694165914170473340861272870455417",
+      "current_tick": "8398480",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40859,15 +40859,15 @@
       "incentives_address": "osmo1c4ydgda5zam7ssnyv3eh2h4sn92sg0tjrt3vm4l97cfu0dggf30qxta2az",
       "spread_rewards_address": "osmo18e3vhljqm4kl8gllf28rthlj0g2kf9nzdzr2v75m6m98zvzmduvqnlg3h4",
       "id": "1349",
-      "current_tick_liquidity": "775198076640077.723719012598468432",
+      "current_tick_liquidity": "1539173216021177.716315918073462510",
       "token0": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000005897700452064641318249880949906",
-      "current_tick": "-96521713",
+      "current_sqrt_price": "0.000006046846191168130693969564274826",
+      "current_tick": "-96343566",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T06:28:06.318602208Z"
+      "last_liquidity_update": "2024-05-17T12:17:52.338582700Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40875,15 +40875,15 @@
       "incentives_address": "osmo1wvwh8290ms5469d7un29exvykxweh32g7j7zta8z8ds5pzt4aarqpkhg84",
       "spread_rewards_address": "osmo13zzjcx3hxa6etkw5tynt23y78p7rw3n5kflstfa5skcq7jnpz2pslzk08k",
       "id": "1350",
-      "current_tick_liquidity": "2436439162966263.677152345774217403",
+      "current_tick_liquidity": "2437518189682174.052930724339872525",
       "token0": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000024216434081917902238228186689431",
-      "current_tick": "-85135644",
+      "current_sqrt_price": "0.000024043523284304980049892625096210",
+      "current_tick": "-85219090",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T11:16:08.236611382Z"
+      "last_liquidity_update": "2024-05-17T19:33:37.781353362Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -40891,15 +40891,15 @@
       "incentives_address": "osmo14n0al8mhgn3wz6kv8uxc8ag0f5sseda00u440tcravslvudcwf3qzge3gz",
       "spread_rewards_address": "osmo1z0yan232tjv08ptaupywmu84clqa8fx5d3ha2c3d97cflg78jguqpwn90z",
       "id": "1351",
-      "current_tick_liquidity": "4905445551564034.109696132479373506",
+      "current_tick_liquidity": "8468253874074065.133207558995459152",
       "token0": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000001430844890040967653460950816448",
-      "current_tick": "-106952683",
+      "current_sqrt_price": "0.000001436782763644597359918612342130",
+      "current_tick": "-106935656",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:50:22.338043780Z"
+      "last_liquidity_update": "2024-05-17T12:23:20.333144170Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -41046,14 +41046,14 @@
         {
           "token": {
             "denom": "ibc/2FFE07C4B4EFC0DDA099A16C6AF3C9CCA653CC56077E87217A585D48794B0BC7",
-            "amount": "722865100418"
+            "amount": "693909735306"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "116089079302"
+            "amount": "120933227620"
           },
           "weight": "536870912000000"
         }
@@ -41078,14 +41078,14 @@
         {
           "token": {
             "denom": "ibc/2FFE07C4B4EFC0DDA099A16C6AF3C9CCA653CC56077E87217A585D48794B0BC7",
-            "amount": "680518065458"
+            "amount": "599728712801"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "11189282"
+            "amount": "12702863"
           },
           "weight": "536870912000000"
         }
@@ -41101,8 +41101,8 @@
       "current_tick_liquidity": "141804261399.573228242059046272",
       "token0": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.061369198121635346764285714215656541",
-      "current_tick": "126504",
+      "current_sqrt_price": "1.058262362168034274207865795088734553",
+      "current_tick": "119919",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -41146,15 +41146,15 @@
       "incentives_address": "osmo1nya5dc5u6tnftnha4avmta49rzhjnz4ycgypp2xv5xf9fat4kwgs9jla2z",
       "spread_rewards_address": "osmo1n2u56jvehu3807mwfrhcjf4jtzv88k6ayd432j85yfwg9tfzuhesrzqn5r",
       "id": "1361",
-      "current_tick_liquidity": "1413296732717.314918481348505438",
+      "current_tick_liquidity": "543922182014.937055634601073169",
       "token0": "ibc/37CB3078432510EE57B9AFA8DBE028B33AE3280A144826FEAC5F2334CF2C5539",
       "token1": "uosmo",
-      "current_sqrt_price": "0.435245751801401994681803612093703391",
-      "current_tick": "-8105612",
+      "current_sqrt_price": "0.426958406614120614259154037542342968",
+      "current_tick": "-8177066",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-14T15:05:31.264020718Z"
+      "last_liquidity_update": "2024-05-17T16:41:54.607140607Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -41203,14 +41203,14 @@
         {
           "token": {
             "denom": "ibc/42A9553A7770F3D7B62F3A82AF04E7719B4FD6EAF31BE5645092AAC4A6C2201D",
-            "amount": "3665442499486331"
+            "amount": "3470103830373435"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "196103224"
+            "amount": "207245647"
           },
           "weight": "536870912000000"
         }
@@ -41261,20 +41261,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1365",
-        "amount": "2240207562278987233333"
+        "amount": "3286998011891370105098"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "152685360"
+            "amount": "419876033"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9B8EC667B6DF55387DC0F3ACC4F187DA6921B0806ED35DE6B04DE96F5AB81F53",
-            "amount": "18572775390"
+            "amount": "14723956092"
           },
           "weight": "536870912000000"
         }
@@ -41299,14 +41299,14 @@
         {
           "token": {
             "denom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
-            "amount": "800075694625"
+            "amount": "790545735768"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
-            "amount": "38304409"
+            "amount": "38772086"
           },
           "weight": "536870912000000"
         }
@@ -41363,14 +41363,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "538771585"
+            "amount": "544070417"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
-            "amount": "30771822763"
+            "amount": "30526166125"
           },
           "weight": "536870912000000"
         }
@@ -41395,14 +41395,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "13557683"
+            "amount": "13862611"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "16181636"
+            "amount": "15840784"
           },
           "weight": "536870912000000"
         }
@@ -41415,15 +41415,15 @@
       "incentives_address": "osmo1muwmrwnu7d2nnexz68mnk4danu2wuwcd350tu23mrcdszhkts5vqgrx6la",
       "spread_rewards_address": "osmo1vgecqdce5vq7f495rat4jn4murmvera6lu3ftx394e3t49wjvlksq5zplm",
       "id": "1370",
-      "current_tick_liquidity": "3966805136.381667209080955823",
+      "current_tick_liquidity": "3978567583.019260340700103651",
       "token0": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
       "token1": "uosmo",
-      "current_sqrt_price": "1.372252934874720617921686036995242452",
-      "current_tick": "883078",
+      "current_sqrt_price": "1.390994331394258940159887774458410686",
+      "current_tick": "934865",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:11:10.508146448Z"
+      "last_liquidity_update": "2024-05-17T17:09:58.380733477Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -41443,14 +41443,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "30845"
+            "amount": "31689"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
-            "amount": "66906"
+            "amount": "65128"
           },
           "weight": "536870912000000"
         }
@@ -41463,15 +41463,15 @@
       "incentives_address": "osmo13zeg9t7g6fcl63hfk502h5hfqzj54wg5mjsqvgg9kgcrle3q9p7s9ngsmk",
       "spread_rewards_address": "osmo1dyrt38ucpgrjfmuuhscynmjnjxzyqt84k9qy6y7hdl3yln60jt2sgc5jx8",
       "id": "1372",
-      "current_tick_liquidity": "707372376.594500911826509878",
+      "current_tick_liquidity": "7904072426.163214733119147635",
       "token0": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.272842333957669131619566233985500660",
-      "current_tick": "-11555707",
+      "current_sqrt_price": "0.286105399129197206817041294316348491",
+      "current_tick": "-10814371",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
-      "last_liquidity_update": "2024-05-15T19:41:31.958893171Z"
+      "last_liquidity_update": "2024-05-17T13:43:33.836159787Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -41482,8 +41482,8 @@
       "current_tick_liquidity": "4611903.738289320785166860",
       "token0": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.315766210431332073012455455960391711",
-      "current_tick": "-9029171",
+      "current_sqrt_price": "0.316940088895784432549809123389267993",
+      "current_tick": "-8995490",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
@@ -41539,14 +41539,14 @@
         {
           "token": {
             "denom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
-            "amount": "293870090912433474646058"
+            "amount": "287405011385223555666144"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "32218200305"
+            "amount": "33034103014"
           },
           "weight": "536870912000000"
         }
@@ -41607,15 +41607,15 @@
       "incentives_address": "osmo1yraqy28zxpgvymfvsksjranj4u6tc044ml0uc6ppdcpy7s3hmr8qsrrftn",
       "spread_rewards_address": "osmo16aj87c0v9kyatg0mtglx8m0s670repl5eg8zm98hm8gw02heqs2q9tqgm9",
       "id": "1378",
-      "current_tick_liquidity": "71434961.829433160388504674",
+      "current_tick_liquidity": "35465920.348697687678766972",
       "token0": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqtia",
       "token1": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-      "current_sqrt_price": "0.276287276183859713626543448418153642",
-      "current_tick": "-11366535",
+      "current_sqrt_price": "0.230440915034102731708655210658117734",
+      "current_tick": "-13689699",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T19:13:07.679211865Z"
+      "last_liquidity_update": "2024-05-16T00:27:27.897784497Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -41651,14 +41651,14 @@
         {
           "token": {
             "denom": "ibc/442A08C33AE9875DF90792FFA73B5728E1CAECE87AB4F26AE9B422F1E682ED23",
-            "amount": "803458938824"
+            "amount": "806185915420"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "18088637"
+            "amount": "18031531"
           },
           "weight": "536870912000000"
         }
@@ -41677,20 +41677,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1381",
-        "amount": "743494148121853315818"
+        "amount": "735193111271926149142"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/442A08C33AE9875DF90792FFA73B5728E1CAECE87AB4F26AE9B422F1E682ED23",
-            "amount": "231199371900401"
+            "amount": "221071491071165"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "4175178024"
+            "amount": "4270950237"
           },
           "weight": "536870912000000"
         }
@@ -41747,14 +41747,14 @@
         {
           "token": {
             "denom": "ibc/2FFE07C4B4EFC0DDA099A16C6AF3C9CCA653CC56077E87217A585D48794B0BC7",
-            "amount": "889574371506"
+            "amount": "789182911503"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "17240865"
+            "amount": "19464158"
           },
           "weight": "536870912000000"
         }
@@ -41770,8 +41770,8 @@
       "current_tick_liquidity": "474311476605.977826009695119190",
       "token0": "ibc/183C0BB962D2F57C957E0B134CFA0AC9D6F755C02DE9DC2A59089BA23009DEC3",
       "token1": "uosmo",
-      "current_sqrt_price": "0.091219255358180870292879553246950952",
-      "current_tick": "-19679048",
+      "current_sqrt_price": "0.091637382817073294226919567805859326",
+      "current_tick": "-19602591",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -41795,14 +41795,14 @@
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "127399188"
+            "amount": "123715406"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
-            "amount": "1183312509"
+            "amount": "1218834540"
           },
           "weight": "536870912000000"
         }
@@ -41827,14 +41827,14 @@
         {
           "token": {
             "denom": "ibc/0835781EF3F3ADD053874323AB660C75B50B18B16733CAB783CA6BBD78244EDF",
-            "amount": "11026000968"
+            "amount": "11264674866"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4596728737"
+            "amount": "4501735258"
           },
           "weight": "536870912000000"
         }
@@ -41863,15 +41863,15 @@
       "incentives_address": "osmo1tr5cfnm98dakwe8fs6hjqfcwtcka08q3tgjfkz8r9src6vytkauqsfqf3p",
       "spread_rewards_address": "osmo1mds3tsdvp7ke39m8mqwt7u9z25wet7uh48qqqy979pz06mzc7kxqty2d3c",
       "id": "1388",
-      "current_tick_liquidity": "560055102169.639612380477371055",
+      "current_tick_liquidity": "591383103582.160325946337051600",
       "token0": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
       "token1": "uosmo",
-      "current_sqrt_price": "0.883549871145426070223551253168530976",
-      "current_tick": "-2193397",
+      "current_sqrt_price": "0.889217097707529957031868904592049032",
+      "current_tick": "-2092930",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:45:00.006881556Z"
+      "last_liquidity_update": "2024-05-17T23:17:13.892519924Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -41885,20 +41885,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1389",
-        "amount": "602301586010700282039"
+        "amount": "604064219923150545868"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
-            "amount": "465985844964"
+            "amount": "470914895569"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "3596221666"
+            "amount": "3580438703"
           },
           "weight": "536870912000000"
         }
@@ -41987,14 +41987,14 @@
         {
           "token": {
             "denom": "ibc/4BDADBEDA31899036AB286E9901116496A9D85FB87B35A408C9D67C0DCAC660A",
-            "amount": "85403599496"
+            "amount": "86287473486"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "654998775"
+            "amount": "648309307"
           },
           "weight": "536870912000000"
         }
@@ -42113,11 +42113,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-          "amount": "20043964"
+          "amount": "19514701"
         },
         {
           "denom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
-          "amount": "2047820036"
+          "amount": "2071840229"
         }
       ],
       "scaling_factors": [
@@ -42135,8 +42135,8 @@
       "current_tick_liquidity": "174021711975361.734132874968268064",
       "token0": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
       "token1": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-      "current_sqrt_price": "1.213817696018580662366728463880113175",
-      "current_tick": "473353",
+      "current_sqrt_price": "1.214407650827163723140240586766021051",
+      "current_tick": "474785",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -42164,15 +42164,15 @@
       "incentives_address": "osmo1a6n7060u8rqm4yy4y9trez03wkzfxn2qkh94823had094dcgh3vssvlsat",
       "spread_rewards_address": "osmo1ll95eu8kemuah5h3ulke4vcm333erd6vvg3fjxnrx8ec437n0ceq9wz3ny",
       "id": "1399",
-      "current_tick_liquidity": "282964876196.862347557423559707",
+      "current_tick_liquidity": "1049339976265.802865137884408628",
       "token0": "uosmo",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "0.315904405106073079887960126831320750",
-      "current_tick": "-9020441",
+      "current_sqrt_price": "0.317495118982597198677202212920643556",
+      "current_tick": "-8991969",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:56.532320747Z"
+      "last_liquidity_update": "2024-05-18T00:12:06.980631118Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -42180,15 +42180,15 @@
       "incentives_address": "osmo1yfs3mhtv628v2npp928qze5x2vm8x0l67smhcpfh9aycysaj27qsq8t58n",
       "spread_rewards_address": "osmo1k40evxq22fafj74wpqquyvrz2wmul7j530k39s9wnp0ehspdk4rsckns2p",
       "id": "1400",
-      "current_tick_liquidity": "27568502263783.467072611227533796",
+      "current_tick_liquidity": "5251089394501.737769117823782566",
       "token0": "uosmo",
       "token1": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-      "current_sqrt_price": "0.315920974083093603573631474394894733",
-      "current_tick": "-9019394",
+      "current_sqrt_price": "0.317478920852615437062601223687755106",
+      "current_tick": "-8992072",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000000000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:13:15.557503681Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -42206,11 +42206,11 @@
       "pool_liquidity": [
         {
           "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-          "amount": "1191141"
+          "amount": "1179028"
         },
         {
           "denom": "uosmo",
-          "amount": "40159894"
+          "amount": "40297308"
         }
       ],
       "scaling_factors": [
@@ -42269,14 +42269,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "1857348986"
+            "amount": "1869613402"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/94ED1F172BC633DFC56D7E26551D8B101ADCCC69052AC44FED89F97FF658138F",
-            "amount": "1587924708"
+            "amount": "1577569339"
           },
           "weight": "536870912000000"
         }
@@ -42365,14 +42365,14 @@
         {
           "token": {
             "denom": "factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO",
-            "amount": "243334935476"
+            "amount": "248060742070"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "207927710"
+            "amount": "204002293"
           },
           "weight": "536870912000000"
         }
@@ -42407,20 +42407,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1408",
-        "amount": "1335023925007988880613"
+        "amount": "1261910584452613374460"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO",
-            "amount": "38854479791944"
+            "amount": "38134623856142"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "39832546043"
+            "amount": "36271194406"
           },
           "weight": "536870912000000"
         }
@@ -42449,15 +42449,15 @@
       "incentives_address": "osmo132fz8lz0nwl43ywu62xnwmxcng6dp3s4d0t7z3f57ph02xy9nvxq2edgvm",
       "spread_rewards_address": "osmo1eyf8lmpk3x25zxve0n296gwfnnd7m2p0sxdl7pr22u4tdsy325tqlle2ku",
       "id": "1410",
-      "current_tick_liquidity": "2075589325.223181786466225301",
+      "current_tick_liquidity": "2075492808.221391401178316033",
       "token0": "ibc/73BB20AF857D1FE6E061D01CA13870872AD0C979497CAF71BEA25B1CBF6879F1",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.337281163814748209022045781972243989",
-      "current_tick": "-8862415",
+      "current_sqrt_price": "0.307481034832123112410468491623806980",
+      "current_tick": "-9545542",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-07T10:52:26.275681135Z"
+      "last_liquidity_update": "2024-05-17T22:44:12.553043869Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -42573,14 +42573,14 @@
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "2907223"
+            "amount": "2867194"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
-            "amount": "505415349433"
+            "amount": "512615631672"
           },
           "weight": "536870912000000"
         }
@@ -42605,14 +42605,14 @@
         {
           "token": {
             "denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
-            "amount": "85176461"
+            "amount": "88562925"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO",
-            "amount": "7077130488"
+            "amount": "6811724909"
           },
           "weight": "536870912000000"
         }
@@ -42644,8 +42644,8 @@
       "current_tick_liquidity": "174878200468.889357927631375269",
       "token0": "factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.029194264368142613284803945418814014",
-      "current_tick": "-28476950",
+      "current_sqrt_price": "0.028695687432816024448133604258234057",
+      "current_tick": "-28765576",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
@@ -42701,14 +42701,14 @@
         {
           "token": {
             "denom": "ibc/2FFE07C4B4EFC0DDA099A16C6AF3C9CCA653CC56077E87217A585D48794B0BC7",
-            "amount": "188020687038694"
+            "amount": "178900481506214"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "29914851381437"
+            "amount": "31456692277852"
           },
           "weight": "536870912000000"
         }
@@ -42733,14 +42733,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "16179771710"
+            "amount": "16249450564"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5F5B7DA5ECC80F6C7A8702D525BB0B74279B1F7B8EFAE36E423D68788F7F39FF",
-            "amount": "8433604020302"
+            "amount": "8397846094429"
           },
           "weight": "536870912000000"
         }
@@ -42753,15 +42753,15 @@
       "incentives_address": "osmo1uypu5dat0pw23w8cpkyhuvnqyjzyh2hac4mx9zk5t2rrwjxrfteq8ulplx",
       "spread_rewards_address": "osmo14efvzy6s9a6r3tcr0afq0hwsqww9uq8hs3mcmhw9nsmf5cp3mhrsy6cr4s",
       "id": "1422",
-      "current_tick_liquidity": "4486497523609.902668604525530372",
+      "current_tick_liquidity": "4486930925868.181362125443014119",
       "token0": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.999521332911497362348899108505629483",
-      "current_tick": "-9572",
+      "current_sqrt_price": "0.999538416169652785486863024319351663",
+      "current_tick": "-9230",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T23:54:15.329112584Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -42769,15 +42769,15 @@
       "incentives_address": "osmo1v0fmyz8udx3ycncsy7re8xxpgxvcdhjjsay72ksr0jxwex4szvfqplsk86",
       "spread_rewards_address": "osmo1r35ey2thyxd3uh9duyy9zfzp94k5r32xaqqr9ghyjckcgyt60rzqxg4c6k",
       "id": "1423",
-      "current_tick_liquidity": "1455080868906926795481836.912188620139916444",
+      "current_tick_liquidity": "2221621610713655470388137.725678789600736011",
       "token0": "ibc/980E82A9F8E7CA8CD480F4577E73682A6D3855A267D1831485D7EBEF0E7A6C2C",
       "token1": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
-      "current_sqrt_price": "1.012258309383654193766327785573828900",
-      "current_tick": "24666",
+      "current_sqrt_price": "1.022452403716247611487540448411217608",
+      "current_tick": "45408",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:57:24.966619708Z"
+      "last_liquidity_update": "2024-05-17T23:56:37.341382730Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -42859,11 +42859,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
-          "amount": "5665229365421850780"
+          "amount": "5723152849166961008"
         },
         {
           "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-          "amount": "4409278063236933343"
+          "amount": "4351684547878200714"
         }
       ],
       "scaling_factors": [
@@ -42881,8 +42881,8 @@
       "current_tick_liquidity": "1843465812669934.514295292066619091",
       "token0": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
       "token1": "uosmo",
-      "current_sqrt_price": "0.000006426210851095842809961445857862",
-      "current_tick": "-95870382",
+      "current_sqrt_price": "0.000006461336765553383805480220816819",
+      "current_tick": "-95825113",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -42894,15 +42894,15 @@
       "incentives_address": "osmo17kjs2lrgzs9lmkc70qt67jd6wkn25qlmefjxhqmmum534g9xew4qv8cvtq",
       "spread_rewards_address": "osmo19dr8l30007hwkecmec9mjfrldy9kh3nz2n0zs7duqku95n2ftnxqz2gq6m",
       "id": "1428",
-      "current_tick_liquidity": "40064443156292.809364715366094228",
+      "current_tick_liquidity": "38368847495611.206439035419660583",
       "token0": "ibc/698350B8A61D575025F3ED13E9AC9C0F45C89DEFE92F76D5838F1D3C1A7FF7C9",
       "token1": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-      "current_sqrt_price": "1.007631861988955313490807396794871428",
-      "current_tick": "15321",
+      "current_sqrt_price": "1.006928056602032388544426312652037268",
+      "current_tick": "13904",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:11:57.328916576Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -42922,14 +42922,14 @@
         {
           "token": {
             "denom": "ibc/980E82A9F8E7CA8CD480F4577E73682A6D3855A267D1831485D7EBEF0E7A6C2C",
-            "amount": "357986220398791752532"
+            "amount": "358161321686984190212"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "850849388"
+            "amount": "850521577"
           },
           "weight": "536870912000000"
         }
@@ -42945,8 +42945,8 @@
       "current_tick_liquidity": "23415592.544416973723394273",
       "token0": "uosmo",
       "token1": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-      "current_sqrt_price": "0.035665778873368552569099995541580743",
-      "current_tick": "-26727953",
+      "current_sqrt_price": "0.036147065469324268480948519817321242",
+      "current_tick": "-26693390",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
@@ -42958,15 +42958,15 @@
       "incentives_address": "osmo1d27934qsuawccvw8ka6engkx954w6amhmhpy5875uk4yah47493sr9rvk6",
       "spread_rewards_address": "osmo1q4w2z67f0swwwxw5mycyeu32s4t8v4vdke3dh02v8qrwe8xmgp9sjesk5m",
       "id": "1431",
-      "current_tick_liquidity": "8253813866032021578091496.550410712130465103",
+      "current_tick_liquidity": "8281628607655764656397572.779572703314396110",
       "token0": "ibc/2F21E6D4271DE3F561F20A02CD541DAF7405B1E9CB3B9B07E3C2AC7D8A4338A5",
       "token1": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "current_sqrt_price": "1.078916838213813598919292692297642748",
-      "current_tick": "164061",
+      "current_sqrt_price": "1.078919541058485329833858411835393419",
+      "current_tick": "164067",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -42974,15 +42974,15 @@
       "incentives_address": "osmo1ghyngy8wre4sucsffde54uuykjljdzr0p7hnxryngagwy6xw33ns4e7y2k",
       "spread_rewards_address": "osmo1frv3ql9dj3kysmhsa40zka4fwghnwpx9msfr4gtmzzuw7uqcytfsc3yhte",
       "id": "1432",
-      "current_tick_liquidity": "44503626.154696332095687616",
+      "current_tick_liquidity": "44506506.644556187653670360",
       "token0": "uosmo",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.035629528921826538739776758906332507",
-      "current_tick": "-26730537",
+      "current_sqrt_price": "0.036152276068527809252325839377988834",
+      "current_tick": "-26693013",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -42993,12 +42993,12 @@
       "current_tick_liquidity": "18415487.184546289571732138",
       "token0": "uosmo",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.035594707586221494290253583906671970",
-      "current_tick": "-26733017",
+      "current_sqrt_price": "0.036106542528655653823510976693227153",
+      "current_tick": "-26696318",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43006,15 +43006,15 @@
       "incentives_address": "osmo1jx9rldvj6xdd8wurp0x94w2wswplzxgjwp0yquk72k2vu04gx3rqr0fyn3",
       "spread_rewards_address": "osmo12hlk07xr7f90uxfd9jttauleancd9mr7d3pk064vajfytwtdrx4qs7kvmc",
       "id": "1434",
-      "current_tick_liquidity": "3144642840186.653147636595896125",
+      "current_tick_liquidity": "3020932203701.724484648334188183",
       "token0": "uosmo",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.035657097667457137673889785029505931",
-      "current_tick": "-26728572",
+      "current_sqrt_price": "0.036108756128907790615617298588317444",
+      "current_tick": "-26696158",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T23:52:42.702326642Z"
+      "last_liquidity_update": "2024-05-18T00:11:38.482022147Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43022,15 +43022,15 @@
       "incentives_address": "osmo1kkm0vfek6cqstrgeae6xdrel45ftd3hxt74z5g5g5p6wlqzhmads7pd5s0",
       "spread_rewards_address": "osmo13yj08xy6xvyu9z54x49es2unrkagfsz0hye5ytz3kzg2pytnvnwqataxfj",
       "id": "1435",
-      "current_tick_liquidity": "3218146332376.711724032030140507",
+      "current_tick_liquidity": "592277469871.557005682060925936",
       "token0": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "25.718843500895764577695722164693690048",
-      "current_tick": "23614589",
+      "current_sqrt_price": "25.858896449914027807196920003835137482",
+      "current_tick": "23686825",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:12.728562260Z"
+      "last_liquidity_update": "2024-05-18T00:12:58.350083072Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43038,15 +43038,15 @@
       "incentives_address": "osmo14rl8r9078tmzjtyaax5c3vy0fal5faarpc2wk6ef9c8qtvt30xyqd3ve2w",
       "spread_rewards_address": "osmo1q8f0c6g7262l8tn3wt94ns5n80ckcufyllpzhyzsazhs4zw8c4kshrsx4r",
       "id": "1436",
-      "current_tick_liquidity": "17109989828555.899205985299271359",
+      "current_tick_liquidity": "17531605449027.101581791690971309",
       "token0": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "25.730866136580175544713178993817397535",
-      "current_tick": "23620774",
+      "current_sqrt_price": "25.878091926309023152923982889710658916",
+      "current_tick": "23696756",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:22.662795311Z"
+      "last_liquidity_update": "2024-05-18T00:08:26.396271338Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43054,15 +43054,15 @@
       "incentives_address": "osmo12tcdd6ptl049unknq5mw9pcmgj76alnafunks7kx960xstadss8shdfe9a",
       "spread_rewards_address": "osmo1c87n444c5mxfqe60hhjkjf5ez7yj29xv7fu0fvu982qjjngt5d9qzpj80q",
       "id": "1437",
-      "current_tick_liquidity": "53254264731.074012906216106977",
+      "current_tick_liquidity": "66714615176.413919778261357811",
       "token0": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "25.735590042536706701529233761943390477",
-      "current_tick": "23623205",
+      "current_sqrt_price": "25.882853284393463451303897380446439629",
+      "current_tick": "23699220",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-16T00:05:42.536947632Z"
+      "last_liquidity_update": "2024-05-18T00:12:13.378239378Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43073,12 +43073,12 @@
       "current_tick_liquidity": "383011514.221577187106929688",
       "token0": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "25.729050126031570466604582131456540852",
-      "current_tick": "23619840",
+      "current_sqrt_price": "25.865681849341238056772316373490758454",
+      "current_tick": "23690334",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43094,7 +43094,7 @@
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43102,15 +43102,15 @@
       "incentives_address": "osmo148yktpse8vc5g07ajnknhfpdzmn99z4vv3xueends6pzxm5l795semea3k",
       "spread_rewards_address": "osmo1f3jfkankrzgxhqrfd9nyh7gaw58fy7l6qdmurx5u5gl3ycf5wpzqucssrs",
       "id": "1440",
-      "current_tick_liquidity": "41460664178731.033521956793534990",
+      "current_tick_liquidity": "41070074607813.558973128515206819",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.000002139287693188057184816214101520",
-      "current_tick": "-104423449",
+      "current_sqrt_price": "0.000002149660415468553508370059265760",
+      "current_tick": "-104378961",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T19:05:05.622854308Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43118,15 +43118,15 @@
       "incentives_address": "osmo15gcyl8up0p2uzn2yggrtu4p7fup2fyzdgj4pyrre9wrzpg58ft8qv7c09v",
       "spread_rewards_address": "osmo1jr4drq5xda5ynnvusmnv75hmqdravg653ukwcmeta2f2dz07sl7q58na2a",
       "id": "1441",
-      "current_tick_liquidity": "138404526826121824.640248254134372310",
+      "current_tick_liquidity": "149962678692581566.919461704816658843",
       "token0": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.000002140802101728074702050280029890",
-      "current_tick": "-104416967",
+      "current_sqrt_price": "0.000002149283285808150651097917379859",
+      "current_tick": "-104380582",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:31.653987474Z"
+      "last_liquidity_update": "2024-05-18T00:02:11.257685885Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -43240,20 +43240,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1446",
-        "amount": "2539982610540359451675"
+        "amount": "2548750864909876063297"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "2276561438"
+            "amount": "2295863676"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/698350B8A61D575025F3ED13E9AC9C0F45C89DEFE92F76D5838F1D3C1A7FF7C9",
-            "amount": "2344339157"
+            "amount": "2340841964"
           },
           "weight": "536870912000000"
         }
@@ -43269,12 +43269,12 @@
       "current_tick_liquidity": "24891713613.167386788325954427",
       "token0": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.274747332514379925214117746404220139",
-      "current_tick": "-11451391",
+      "current_sqrt_price": "0.265200863930159154265713894711316204",
+      "current_tick": "-11966851",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T20:32:52.931842837Z"
+      "last_liquidity_update": "2024-05-16T12:10:58.759111230Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -43314,15 +43314,15 @@
       "incentives_address": "osmo1e6h2l7d4vtzx833gqdyhn65fy735vfyvaeltn5het5j3u8dy9qust7hcdm",
       "spread_rewards_address": "osmo1x43ku3f0xgspjtu0mxf4mc56mxcdnkjz0yw4accuqzkz97csayas4zmveh",
       "id": "1449",
-      "current_tick_liquidity": "776912768285071286.609072816394343156",
+      "current_tick_liquidity": "576945281278629634.560611834381229045",
       "token0": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
       "token1": "uosmo",
-      "current_sqrt_price": "0.000001806798957462019011665067208113",
-      "current_tick": "-105735478",
+      "current_sqrt_price": "0.000001762188888219263412037514457925",
+      "current_tick": "-105894691",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:03:03.745043012Z"
+      "last_liquidity_update": "2024-05-17T23:20:04.909927299Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43330,15 +43330,15 @@
       "incentives_address": "osmo18gcrqca6me2pqche6mynyl8f60w297pxny8kdzwmpm7cd5vnglqsqehy4e",
       "spread_rewards_address": "osmo109gftlgpjc2rlzduw5jtyeq2nczuj0fdl26qh6wu94uaqjydmzjqrxyt67",
       "id": "1450",
-      "current_tick_liquidity": "238740691252810326.639538278688112963",
+      "current_tick_liquidity": "160733914927927109.719164536205149551",
       "token0": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000001656271099484006539338183496557",
-      "current_tick": "-106256767",
+      "current_sqrt_price": "0.000001647826276230628728203571313710",
+      "current_tick": "-106284669",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:40.757728305Z"
+      "last_liquidity_update": "2024-05-18T00:08:08.382222535Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -43358,14 +43358,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "1866073"
+            "amount": "1886219"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-            "amount": "2136268502796577364"
+            "amount": "2128863102040508306"
           },
           "weight": "805306368000000"
         }
@@ -43422,14 +43422,14 @@
         {
           "token": {
             "denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-            "amount": "18452632679735343189"
+            "amount": "18909570096141751672"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "60946144"
+            "amount": "59499958"
           },
           "weight": "536870912000000"
         }
@@ -43448,20 +43448,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1454",
-        "amount": "94509580157245"
+        "amount": "126360829100462"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/698350B8A61D575025F3ED13E9AC9C0F45C89DEFE92F76D5838F1D3C1A7FF7C9",
-            "amount": "1378378"
+            "amount": "1976444"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "14036570"
+            "amount": "20604569"
           },
           "weight": "536870912000000"
         }
@@ -43486,14 +43486,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "20209859"
+            "amount": "20310851"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-            "amount": "7402754309049410664"
+            "amount": "7370621077422393324"
           },
           "weight": "536870912000000"
         }
@@ -43611,14 +43611,14 @@
         {
           "token": {
             "denom": "ibc/980E82A9F8E7CA8CD480F4577E73682A6D3855A267D1831485D7EBEF0E7A6C2C",
-            "amount": "14660437463636815"
+            "amount": "14854669308673951"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "38267"
+            "amount": "37768"
           },
           "weight": "536870912000000"
         }
@@ -43637,20 +43637,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1460",
-        "amount": "3222146873355935506051"
+        "amount": "3194767382412336961950"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "623427445"
+            "amount": "613374517"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "6895887539"
+            "amount": "6893520680"
           },
           "weight": "536870912000000"
         }
@@ -43684,15 +43684,15 @@
       "incentives_address": "osmo1wsfhgwgvpylkcde80vzyry3dt2vhkah83ctqc23r8780vujsxvdq952del",
       "spread_rewards_address": "osmo1zdze9lvalg9x6zj9u4vzrsyjljnmgp46kwcelzz4eqddsqk8uecsrxwmcv",
       "id": "1464",
-      "current_tick_liquidity": "2575293477250.783190796505602128",
+      "current_tick_liquidity": "2367473922738182.303616987380661883",
       "token0": "uosmo",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.918795633278355073322766538938733860",
-      "current_tick": "-1558146",
+      "current_sqrt_price": "0.934319082518811395261592787888440237",
+      "current_tick": "-1270479",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:39.263910827Z"
+      "last_liquidity_update": "2024-05-18T00:12:45.130926523Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -43703,12 +43703,12 @@
       "current_tick_liquidity": "50226699.711448953882824400",
       "token0": "uosmo",
       "token1": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-      "current_sqrt_price": "0.916193944238706850392277249490143354",
-      "current_tick": "-1605887",
+      "current_sqrt_price": "0.933149113880202252476462603122178298",
+      "current_tick": "-1292328",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T17:16:10.136043198Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -43806,14 +43806,14 @@
         {
           "token": {
             "denom": "ibc/6928AFA9EA721938FED13B051F9DBF1272B16393D20C49EA5E4901BB76D94A90",
-            "amount": "157415072"
+            "amount": "197947601"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2721868"
+            "amount": "2260333"
           },
           "weight": "536870912000000"
         }
@@ -43866,20 +43866,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1470",
-        "amount": "808121595018188359256521"
+        "amount": "809718686837896840710956"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo10n8rv8npx870l69248hnp6djy6pll2yuzzn9x8/BADKID",
-            "amount": "148273908487713"
+            "amount": "153389247334702"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1213921309"
+            "amount": "1178210578"
           },
           "weight": "536870912000000"
         }
@@ -43904,14 +43904,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "11331266879"
+            "amount": "11494686242"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "9501780544980"
+            "amount": "9369251757044"
           },
           "weight": "536870912000000"
         }
@@ -43927,8 +43927,8 @@
       "current_tick_liquidity": "108088361914.593246304709618886",
       "token0": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.240177941865964450700052560693324565",
-      "current_tick": "-13231456",
+      "current_sqrt_price": "0.244035013792829464009119359771511584",
+      "current_tick": "-13044692",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -43975,8 +43975,8 @@
       "current_tick_liquidity": "20108182404.972100154248656029",
       "token0": "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.998105123811094821236306775218393855",
-      "current_tick": "-37862",
+      "current_sqrt_price": "0.994376302990378700485457062902067121",
+      "current_tick": "-112158",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
@@ -43988,15 +43988,15 @@
       "incentives_address": "osmo17p45glv8dr0upmqaalsrttd84l8w980rvlvkdv80q98wqtjm3y3su9zt49",
       "spread_rewards_address": "osmo1mzyrrtmjy8mttalx8mdu6l4cufgt3xcd43g4d37xcmrl7xjjdn9sc0yts8",
       "id": "1475",
-      "current_tick_liquidity": "43227622636736.434974699542471964",
+      "current_tick_liquidity": "42133757981350.404160937086081001",
       "token0": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
       "token1": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-      "current_sqrt_price": "1.020706772535199751496803401768599424",
-      "current_tick": "41842",
+      "current_sqrt_price": "1.017108278416791664381886631183451944",
+      "current_tick": "34509",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-16T00:05:47.886344486Z"
+      "last_liquidity_update": "2024-05-18T00:02:58.159522215Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44004,15 +44004,15 @@
       "incentives_address": "osmo1dswvhaxvte7crfvey8nzv547t9pmgvcrs64xqlzwj5v4nf83nrkqw8dacv",
       "spread_rewards_address": "osmo1q0hc25kehgqxlcy8f3dgeq0hflffm03ghwatw8dghrr64qruskjqgjfrpu",
       "id": "1476",
-      "current_tick_liquidity": "38001742958706.119736912487600749",
+      "current_tick_liquidity": "34700910125173.640643189812175020",
       "token0": "ibc/698350B8A61D575025F3ED13E9AC9C0F45C89DEFE92F76D5838F1D3C1A7FF7C9",
       "token1": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-      "current_sqrt_price": "1.006837812375288042372788019184701544",
-      "current_tick": "13722",
+      "current_sqrt_price": "1.006435443720168086186746895842563174",
+      "current_tick": "12912",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:34:44.973515386Z"
+      "last_liquidity_update": "2024-05-17T21:32:49.249518909Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44020,15 +44020,15 @@
       "incentives_address": "osmo13555v085c3yjrectkzqh7k4yfm429td06v27h35yk9an4pwrdmyq9zze8u",
       "spread_rewards_address": "osmo1zxjwg74hvgv9eczu6m8sfw3tcg6tfdseh8qr2lfa7lupf478xqkqc0erz3",
       "id": "1477",
-      "current_tick_liquidity": "3234160456084606335.580979599505818129",
+      "current_tick_liquidity": "4475616854997984555.939901216564525800",
       "token0": "uosmo",
       "token1": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "current_sqrt_price": "16669.478884378418802798528402442131479709",
-      "current_tick": "73778715",
+      "current_sqrt_price": "16811.604640407050304576419281272735272384",
+      "current_tick": "73826300",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-16T00:08:15.537542831Z"
+      "last_liquidity_update": "2024-05-18T00:13:10.535913576Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44036,15 +44036,15 @@
       "incentives_address": "osmo1ny96w0kyqsa8g2my0xa7xhllclk5gxa8ta62gw5z8q2gjtyl88wqkzym05",
       "spread_rewards_address": "osmo19cw2gmtxk5tmnw3tkjsapfvzzq6gaz0zr4h4y8h5v0wc5e3ka4nszzwc57",
       "id": "1478",
-      "current_tick_liquidity": "137531348.381866915280681382",
+      "current_tick_liquidity": "3094955876.731023225612384710",
       "token0": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.989988235976352218951716467031084603",
-      "current_tick": "7940029",
+      "current_sqrt_price": "3.078638234726655273196671915216013334",
+      "current_tick": "8478013",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000100000000000000",
-      "last_liquidity_update": "2024-05-15T21:01:58.920038399Z"
+      "last_liquidity_update": "2024-05-17T17:16:11.642189416Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44052,15 +44052,15 @@
       "incentives_address": "osmo1y8ws3axg8c4frt0z45f77ahq0yegsk6gvtk0hf02fx7vvhkxednsz4he3n",
       "spread_rewards_address": "osmo1fvecy04m3jc6ytxs4wz7eguwgwy88n70yh7zvan4dhwlzc6lgc2qqfcmfq",
       "id": "1479",
-      "current_tick_liquidity": "61160315675365.770690232974440831",
+      "current_tick_liquidity": "50624700843870.130329966130867485",
       "token0": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000071162528146266709553191942854682",
-      "current_tick": "-76935895",
+      "current_sqrt_price": "0.000069191137334553559934541782274955",
+      "current_tick": "-77212587",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T21:04:08.930550756Z"
+      "last_liquidity_update": "2024-05-17T23:48:05.731407545Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44068,15 +44068,15 @@
       "incentives_address": "osmo15rgyn3fuyrjc6z0xqmh7ap3x3ge4mpnefc8np5wwgeyrtjfj5ksswfgpev",
       "spread_rewards_address": "osmo1d94ncdwquvunrnv6yqg4pvslg6qjj9tcvps4sfy2vl2vzc55699qcnvw52",
       "id": "1480",
-      "current_tick_liquidity": "1881354839.666507721217438096",
+      "current_tick_liquidity": "4009461149.119526252307084092",
       "token0": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "2.398244343274899523339312381991189339",
-      "current_tick": "4751575",
+      "current_sqrt_price": "2.423288061825080566238437849939384660",
+      "current_tick": "4872325",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-10T09:32:31.161320919Z"
+      "last_liquidity_update": "2024-05-17T12:11:59.581515035Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44084,15 +44084,15 @@
       "incentives_address": "osmo1uqdyht007skwqvn5mnxfzqccnqtw0kr7phe5nrrngn9c9cda4j7s2uufvg",
       "spread_rewards_address": "osmo1m8ecucxp62736hu99dhs3w4seyxkw5tk24qkk3wjegtjr8t64ygqzvc36n",
       "id": "1481",
-      "current_tick_liquidity": "8110457892.714603998445923881",
+      "current_tick_liquidity": "8350218131.293752304364399991",
       "token0": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.727201234444561321908826178734096285",
-      "current_tick": "-4711784",
+      "current_sqrt_price": "0.749944723896338468587250721350516047",
+      "current_tick": "-4375830",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T16:04:04.223366103Z"
+      "last_liquidity_update": "2024-05-17T22:03:41.192806335Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44103,8 +44103,8 @@
       "current_tick_liquidity": "2257851345315036.578419274482003334",
       "token0": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000004862516758384886215060225509388",
-      "current_tick": "-97635594",
+      "current_sqrt_price": "0.000004974111298509681746337707463640",
+      "current_tick": "-97525822",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -44119,8 +44119,8 @@
       "current_tick_liquidity": "944633861912.260761981670025934",
       "token0": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "token1": "uosmo",
-      "current_sqrt_price": "0.262037404692175020848571610487935627",
-      "current_tick": "-12133640",
+      "current_sqrt_price": "0.261010046958048210076174286856886733",
+      "current_tick": "-12187376",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -44219,14 +44219,14 @@
         {
           "token": {
             "denom": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
-            "amount": "94610023879"
+            "amount": "92516642057"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "2556369243"
+            "amount": "2615363754"
           },
           "weight": "536870912000000"
         }
@@ -44335,15 +44335,15 @@
       "incentives_address": "osmo1l75xpusmsm44z3ekhjdsw9xflecjhrchk2fe4j9k83ga2hfhjm2qqkppra",
       "spread_rewards_address": "osmo1u0pec6cucffqty888atsndp0fua3jr6qxev606wmlt523stqrtqq2l5gxw",
       "id": "1490",
-      "current_tick_liquidity": "7818118403948.539908012425695340",
+      "current_tick_liquidity": "7852304245708.201083751473039418",
       "token0": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.000999095604549631621641971966149128",
-      "current_tick": "-54018080",
+      "current_sqrt_price": "0.000999656986929239136395309695795238",
+      "current_tick": "-54006860",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T22:13:00.978640357Z"
+      "last_liquidity_update": "2024-05-17T23:57:48.934812449Z"
     },
     {
       "@type": "/osmosis.gamm.poolmodels.stableswap.v1beta1.Pool",
@@ -44383,12 +44383,12 @@
       "current_tick_liquidity": "552439078019569.571779226070150374",
       "token0": "ibc/A5CCD24BA902843B1003A7EEE5F937C632808B9CF4925601241B15C5A0A51A53",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000048391880876237770383620516175982",
-      "current_tick": "-79658226",
+      "current_sqrt_price": "0.000048167912106561553568444248540819",
+      "current_tick": "-79679853",
       "tick_spacing": "10",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
-      "last_liquidity_update": "2024-05-15T16:50:35.759498312Z"
+      "last_liquidity_update": "2024-05-17T16:14:44.531552894Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -44408,14 +44408,14 @@
         {
           "token": {
             "denom": "ibc/35CECC330D11DD00FACB555D07687631E0BC7D226260CC5F015F6D7980819533",
-            "amount": "1197397213155527204604271"
+            "amount": "1226544968970872301503736"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "29310318869"
+            "amount": "28648445835"
           },
           "weight": "5368709120"
         }
@@ -44562,20 +44562,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1498",
-        "amount": "106443663920002514574"
+        "amount": "106452231559059912522"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "28063759122"
+            "amount": "28287810485"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
-            "amount": "5927886631208"
+            "amount": "5885619036075"
           },
           "weight": "536870912000000"
         }
@@ -44594,20 +44594,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1499",
-        "amount": "485461349846614628358651"
+        "amount": "485461025818089602341591"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-            "amount": "27894407324"
+            "amount": "28152230442"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
-            "amount": "307305332818"
+            "amount": "304537794618"
           },
           "weight": "536870912000000"
         }
@@ -44623,8 +44623,8 @@
       "current_tick_liquidity": "59604754894.443841124734203754",
       "token0": "ibc/A4D176906C1646949574B48C1928D475F2DF56DE0AC04E1C99B08F90BC21ABDE",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.289322980775641595517785844966494361",
-      "current_tick": "-10629222",
+      "current_sqrt_price": "0.292937333158515881019054130280756328",
+      "current_tick": "-10418772",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -44636,15 +44636,15 @@
       "incentives_address": "osmo1ywt6h39tfl09mjlkqgrtynezawsxuednzy59z3kt0n9nqgvgup2sk36qpw",
       "spread_rewards_address": "osmo12wlww09lkcjnem7tpzfzkhykha8k4ezgn09gnn0adw2wlrpwk3rskeks5m",
       "id": "1501",
-      "current_tick_liquidity": "189777169596.561895735202314715",
+      "current_tick_liquidity": "158008897368.578716139240516851",
       "token0": "ibc/A4D176906C1646949574B48C1928D475F2DF56DE0AC04E1C99B08F90BC21ABDE",
       "token1": "uosmo",
-      "current_sqrt_price": "0.316430685747947143779715029701260792",
-      "current_tick": "-8998717",
+      "current_sqrt_price": "0.313313245249419462363750758619076812",
+      "current_tick": "-9183482",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-10T09:10:45.873852492Z"
+      "last_liquidity_update": "2024-05-17T00:18:14.148548972Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44655,12 +44655,12 @@
       "current_tick_liquidity": "33164351782.699437742698337219",
       "token0": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.100121675850455505001117233684324214",
-      "current_tick": "-17997566",
+      "current_sqrt_price": "0.104894491943110298223848556396831724",
+      "current_tick": "-17899715",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T17:06:20.746508417Z"
+      "last_liquidity_update": "2024-05-16T07:27:33.522018803Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44668,15 +44668,15 @@
       "incentives_address": "osmo1llg9qypgylrgxq42dlyker5hjv9nj4csnl7q23mh0dymv800h69qm434me",
       "spread_rewards_address": "osmo1wvplkqu3fvqpn3lr2qv4h87hk4a02me50rms2c3u7x9chxhv4dtsh03c44",
       "id": "1503",
-      "current_tick_liquidity": "87112562261.422797333038557416",
+      "current_tick_liquidity": "119631486356.146230228067152380",
       "token0": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
       "token1": "uosmo",
-      "current_sqrt_price": "0.108924915296608690400817220958718787",
-      "current_tick": "-17813537",
+      "current_sqrt_price": "0.112045545492146956541113448310067889",
+      "current_tick": "-17744580",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:33:12.104933020Z"
+      "last_liquidity_update": "2024-05-17T12:10:47.927256060Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44687,8 +44687,8 @@
       "current_tick_liquidity": "1788854381.999831758160000000",
       "token0": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.810671188056630107560010427780191981",
-      "current_tick": "-3428123",
+      "current_sqrt_price": "0.819733993239562152617422089697215559",
+      "current_tick": "-3280362",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -44706,20 +44706,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1505",
-        "amount": "1217048562086065656121"
+        "amount": "13727124183766364859"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/7D389F0ABF1E4D45BE6D7BBE36A2C50EA0559C01E076B02F8E381E685EC1F942",
-            "amount": "2281850776"
+            "amount": "25737058"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "10861008"
+            "amount": "122502"
           },
           "weight": "536870912000000"
         }
@@ -44748,15 +44748,15 @@
       "incentives_address": "osmo100wv5wlv3l6kr52w720fpkcl8f4mwmmrytu4za9da833m0cgfdeqxzjal2",
       "spread_rewards_address": "osmo1cm89zxexm5v4kdfekr5cvsz85yqftdkjz564qte7wsmpkmqxkhlsfp9u3m",
       "id": "1507",
-      "current_tick_liquidity": "8783903822096.240093700992875316",
+      "current_tick_liquidity": "8851003341250.819979260013098571",
       "token0": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.009826973330511952965168346395330946",
-      "current_tick": "-36343060",
+      "current_sqrt_price": "0.009996333702633591485725893797404714",
+      "current_tick": "-36007332",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T10:30:01.013983248Z"
+      "last_liquidity_update": "2024-05-17T07:17:32.801158791Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -44917,14 +44917,14 @@
         {
           "token": {
             "denom": "ibc/C97473CD237EBA2F94FDFA6ABA5EC0E22FA140655D73D2A2754F03A347BBA40B",
-            "amount": "215373016834249"
+            "amount": "221727523020460"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
-            "amount": "29531152332"
+            "amount": "28687303252"
           },
           "weight": "536870912000000"
         }
@@ -44976,15 +44976,15 @@
       "incentives_address": "osmo1rq9e5k6pvgz8540ggzndl5u3tsucyazf0e2z3fw8sh4s069p4grq63nlru",
       "spread_rewards_address": "osmo1487k99rjuyn8dw34h4jfm7g0rqsylzjuw35xdp33cupxhxyluvrqvqv0hr",
       "id": "1516",
-      "current_tick_liquidity": "98489409761223130.104643517859085061",
+      "current_tick_liquidity": "137686991428953517.725796517501659640",
       "token0": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000001504103310284348284597549848570",
-      "current_tick": "-106737674",
+      "current_sqrt_price": "0.000001535776099031391023527913917917",
+      "current_tick": "-106641392",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:33:15.058086732Z"
+      "last_liquidity_update": "2024-05-17T23:55:22.057551309Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -44995,8 +44995,8 @@
       "current_tick_liquidity": "1366915094624165.964243648946526171",
       "token0": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000052339999997454964246672339985916",
-      "current_tick": "-79260525",
+      "current_sqrt_price": "0.000052485022245669387174583042859063",
+      "current_tick": "-79245323",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -45049,14 +45049,14 @@
         {
           "token": {
             "denom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
-            "amount": "49023260104237014835"
+            "amount": "47593737687631767095"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "77744320913"
+            "amount": "80116829052"
           },
           "weight": "536870912000000"
         }
@@ -45081,14 +45081,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "1801968815"
+            "amount": "1803978899"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "82029838859"
+            "amount": "81981611593"
           },
           "weight": "536870912000000"
         }
@@ -45113,14 +45113,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "178418087034"
+            "amount": "181141108741"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
-            "amount": "1421477383060958429505"
+            "amount": "1401062728549806455636"
           },
           "weight": "536870912000000"
         }
@@ -45145,14 +45145,14 @@
         {
           "token": {
             "denom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
-            "amount": "542898944045137899755"
+            "amount": "535436786063062256088"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "98989493361"
+            "amount": "100603242536"
           },
           "weight": "536870912000000"
         }
@@ -45177,14 +45177,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "177734609"
+            "amount": "175701880"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "184104823981"
+            "amount": "186317870538"
           },
           "weight": "536870912000000"
         }
@@ -45209,14 +45209,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "132513409381"
+            "amount": "129971546021"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-            "amount": "681499618"
+            "amount": "694983244"
           },
           "weight": "536870912000000"
         }
@@ -45241,14 +45241,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "168176878859"
+            "amount": "171105113644"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-            "amount": "407264831680253380713"
+            "amount": "400410436053707961707"
           },
           "weight": "536870912000000"
         }
@@ -45273,14 +45273,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "73331364986"
+            "amount": "72636256658"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-            "amount": "145497967814951809081"
+            "amount": "146939752928209374005"
           },
           "weight": "536870912000000"
         }
@@ -45305,14 +45305,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "229004475174"
+            "amount": "230606507828"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-            "amount": "63124771044"
+            "amount": "62777034825"
           },
           "weight": "536870912000000"
         }
@@ -45337,14 +45337,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "120623576912"
+            "amount": "122697042224"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-            "amount": "27857053193645551170"
+            "amount": "27394691650175597494"
           },
           "weight": "536870912000000"
         }
@@ -45369,14 +45369,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "243522551589"
+            "amount": "236908319009"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
-            "amount": "263194412951708419"
+            "amount": "270961291315257638"
           },
           "weight": "536870912000000"
         }
@@ -45401,14 +45401,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "176622136782"
+            "amount": "178205639439"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "814502634622"
+            "amount": "807410256423"
           },
           "weight": "536870912000000"
         }
@@ -45433,14 +45433,14 @@
         {
           "token": {
             "denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
-            "amount": "1305997300"
+            "amount": "1288858055"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "158522021787"
+            "amount": "160662738219"
           },
           "weight": "536870912000000"
         }
@@ -45465,14 +45465,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "169508477227"
+            "amount": "180402697027"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
-            "amount": "2639298039"
+            "amount": "2482437888"
           },
           "weight": "536870912000000"
         }
@@ -45497,14 +45497,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "109976946753"
+            "amount": "116507439245"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-            "amount": "13461521852763332954602"
+            "amount": "12718699839723995881816"
           },
           "weight": "536870912000000"
         }
@@ -45529,14 +45529,14 @@
         {
           "token": {
             "denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
-            "amount": "6659365062"
+            "amount": "6795603599"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "81578283122"
+            "amount": "79953753844"
           },
           "weight": "536870912000000"
         }
@@ -45561,14 +45561,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "164516326986"
+            "amount": "163138036957"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
-            "amount": "327407129153"
+            "amount": "330197176768"
           },
           "weight": "536870912000000"
         }
@@ -45593,14 +45593,14 @@
         {
           "token": {
             "denom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
-            "amount": "3023410381"
+            "amount": "3094075621"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "97815289687"
+            "amount": "95607798143"
           },
           "weight": "536870912000000"
         }
@@ -45625,14 +45625,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "118360746505"
+            "amount": "114516808796"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-            "amount": "8581985200"
+            "amount": "8875957568"
           },
           "weight": "536870912000000"
         }
@@ -45657,14 +45657,14 @@
         {
           "token": {
             "denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
-            "amount": "6475058586"
+            "amount": "6359959635"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "118028357389"
+            "amount": "120277102614"
           },
           "weight": "536870912000000"
         }
@@ -45689,14 +45689,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "128838096953"
+            "amount": "133520245021"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
-            "amount": "467894025"
+            "amount": "452417167"
           },
           "weight": "536870912000000"
         }
@@ -45721,14 +45721,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "96401045907"
+            "amount": "102318799281"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-            "amount": "3807870603"
+            "amount": "3590730146"
           },
           "weight": "536870912000000"
         }
@@ -45753,14 +45753,14 @@
         {
           "token": {
             "denom": "ibc/A4D176906C1646949574B48C1928D475F2DF56DE0AC04E1C99B08F90BC21ABDE",
-            "amount": "10620118670"
+            "amount": "10496332804"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "40858921012"
+            "amount": "41346453397"
           },
           "weight": "536870912000000"
         }
@@ -45785,14 +45785,14 @@
         {
           "token": {
             "denom": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
-            "amount": "154200863428"
+            "amount": "147611135676"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "70643597772"
+            "amount": "73880627458"
           },
           "weight": "536870912000000"
         }
@@ -45849,14 +45849,14 @@
         {
           "token": {
             "denom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
-            "amount": "83294037"
+            "amount": "81349307"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "193755178788"
+            "amount": "198516463306"
           },
           "weight": "536870912000000"
         }
@@ -45881,14 +45881,14 @@
         {
           "token": {
             "denom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
-            "amount": "98942472729"
+            "amount": "97828713106"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "159142936504"
+            "amount": "160963884867"
           },
           "weight": "536870912000000"
         }
@@ -45913,14 +45913,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "148643692623"
+            "amount": "150758465836"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
-            "amount": "484688716881"
+            "amount": "477958159665"
           },
           "weight": "536870912000000"
         }
@@ -45945,14 +45945,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "154490415871"
+            "amount": "153990183756"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
-            "amount": "410658591080449362812"
+            "amount": "412049751694160897929"
           },
           "weight": "536870912000000"
         }
@@ -45977,14 +45977,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "146201949017"
+            "amount": "145157247927"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
-            "amount": "1355710821"
+            "amount": "1365618605"
           },
           "weight": "536870912000000"
         }
@@ -46009,14 +46009,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "184582736807"
+            "amount": "189629849800"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
-            "amount": "1342703988785341582879"
+            "amount": "1307647632955333826475"
           },
           "weight": "536870912000000"
         }
@@ -46041,14 +46041,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "126028734746"
+            "amount": "128709251423"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
-            "amount": "1291306774"
+            "amount": "1264911400"
           },
           "weight": "536870912000000"
         }
@@ -46073,14 +46073,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "95031244541"
+            "amount": "100358438328"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
-            "amount": "45155562949038584355948"
+            "amount": "42770248175116902706936"
           },
           "weight": "536870912000000"
         }
@@ -46105,14 +46105,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "104185566363"
+            "amount": "103087066258"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
-            "amount": "31102772919"
+            "amount": "31435876762"
           },
           "weight": "536870912000000"
         }
@@ -46137,14 +46137,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "112421900598"
+            "amount": "113075620121"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
-            "amount": "415579115"
+            "amount": "413228922"
           },
           "weight": "536870912000000"
         }
@@ -46169,14 +46169,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "100061255759"
+            "amount": "99476334414"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
-            "amount": "67948867794"
+            "amount": "68373709733"
           },
           "weight": "536870912000000"
         }
@@ -46201,14 +46201,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "125840047245"
+            "amount": "126253502650"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
-            "amount": "1020415725"
+            "amount": "1017179848"
           },
           "weight": "536870912000000"
         }
@@ -46233,14 +46233,14 @@
         {
           "token": {
             "denom": "ibc/37CB3078432510EE57B9AFA8DBE028B33AE3280A144826FEAC5F2334CF2C5539",
-            "amount": "2939164087"
+            "amount": "2965777861"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "86333984058"
+            "amount": "85574133548"
           },
           "weight": "536870912000000"
         }
@@ -46265,14 +46265,14 @@
         {
           "token": {
             "denom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-            "amount": "10541818340"
+            "amount": "10498275844"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "112117182983"
+            "amount": "112584535341"
           },
           "weight": "536870912000000"
         }
@@ -46297,14 +46297,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "51825001355"
+            "amount": "51611444746"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
-            "amount": "31415213341"
+            "amount": "31550528257"
           },
           "weight": "536870912000000"
         }
@@ -46329,14 +46329,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "51719886662"
+            "amount": "54989780924"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
-            "amount": "20352378781"
+            "amount": "19151505645"
           },
           "weight": "536870912000000"
         }
@@ -46361,14 +46361,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "182980942588"
+            "amount": "180765939698"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "45550062044"
+            "amount": "46112037597"
           },
           "weight": "536870912000000"
         }
@@ -46393,14 +46393,14 @@
         {
           "token": {
             "denom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
-            "amount": "182370620880"
+            "amount": "180766692700"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "45386316812"
+            "amount": "45792789795"
           },
           "weight": "536870912000000"
         }
@@ -46425,14 +46425,14 @@
         {
           "token": {
             "denom": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
-            "amount": "223992022132933069117"
+            "amount": "233851630602423017154"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
-            "amount": "65299207861"
+            "amount": "62566612111"
           },
           "weight": "536870912000000"
         }
@@ -46457,14 +46457,14 @@
         {
           "token": {
             "denom": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-            "amount": "5689"
+            "amount": "6241"
           },
           "weight": "375809638400000"
         },
         {
           "token": {
             "denom": "ibc/C5579A9595790017C600DD726276D978B9BF314CF82406CE342720A9C7911A01",
-            "amount": "2101499184887468503"
+            "amount": "2002858030812882380"
           },
           "weight": "697932185600000"
         }
@@ -46484,15 +46484,15 @@
       "incentives_address": "osmo1phy4snyvspr0j48xfrm0lka7jh3y6940kzvp3ss49jjyxmsaxw6qkxr77a",
       "spread_rewards_address": "osmo1lrrx0ru6lk0edwz96m6yw48azsxcch3cgvw5h8eayws552evlgus0exgxe",
       "id": "1565",
-      "current_tick_liquidity": "6595450720499990099092.103604980327234801",
+      "current_tick_liquidity": "6857542978793236236213.462761454421756140",
       "token0": "ibc/BB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "0.867167144724481132896653116976938729",
-      "current_tick": "-2480212",
+      "current_sqrt_price": "0.896910530916856363782729429053548750",
+      "current_tick": "-1955515",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-14T08:56:41.269689017Z"
+      "last_liquidity_update": "2024-05-17T12:37:40.630916371Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -46500,15 +46500,15 @@
       "incentives_address": "osmo19pqdg835ulzafg7e7t7yepunls3q3ugmqz6kugj00ztrugmk785qvlthzr",
       "spread_rewards_address": "osmo1xr5l4tt8ef62ekn928f58aszcetqv5csy9s2q5059gqjfvv5vvvqc4wqqm",
       "id": "1566",
-      "current_tick_liquidity": "598363619105226723359249.982296356140086482",
+      "current_tick_liquidity": "656875592661352793854415.675703376107718294",
       "token0": "ibc/D53E785DC9C5C2CA50CADB1EFE4DE5D0C30418BE0E9C6F2AF9F092A247E8BC22",
       "token1": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-      "current_sqrt_price": "0.991565020843286092358788332048122016",
-      "current_tick": "-167989",
+      "current_sqrt_price": "0.994609115738260457359734090244372556",
+      "current_tick": "-107528",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:15:02.164418948Z"
+      "last_liquidity_update": "2024-05-17T13:24:05.994947319Z"
     },
     {
       "@type": "/osmosis.cosmwasmpool.v1beta1.CosmWasmPool",
@@ -46564,20 +46564,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1573",
-        "amount": "41512068465205079065"
+        "amount": "41509666314184093483"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/C12C353A83CD1005FC38943410B894DBEC5F2ABC97FC12908F0FB03B970E8E1B",
-            "amount": "3851662353866"
+            "amount": "3861964168850"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
-            "amount": "475262190960"
+            "amount": "473957147556"
           },
           "weight": "536870912000000"
         }
@@ -46596,20 +46596,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1574",
-        "amount": "1180776915104803279015"
+        "amount": "1180788245815751166247"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/072E5B3D6F278B3E6A9C51D7EAD1A737148609512C5EBE8CBCB5663264A0DDB7",
-            "amount": "4727263654960"
+            "amount": "4728236265926"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "9638484474"
+            "amount": "9636758576"
           },
           "weight": "536870912000000"
         }
@@ -46641,14 +46641,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "10660694597"
+            "amount": "10743418080"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
-            "amount": "86707738197431"
+            "amount": "86121521671238"
           },
           "weight": "536870912000000"
         }
@@ -46735,12 +46735,12 @@
       "current_tick_liquidity": "31552004346840873.442499089763944567",
       "token0": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000001000001189413489602177120893956",
-      "current_tick": "-107999998",
+      "current_sqrt_price": "0.000001017140172918908774302330696031",
+      "current_tick": "-107965426",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T19:38:25.291527454Z"
+      "last_liquidity_update": "2024-05-16T23:15:06.298857456Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -46751,8 +46751,8 @@
       "current_tick_liquidity": "5704627443.077655585980018300",
       "token0": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.208414734700583643839077126736389158",
-      "current_tick": "460266",
+      "current_sqrt_price": "1.232560499145815702031777706549344911",
+      "current_tick": "519205",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -46799,20 +46799,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1583",
-        "amount": "101231597864068121373"
+        "amount": "101208937600101516146"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-            "amount": "18065614547290463250676"
+            "amount": "18715853985310184211316"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-            "amount": "5552495982"
+            "amount": "5360808420"
           },
           "weight": "536870912000000"
         }
@@ -46928,15 +46928,15 @@
       "incentives_address": "osmo1mhmsy0593e8mej4wv038nsu9nyvshwpj6pgrp72ke4e4stxgntjsrlt3a7",
       "spread_rewards_address": "osmo1n6w2yx32x7ymfz4gk0vs20yfwzpz9epzljn3znpff85wqkppx8zsf6apw3",
       "id": "1588",
-      "current_tick_liquidity": "9307150090196178.995500935442893659",
+      "current_tick_liquidity": "766091300239809.332569153391560592",
       "token0": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000003704323390828334307730214746487",
-      "current_tick": "-98627799",
+      "current_sqrt_price": "0.000004039786062886839441038863114043",
+      "current_tick": "-98368013",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T14:56:28.665829482Z"
+      "last_liquidity_update": "2024-05-17T20:30:58.146166019Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -46963,8 +46963,8 @@
       "current_tick_liquidity": "2087592960394.399195262984792926",
       "token0": "ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC",
       "token1": "uosmo",
-      "current_sqrt_price": "1.057158730147617586030776329051912113",
-      "current_tick": "117584",
+      "current_sqrt_price": "1.057461737687947036728109785917283671",
+      "current_tick": "118225",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -46976,15 +46976,15 @@
       "incentives_address": "osmo1ugydyu3rd7jxuz5zs64czu08p3jtj8dznwfhxqwppt6clsvrskds48ht94",
       "spread_rewards_address": "osmo16kh8lrd4mqhcacarzj2uay5chuucrh8r3jjdk6ucry3ppja6r3fqn96e34",
       "id": "1591",
-      "current_tick_liquidity": "133047914611.597381436415671652",
+      "current_tick_liquidity": "133197953009.910340201154296421",
       "token0": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.714881663775219232743030424121240953",
-      "current_tick": "-4889443",
+      "current_sqrt_price": "0.722957195502080929312228700809850576",
+      "current_tick": "-4773329",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T15:27:52.702378800Z"
+      "last_liquidity_update": "2024-05-17T12:21:50.088459630Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -47024,15 +47024,15 @@
       "incentives_address": "osmo1uyc5ldrjhqj02vv4yxzkceqvvkd06harv8ely6samdfuvzjtz5dq27weny",
       "spread_rewards_address": "osmo1r7dknmh5ykfzg0sgfwypc77dak94rjzal5pk67c52p6pk6wgwscqu7er45",
       "id": "1594",
-      "current_tick_liquidity": "4200276851.124746077213442241",
+      "current_tick_liquidity": "7046113074.595873848008524597",
       "token0": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "3.362480978339017382539794268097382143",
-      "current_tick": "9130627",
+      "current_sqrt_price": "3.407299854818578970290386921963755797",
+      "current_tick": "9160969",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T12:32:57.372545918Z"
+      "last_liquidity_update": "2024-05-17T12:14:10.888620950Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -47052,14 +47052,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "6592113"
+            "amount": "6795273"
           },
           "weight": "322122547200000"
         },
         {
           "token": {
             "denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-            "amount": "59480528771517198563"
+            "amount": "58714041150823593373"
           },
           "weight": "751619276800000"
         }
@@ -47084,14 +47084,14 @@
         {
           "token": {
             "denom": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
-            "amount": "4369746"
+            "amount": "4412428"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "2666146"
+            "amount": "2640358"
           },
           "weight": "536870912000000"
         }
@@ -47148,14 +47148,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "206042858313611536087"
+            "amount": "212260775910718662112"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "12371738"
+            "amount": "12011093"
           },
           "weight": "536870912000000"
         }
@@ -47235,14 +47235,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "2288394"
+            "amount": "2278267"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "384376536462590960214"
+            "amount": "386093789278477049877"
           },
           "weight": "536870912000000"
         }
@@ -47267,14 +47267,14 @@
         {
           "token": {
             "denom": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
-            "amount": "1007112282670216467725"
+            "amount": "1029420228228253964602"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "3387886865"
+            "amount": "3315991383"
           },
           "weight": "536870912000000"
         }
@@ -47290,8 +47290,8 @@
       "current_tick_liquidity": "1165089027331512016.093687065977796403",
       "token0": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000001672381130355339647919187248013",
-      "current_tick": "-106203142",
+      "current_sqrt_price": "0.000001672444201489419930363653734244",
+      "current_tick": "-106202931",
       "tick_spacing": "1",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -47303,15 +47303,15 @@
       "incentives_address": "osmo1mnfftk3605yn2hzq76ehyuqha9vhwv0w63lhxmcawmzta7ut2wtqhv7hn7",
       "spread_rewards_address": "osmo10z708j59kljh3k43l4u2rvqyk4j826nhlvnakxaja8z2e90rn6yqqjv850",
       "id": "1605",
-      "current_tick_liquidity": "72155610425.994708358452712282",
+      "current_tick_liquidity": "72213712711.299984821141320241",
       "token0": "ibc/4017C65CEA338196ECCEC3FE3FE8258F23D1DE88F1D95750CC912C7A1C1016FF",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.445870782303430949074799271142394995",
-      "current_tick": "-8011993",
+      "current_sqrt_price": "0.438383410230561612283530791670874811",
+      "current_tick": "-8078200",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:14:32.686734435Z"
+      "last_liquidity_update": "2024-05-17T13:55:26.360290845Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -47395,14 +47395,14 @@
         {
           "token": {
             "denom": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-            "amount": "68196891"
+            "amount": "67844940"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "923905212759659031972537"
+            "amount": "928893097425226474766652"
           },
           "weight": "536870912000000"
         }
@@ -47459,28 +47459,28 @@
         {
           "token": {
             "denom": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-            "amount": "14382"
+            "amount": "14521"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "1098752"
+            "amount": "1138442"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
-            "amount": "189864162"
+            "amount": "187639569"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "11597330"
+            "amount": "11226692"
           },
           "weight": "268435456000000"
         }
@@ -47505,14 +47505,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "180660912402818063073452"
+            "amount": "178349733580478300648675"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
-            "amount": "4703950940"
+            "amount": "4765409154"
           },
           "weight": "536870912000000"
         }
@@ -47537,14 +47537,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "191988572"
+            "amount": "190939039"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "3893146389914082773278"
+            "amount": "3914700103998239330163"
           },
           "weight": "536870912000000"
         }
@@ -47601,14 +47601,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "16728430298439921352942"
+            "amount": "17071561723795109746824"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "975107299"
+            "amount": "955589944"
           },
           "weight": "536870912000000"
         }
@@ -47683,15 +47683,15 @@
       "incentives_address": "osmo1yaca20wpztcd0mpcsulsmclkx98mcfdztt42h5ye22t2839vxvvsayqcel",
       "spread_rewards_address": "osmo1vwe3utruavgee03us9vshkgl3gv72sqm7k6duyjcuwewarxz8mlqr4qn6k",
       "id": "1620",
-      "current_tick_liquidity": "62719841207.791415393079172823",
+      "current_tick_liquidity": "59470459816.328362839401269559",
       "token0": "ibc/4017C65CEA338196ECCEC3FE3FE8258F23D1DE88F1D95750CC912C7A1C1016FF",
       "token1": "uosmo",
-      "current_sqrt_price": "0.487162808977251881649856351030304268",
-      "current_tick": "-7626724",
+      "current_sqrt_price": "0.468129263774970289327413685105418758",
+      "current_tick": "-7808550",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T16:15:28.534612593Z"
+      "last_liquidity_update": "2024-05-17T07:21:53.589873277Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -47702,8 +47702,8 @@
       "current_tick_liquidity": "151629552867.508857325760147601",
       "token0": "ibc/0B3D528E74E3DEAADF8A68F393887AC7E06028904D02173561B0D27F6E751D0A",
       "token1": "uosmo",
-      "current_sqrt_price": "0.199743604219276119378621131879885263",
-      "current_tick": "-15010250",
+      "current_sqrt_price": "0.193548803830689337725303660370437458",
+      "current_tick": "-15253887",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -47727,14 +47727,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "3950127044501658390725"
+            "amount": "3993966057672781903498"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-            "amount": "64083190970487820"
+            "amount": "63381509947415453"
           },
           "weight": "536870912000000"
         }
@@ -47747,15 +47747,15 @@
       "incentives_address": "osmo17qye3ld54j52t2zr5fljnuumkzrqx90y74j79lf7ggs5xjxfvgas5fysgh",
       "spread_rewards_address": "osmo105zsheher6nc4d2vzcnaryzxe36385pt7yhygf86qms3zjyf0m3sv2mf7u",
       "id": "1623",
-      "current_tick_liquidity": "297982202441.914928228576172350",
+      "current_tick_liquidity": "289095121774.820338146930533259",
       "token0": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
       "token1": "uosmo",
-      "current_sqrt_price": "0.211173372303101175672877937186776993",
-      "current_tick": "-14540581",
+      "current_sqrt_price": "0.221304637630309416101907447977490690",
+      "current_tick": "-14102426",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T22:06:55.134838010Z"
+      "last_liquidity_update": "2024-05-18T00:11:29.305249751Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -47769,20 +47769,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1624",
-        "amount": "4340819185748479591294"
+        "amount": "4308336003269383430176"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z/toro",
-            "amount": "327046690381027"
+            "amount": "256933086741060"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "822439771"
+            "amount": "1033295768"
           },
           "weight": "1073741824"
         }
@@ -47807,14 +47807,14 @@
         {
           "token": {
             "denom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
-            "amount": "311421290"
+            "amount": "331755350"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "214470"
+            "amount": "201877"
           },
           "weight": "536870912000000"
         }
@@ -47839,14 +47839,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "174936232045897744472640"
+            "amount": "186324428450273527506120"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-            "amount": "193606740190530935852938"
+            "amount": "181920550647063475864863"
           },
           "weight": "536870912000000"
         }
@@ -47903,14 +47903,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "9738837406669079839185915"
+            "amount": "9704911132135108635148828"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
-            "amount": "173851791605205857658048"
+            "amount": "174496727088936419456925"
           },
           "weight": "536870912000000"
         }
@@ -47929,20 +47929,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1629",
-        "amount": "1932812645897294440185"
+        "amount": "1947852963153931375911"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "2269394982"
+            "amount": "2337761741"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206",
-            "amount": "30567064217"
+            "amount": "30153277656"
           },
           "weight": "536870912000000"
         }
@@ -47961,20 +47961,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1630",
-        "amount": "104335047763209146917"
+        "amount": "104322386444587027966"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/B84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000",
-            "amount": "186138875039"
+            "amount": "188318633911"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "653612178"
+            "amount": "646117494"
           },
           "weight": "536870912000000"
         }
@@ -48031,14 +48031,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "6333325343598048889212695"
+            "amount": "6470972271485073484619167"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "369787921594"
+            "amount": "362095199280"
           },
           "weight": "536870912000000"
         }
@@ -48093,8 +48093,8 @@
       "current_tick_liquidity": "137295196390848796405420.764524110221144534",
       "token0": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "0.221722008432215143079906684184791358",
-      "current_tick": "-14083936",
+      "current_sqrt_price": "0.221593057723587421518337367875257874",
+      "current_tick": "-14089652",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -48109,8 +48109,8 @@
       "current_tick_liquidity": "43829000677753420575705.365260714075223897",
       "token0": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
       "token1": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-      "current_sqrt_price": "0.004023896386159843559667476215107038",
-      "current_tick": "-44380826",
+      "current_sqrt_price": "0.003983494378122505769151853977060409",
+      "current_tick": "-44413178",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -48198,14 +48198,14 @@
         {
           "token": {
             "denom": "ibc/1CDF9C7D073DD59ED06F15DB08CC0901F2A24759BE70463570E8896F9A444ADF",
-            "amount": "199211362747671074897"
+            "amount": "194882400106061067084"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-            "amount": "134952773257719756986"
+            "amount": "138115371721762182977"
           },
           "weight": "536870912000000"
         }
@@ -48255,15 +48255,15 @@
       "incentives_address": "osmo16uvccmkgfh53zaj53urjr5fh24ltnkma3eldrm9uwwz2q2385elqu6f2y6",
       "spread_rewards_address": "osmo12070pmtgy69hg5y7u84qd8sfcra6wvwtq9fudw8dfl3t84xjgrkqshxvat",
       "id": "1645",
-      "current_tick_liquidity": "532844997481.796421025671141336",
+      "current_tick_liquidity": "525141175825.777249642102167222",
       "token0": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
       "token1": "uosmo",
-      "current_sqrt_price": "0.242653864116656921676322996985147687",
-      "current_tick": "-13111911",
+      "current_sqrt_price": "0.238490326870999484008618870621027215",
+      "current_tick": "-13312237",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-15T23:00:21.687056893Z"
+      "last_liquidity_update": "2024-05-17T23:30:33.709077519Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48271,15 +48271,15 @@
       "incentives_address": "osmo1550lqyl63rjum7rlmqv57x686cm45asd75f0mkydhqg8p4ku45pstzl2rk",
       "spread_rewards_address": "osmo1ax86zfjne8x92h0h3j3mxcgq8dhejmqm7yc2va7un6al2zj6z8qsamgs0h",
       "id": "1646",
-      "current_tick_liquidity": "2034698088567.228370658878360851",
+      "current_tick_liquidity": "1728966967442.754575399582186500",
       "token0": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.221556541338847035277161265176358737",
-      "current_tick": "-14091270",
+      "current_sqrt_price": "0.223631617086614879398269021680511674",
+      "current_tick": "-13998890",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-15T23:44:08.840206507Z"
+      "last_liquidity_update": "2024-05-17T23:44:04.455493451Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48287,15 +48287,15 @@
       "incentives_address": "osmo185q6vs6a9etg8kkthkq8z9lqp47cgqnwh7ewh8t34xwxyn5d93dsl0juvt",
       "spread_rewards_address": "osmo1atkpypd253js9xm94l9lg2je9cjypyzh68nqqap45ldljs4qlpcsl6ctt8",
       "id": "1647",
-      "current_tick_liquidity": "287418177447.376813986441358260",
+      "current_tick_liquidity": "461802370414.480123957319963991",
       "token0": "ibc/208B2F137CDE510B44C41947C045CFDC27F996A9D990EA64460BDD5B3DBEB2ED",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.165230718557279785071127149669461992",
-      "current_tick": "-16269881",
+      "current_sqrt_price": "0.168141159017873997670182515731475102",
+      "current_tick": "-16172856",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-14T04:49:30.631488792Z"
+      "last_liquidity_update": "2024-05-17T15:32:11.404627698Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48306,12 +48306,12 @@
       "current_tick_liquidity": "6628048774286.799670860358026959",
       "token0": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.994881285653584275078559750148932002",
-      "current_tick": "-102113",
+      "current_sqrt_price": "0.994984880521088835401994434696126375",
+      "current_tick": "-100051",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-15T15:45:26.396177391Z"
+      "last_liquidity_update": "2024-05-16T08:27:33.947218969Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -48367,15 +48367,15 @@
       "incentives_address": "osmo1uf3m25wc8p7msfj3nn64jd6vkvlttgsav8tl656m5zlm8qk6xk6seksr5g",
       "spread_rewards_address": "osmo1vr7uldz48k4s4heyw8kg2ljjql00slvdk905v3ae6u95avvxv02slc7jy6",
       "id": "1651",
-      "current_tick_liquidity": "4277349623.873108416322757749",
+      "current_tick_liquidity": "15119495663.203344418695229650",
       "token0": "ibc/AC6EE43E608B5A7EEE460C960480BC1C3708010E32B2071C429DA259836E10C3",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.759194707521488531876332905644089411",
-      "current_tick": "-4236234",
+      "current_sqrt_price": "0.741828479286235810307982255365390147",
+      "current_tick": "-4496906",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T20:23:30.870315304Z"
+      "last_liquidity_update": "2024-05-17T14:22:36.892404113Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48386,8 +48386,8 @@
       "current_tick_liquidity": "1294655849185.048159456678960828",
       "token0": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.239584654035569309505087957956246328",
-      "current_tick": "-13259920",
+      "current_sqrt_price": "0.229790564780828245037034463164343442",
+      "current_tick": "-13719630",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.003000000000000000",
@@ -48422,15 +48422,15 @@
       "incentives_address": "osmo1rd2vsg2pwcnj0hwv7cup2vql93jpy0mvrwag2y2n4gadh0femyxq3tg4n0",
       "spread_rewards_address": "osmo1lx32uj4pckrwf5rgtk0myh9e5hvewhtgpm0kwqmezdthazyrqn6q7k76f4",
       "id": "1655",
-      "current_tick_liquidity": "13591187294.489527354961580204",
+      "current_tick_liquidity": "15799424719.241105354746522101",
       "token0": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
       "token1": "uosmo",
-      "current_sqrt_price": "6.620747887044825221127311594193607622",
-      "current_tick": "12383430",
+      "current_sqrt_price": "6.725305434760671099630362095765657877",
+      "current_tick": "12522973",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-15T23:00:21.687056893Z"
+      "last_liquidity_update": "2024-05-17T23:30:44.741180479Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48438,15 +48438,15 @@
       "incentives_address": "osmo18294ww6ruu20zy9ge46fs45kdt3lx5fmjf3zhl3sg7k830t50flq3qwr6j",
       "spread_rewards_address": "osmo1hunjql5ycsqu4ldzx3k3at3uqrexv8qz9fvyccztw468mh30tarq2a2lxc",
       "id": "1656",
-      "current_tick_liquidity": "10844419623.027371292720990855",
+      "current_tick_liquidity": "10847532141.065409932146582106",
       "token0": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "6.069370918189392783097328640142059790",
-      "current_tick": "11683726",
+      "current_sqrt_price": "6.332874531093124772944024105609068605",
+      "current_tick": "12010529",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-15T19:57:26.608473518Z"
+      "last_liquidity_update": "2024-05-17T11:11:26.408327707Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48482,14 +48482,14 @@
         {
           "token": {
             "denom": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
-            "amount": "14106653"
+            "amount": "13860526"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "615100152"
+            "amount": "626133751"
           },
           "weight": "536870912000000"
         }
@@ -48514,28 +48514,28 @@
         {
           "token": {
             "denom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
-            "amount": "2710061841430"
+            "amount": "2918526521041"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/42A9553A7770F3D7B62F3A82AF04E7719B4FD6EAF31BE5645092AAC4A6C2201D",
-            "amount": "5984201899683952"
+            "amount": "6755349364227528"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/DDF1CD4CDC14AE2D6A3060193624605FF12DEE71CF1F8C19EEF35E9447653493",
-            "amount": "1261395094"
+            "amount": "1008325093"
           },
           "weight": "268435456000000"
         },
         {
           "token": {
             "denom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
-            "amount": "15964796907"
+            "amount": "16852735786"
           },
           "weight": "268435456000000"
         }
@@ -48615,14 +48615,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "525395498423634835574381"
+            "amount": "518881349109694805291118"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
-            "amount": "13709082268"
+            "amount": "13887796550"
           },
           "weight": "536870912000000"
         }
@@ -48647,14 +48647,14 @@
         {
           "token": {
             "denom": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
-            "amount": "138160445"
+            "amount": "139159445"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "8208756"
+            "amount": "8150412"
           },
           "weight": "536870912000000"
         }
@@ -48670,8 +48670,8 @@
       "current_tick_liquidity": "6527260864050.470199429385636394",
       "token0": "ibc/3A0A392E610A8D477851ABFEA74F3D828F36C015AB8E93B0FBB7566A6D13C4D6",
       "token1": "uosmo",
-      "current_sqrt_price": "0.000232207239516684875600040009548308",
-      "current_tick": "-67607980",
+      "current_sqrt_price": "0.000230122288082248234979139237271002",
+      "current_tick": "-67704374",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
@@ -48759,14 +48759,14 @@
         {
           "token": {
             "denom": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
-            "amount": "849205027"
+            "amount": "869502808"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "1012005067"
+            "amount": "988551408"
           },
           "weight": "536870912000000"
         }
@@ -48820,14 +48820,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "10480558519"
+            "amount": "10295042438"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
-            "amount": "2134919651939335784"
+            "amount": "2185917571138730215"
           },
           "weight": "536870912000000"
         }
@@ -48840,15 +48840,15 @@
       "incentives_address": "osmo14nh0xcve9axjtu6sag3vkpa06vdet4pzz2arypx3e7r73wac4epsjlcku6",
       "spread_rewards_address": "osmo1kf2p445mvuxve2j978xaxam2jsf2t5kjnn0fmpfasnxe3fmpergqs4m4gy",
       "id": "1670",
-      "current_tick_liquidity": "233474209980.734545133940038088",
+      "current_tick_liquidity": "261454530844.866199881796090336",
       "token0": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
       "token1": "uosmo",
-      "current_sqrt_price": "1.645205158527558598735624972908779885",
-      "current_tick": "1706700",
+      "current_sqrt_price": "1.592338346571233129744305462421368971",
+      "current_tick": "1535541",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:16.664900657Z"
+      "last_liquidity_update": "2024-05-17T23:30:28.652800958Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48856,15 +48856,15 @@
       "incentives_address": "osmo1u5f3mw7kvj5t6mx3sterd8zkeknwfthz0xa2ukmhrxx6c3ym4h2qq6tf00",
       "spread_rewards_address": "osmo17relzmlmsmzumz58jzenjzhx58kz2q5kc3whsnymrr6jh2mpnxys9d5ksp",
       "id": "1671",
-      "current_tick_liquidity": "661073026934.210542760300775890",
+      "current_tick_liquidity": "574512398446.268283704487923840",
       "token0": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.519245513276151836647030677496921618",
-      "current_tick": "1308106",
+      "current_sqrt_price": "1.483580869308437775541868123128643144",
+      "current_tick": "1201012",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-16T00:07:16.664900657Z"
+      "last_liquidity_update": "2024-05-18T00:06:28.605263244Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48872,15 +48872,15 @@
       "incentives_address": "osmo1d6j7zw025t4e0n53duespyy88pj8lpmzjcqjdvcajsvskw9fvwmqg6xz4z",
       "spread_rewards_address": "osmo1pvlvtsnawy4xa82kphyfdvurymwc4mqgas22vexrpfmazdxk5kvqyuag4r",
       "id": "1672",
-      "current_tick_liquidity": "15214352867.827082209841755275",
+      "current_tick_liquidity": "884369059.404551928611337142",
       "token0": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.507398917527111817806227226780973147",
-      "current_tick": "1272251",
+      "current_sqrt_price": "1.490406217100645500765566978705777182",
+      "current_tick": "1221310",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
-      "last_liquidity_update": "2024-05-15T20:00:00.390521339Z"
+      "last_liquidity_update": "2024-05-17T23:47:34.095275171Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -48894,20 +48894,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1673",
-        "amount": "157409449821042761654"
+        "amount": "156961591231076183332"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
-            "amount": "289723419"
+            "amount": "300863481"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "788965689"
+            "amount": "755898037"
           },
           "weight": "536870912000000"
         }
@@ -48920,15 +48920,15 @@
       "incentives_address": "osmo1d63szu8aery0uhn86lqmsyfjme83w5ce3y3lwn6jwhu6lf84es3qqntd6g",
       "spread_rewards_address": "osmo16elydr04zqxpxpsrnqcxx67xue0mpxxwkv8z8gq7yatka2thwvtq097vjd",
       "id": "1674",
-      "current_tick_liquidity": "21470637434794.969587812274166005",
+      "current_tick_liquidity": "404591584773704.599814688861746375",
       "token0": "ibc/2CD9F8161C3FC332E78EF0C25F6E684D09379FB2F56EF9267E7EC139642EC57B",
       "token1": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
-      "current_sqrt_price": "0.997988413429247312857459563761897336",
-      "current_tick": "-40192",
+      "current_sqrt_price": "0.997996163368735215236643814585562610",
+      "current_tick": "-40037",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T23:22:01.442756711Z"
+      "last_liquidity_update": "2024-05-17T20:24:58.106408003Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -48939,8 +48939,8 @@
       "current_tick_liquidity": "5663340384913749590200.189694480794636990",
       "token0": "ibc/C04DFC9BCD893E57F2BEFE40F63EFD18D2768514DBD5F63ABD2FF7F48FC01D36",
       "token1": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-      "current_sqrt_price": "1.115834530119418469119591858897841873",
-      "current_tick": "245086",
+      "current_sqrt_price": "1.115601441343939316686509646752389915",
+      "current_tick": "244566",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -49028,14 +49028,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "916891998"
+            "amount": "926625987"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "ibc/EFC1776BEFB7842F2DC7BABD9A3050E188145C99007ECC5F3526FED45A68D5F5",
-            "amount": "1786163993"
+            "amount": "1767502101"
           },
           "weight": "5368709120"
         }
@@ -49051,8 +49051,8 @@
       "current_tick_liquidity": "144514058532.304044405618706263",
       "token0": "ibc/0E77E090EC04C476DE2BC0A7056580AC47660DAEB7B0D4701C085E3A046AC7B7",
       "token1": "uosmo",
-      "current_sqrt_price": "0.112868581499612651174104423765848859",
-      "current_tick": "-17726069",
+      "current_sqrt_price": "0.111059972809197997104279468279346687",
+      "current_tick": "-17766569",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
@@ -49070,20 +49070,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1680",
-        "amount": "106819657699971122228"
+        "amount": "106650418905964271903"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/EFC1776BEFB7842F2DC7BABD9A3050E188145C99007ECC5F3526FED45A68D5F5",
-            "amount": "1452512603"
+            "amount": "1468856007"
           },
           "weight": "5368709120"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "894335525"
+            "amount": "881677024"
           },
           "weight": "5368709120"
         }
@@ -49195,8 +49195,8 @@
       "current_tick_liquidity": "2453745093012.146525339059509985",
       "token0": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
       "token1": "uosmo",
-      "current_sqrt_price": "0.010735953869152680369203721347568449",
-      "current_tick": "-35847393",
+      "current_sqrt_price": "0.010690297878227027495256033303947796",
+      "current_tick": "-35857176",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -49237,20 +49237,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1687",
-        "amount": "326750011617156044133"
+        "amount": "321386209594051972148"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/884EBC228DFCE8F1304D917A712AA9611427A6C1ECC3179B2E91D7468FB091A2",
-            "amount": "888736478678877008"
+            "amount": "883047195103190849"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "364391499733"
+            "amount": "354797524226"
           },
           "weight": "536870912000000"
         }
@@ -49273,11 +49273,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-          "amount": "491263"
+          "amount": "535422"
         },
         {
           "denom": "uosmo",
-          "amount": "1312826"
+          "amount": "1261085"
         }
       ],
       "scaling_factors": [
@@ -49304,14 +49304,14 @@
         {
           "token": {
             "denom": "ibc/0E77E090EC04C476DE2BC0A7056580AC47660DAEB7B0D4701C085E3A046AC7B7",
-            "amount": "41038536"
+            "amount": "46342296"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "425437"
+            "amount": "377188"
           },
           "weight": "536870912000000"
         }
@@ -49330,20 +49330,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1690",
-        "amount": "100015768800878246827"
+        "amount": "100247144712185756760"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "70691890973"
+            "amount": "70627653087"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "1432855073280873660655542"
+            "amount": "1442712509815846426217500"
           },
           "weight": "536870912000000"
         }
@@ -49368,14 +49368,14 @@
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "10788019885060251094276253"
+            "amount": "11151946946801255351212916"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
-            "amount": "59267043648"
+            "amount": "57358082354"
           },
           "weight": "536870912000000"
         }
@@ -49407,14 +49407,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "13435026"
+            "amount": "13377425"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
-            "amount": "172778202510"
+            "amount": "173522535390"
           },
           "weight": "536870912000000"
         }
@@ -49439,14 +49439,14 @@
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "8583096187"
+            "amount": "8353232520"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "1637617910566717339300671"
+            "amount": "1683062856183791541676607"
           },
           "weight": "536870912000000"
         }
@@ -49471,14 +49471,14 @@
         {
           "token": {
             "denom": "ibc/6FD2938076A4C1BB3A324A676E76B0150A4443DAE0E002FB62AC0E6B604B1519",
-            "amount": "1987924938316211743462263"
+            "amount": "2004635891091225892794203"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "645114398"
+            "amount": "639747292"
           },
           "weight": "536870912000000"
         }
@@ -49491,15 +49491,15 @@
       "incentives_address": "osmo1al3632zgfh4zkk7x7a4s9jdhnutchm9n2jufcatczef0dzklxr6svjp5sf",
       "spread_rewards_address": "osmo16tf0nz69rgy6z6p4v9mh9dp7qfpen64v7mecatplugkl2wnhrkzssjjpug",
       "id": "1696",
-      "current_tick_liquidity": "6587793157.947777256480124063",
+      "current_tick_liquidity": "7069204111.486663079956842208",
       "token0": "ibc/AC6EE43E608B5A7EEE460C960480BC1C3708010E32B2071C429DA259836E10C3",
       "token1": "uosmo",
-      "current_sqrt_price": "0.828439030768746682358328008954036002",
-      "current_tick": "-3136888",
+      "current_sqrt_price": "0.793943615896066314100280215716549357",
+      "current_tick": "-3696536",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:15:28.720471618Z"
+      "last_liquidity_update": "2024-05-17T21:32:26.497163611Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -49507,15 +49507,15 @@
       "incentives_address": "osmo17wzmkdjjmhtqf9pajnyr90lgmmcjjptad397u20l8ps3nu2xe79qjnqcep",
       "spread_rewards_address": "osmo18zcuqfgn3z8umt4hrmy0csgsgysggetatmau38jtutknc6tcvf5sqjgl4r",
       "id": "1697",
-      "current_tick_liquidity": "201613603017.333728580582981654",
+      "current_tick_liquidity": "199064222886.559468082760759872",
       "token0": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
       "token1": "uosmo",
-      "current_sqrt_price": "0.187343214977825564550796606903770000",
-      "current_tick": "-15490252",
+      "current_sqrt_price": "0.178516995301235669903987382469458589",
+      "current_tick": "-15813169",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.025000000000000000",
-      "last_liquidity_update": "2024-05-15T15:57:17.778062121Z"
+      "last_liquidity_update": "2024-05-16T08:52:45.215345796Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -49535,14 +49535,14 @@
         {
           "token": {
             "denom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-            "amount": "19182150003719635195606"
+            "amount": "18721209902264335212461"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "9265793218562918704456171"
+            "amount": "9497401038247303176094419"
           },
           "weight": "536870912000000"
         }
@@ -49568,20 +49568,20 @@
       "future_pool_governor": "",
       "total_shares": {
         "denom": "gamm/pool/1700",
-        "amount": "104841601708236594987120357"
+        "amount": "104927655216440166390726937"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1s6ht8qrm8x0eg8xag5x3ckx9mse9g4se248yss/BERNESE",
-            "amount": "10455489291755"
+            "amount": "11785232716773"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "4089185890"
+            "amount": "3636503889"
           },
           "weight": "1073741824"
         }
@@ -49599,16 +49599,16 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1701",
-        "amount": "61584627313038684211669"
+        "amount": "61793687306201987363146"
       },
       "pool_liquidity": [
         {
           "denom": "ibc/0D62E47FDEBBC199D4E1853C0708F0F9337AC62D95B719585C9700E466060995",
-          "amount": "2395"
+          "amount": "2431"
         },
         {
           "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-          "amount": "530814264"
+          "amount": "530797052"
         }
       ],
       "scaling_factors": [
@@ -49635,14 +49635,14 @@
         {
           "token": {
             "denom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-            "amount": "83934853782"
+            "amount": "82785971028"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "9813422761473886939141112"
+            "amount": "9952257873508775869284034"
           },
           "weight": "536870912000000"
         }
@@ -49667,14 +49667,14 @@
         {
           "token": {
             "denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
-            "amount": "175220415485312540994594"
+            "amount": "171311834188569931616200"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "8077094780048075813723444"
+            "amount": "8263915173425065872780823"
           },
           "weight": "536870912000000"
         }
@@ -49687,15 +49687,15 @@
       "incentives_address": "osmo188mhyh2vmp7t7susxsj8y0jevt0lxl0jpdvm7n9ewmrurj7zdv6qrlp0zz",
       "spread_rewards_address": "osmo1e6p4p0uzptr3lztfkuma8952x7yhqw3yul8xsyuqflrr3d7dnmuqygrsrf",
       "id": "1704",
-      "current_tick_liquidity": "47622579603.849169809581350153",
+      "current_tick_liquidity": "13937378896.144517802376253580",
       "token0": "ibc/E42006ED917C769EDE1B474650EEA6BFE3F97958912B9206DD7010A28D01D9D5",
       "token1": "uosmo",
-      "current_sqrt_price": "0.748023485607503308244631058608969024",
-      "current_tick": "-4404609",
+      "current_sqrt_price": "0.715842580731758301139900481208700814",
+      "current_tick": "-4875694",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T20:29:59.310491733Z"
+      "last_liquidity_update": "2024-05-17T12:44:04.150049045Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -49706,12 +49706,12 @@
       "current_tick_liquidity": "2616908620.814983098684372108",
       "token0": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.038930071710851692268115773201870706",
-      "current_tick": "-26484450",
+      "current_sqrt_price": "0.038729848774697487547097224270400012",
+      "current_tick": "-26499999",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T15:31:19.131604470Z"
+      "last_liquidity_update": "2024-05-16T07:45:27.436799141Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -49725,20 +49725,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1706",
-        "amount": "315254364702894308955"
+        "amount": "315995504713908716895"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
-            "amount": "29298679771"
+            "amount": "28510882726"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-            "amount": "25467535886"
+            "amount": "26345791149"
           },
           "weight": "536870912000000"
         }
@@ -49763,14 +49763,14 @@
         {
           "token": {
             "denom": "factory/osmo1s6ht8qrm8x0eg8xag5x3ckx9mse9g4se248yss/BERNESE",
-            "amount": "2963686565901"
+            "amount": "3277226925441"
           },
           "weight": "1073741824"
         },
         {
           "token": {
             "denom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-            "amount": "1463619"
+            "amount": "1324625"
           },
           "weight": "1073741824"
         }
@@ -49795,14 +49795,14 @@
         {
           "token": {
             "denom": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
-            "amount": "15106388561"
+            "amount": "15256531145"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "885794048"
+            "amount": "877091605"
           },
           "weight": "536870912000000"
         }
@@ -49827,14 +49827,14 @@
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "1395781"
+            "amount": "1387906"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqtia",
-            "amount": "27089532"
+            "amount": "27391546"
           },
           "weight": "536870912000000"
         }
@@ -49853,20 +49853,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1710",
-        "amount": "121851955742191178406"
+        "amount": "121766432154376083271"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "124480089102"
+            "amount": "127556765133"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/62B50BB1DAEAD2A92D6C6ACAC118F4ED8CBE54265DCF5688E8D0A0A978AA46E7",
-            "amount": "136056425100581368268643755"
+            "amount": "132614112033049612740062999"
           },
           "weight": "536870912000000"
         }
@@ -49882,8 +49882,8 @@
       "current_tick_liquidity": "488234541954.263415623136878106",
       "token0": "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202",
       "token1": "uosmo",
-      "current_sqrt_price": "0.026689456930095203757169593606645272",
-      "current_tick": "-29876729",
+      "current_sqrt_price": "0.026682166950911198236530565170199736",
+      "current_tick": "-29880620",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.005000000000000000",
@@ -49907,14 +49907,14 @@
         {
           "token": {
             "denom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
-            "amount": "2809900275"
+            "amount": "2863532960"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "131434169098094125552331"
+            "amount": "129132977939441969420567"
           },
           "weight": "536870912000000"
         }
@@ -49939,14 +49939,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "29596679766"
+            "amount": "29164499413"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
-            "amount": "5093192093264375488774762"
+            "amount": "5170584926942875288515478"
           },
           "weight": "536870912000000"
         }
@@ -50003,14 +50003,14 @@
         {
           "token": {
             "denom": "ibc/2FFE07C4B4EFC0DDA099A16C6AF3C9CCA653CC56077E87217A585D48794B0BC7",
-            "amount": "218480464156722"
+            "amount": "208169877593753"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "34607279998001"
+            "amount": "36371705505232"
           },
           "weight": "536870912000000"
         }
@@ -50026,8 +50026,8 @@
       "current_tick_liquidity": "54427603.025897586903686245",
       "token0": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.238552308291352775975097484908569392",
-      "current_tick": "-13309280",
+      "current_sqrt_price": "0.241949624445658114566888498468324011",
+      "current_tick": "-13146038",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.025000000000000000",
@@ -50051,14 +50051,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "14045939"
+            "amount": "14568288"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uion",
-            "amount": "52268"
+            "amount": "50413"
           },
           "weight": "536870912000000"
         }
@@ -50074,8 +50074,8 @@
       "current_tick_liquidity": "12715228386.985099778982484045",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/mdj",
       "token1": "uosmo",
-      "current_sqrt_price": "0.002946490673021629595147007434716524",
-      "current_tick": "-46318193",
+      "current_sqrt_price": "0.002962188401282987791985864352339807",
+      "current_tick": "-46225440",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -50151,15 +50151,15 @@
       "incentives_address": "osmo1k5p7er3gu3c25szejc7e7ktr4fqftszwxamz3384eq3eqmeglg9qf3u2ql",
       "spread_rewards_address": "osmo1j9zzs5khs5mn4pzjws3lnvd7kcnw8ypvpzy633n3l8fkpad3wtqsh4h8w2",
       "id": "1721",
-      "current_tick_liquidity": "15727168785731.215616243235557030",
+      "current_tick_liquidity": "15130436918666.435431463584430028",
       "token0": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.063558459485565017824201378393581675",
-      "current_tick": "-23960323",
+      "current_sqrt_price": "0.060019649770183318951809602574216269",
+      "current_tick": "-24397642",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.025000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:12.728562260Z"
+      "last_liquidity_update": "2024-05-18T00:01:57.103876190Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -50170,8 +50170,8 @@
       "current_tick_liquidity": "13071370458.186828514124124879",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/spng",
       "token1": "uosmo",
-      "current_sqrt_price": "0.004978369835559621917924861743513791",
-      "current_tick": "-43521584",
+      "current_sqrt_price": "0.005069990006821000358121116092359414",
+      "current_tick": "-43429521",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -50211,14 +50211,14 @@
         {
           "token": {
             "denom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
-            "amount": "291721388"
+            "amount": "171434182"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-            "amount": "573901"
+            "amount": "1044402"
           },
           "weight": "536870912000000"
         }
@@ -50327,15 +50327,15 @@
       "incentives_address": "osmo1dhgqm3f988qlzpra0jzscapexvqml38vmhphg8n8g8j2j2wy3fyqhzjd5t",
       "spread_rewards_address": "osmo1v4vfs5y9krpe5l4prv59py8t2hhgx3l3zj57wltw0r0xzu2gxp2sncsmwh",
       "id": "1728",
-      "current_tick_liquidity": "135834915712.638017128705504990",
+      "current_tick_liquidity": "76922296605.490715099622302534",
       "token0": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "token1": "uosmo",
-      "current_sqrt_price": "0.836894557183547196454030446271977196",
-      "current_tick": "-2996076",
+      "current_sqrt_price": "0.822838659672232135734793509696118463",
+      "current_tick": "-3229366",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.002000000000000000",
-      "last_liquidity_update": "2024-05-15T23:13:43.203593280Z"
+      "last_liquidity_update": "2024-05-17T23:40:54.205661761Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -50346,8 +50346,8 @@
       "current_tick_liquidity": "227708941438.283116453811889335",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/bwh",
       "token1": "uosmo",
-      "current_sqrt_price": "0.031644267303312972812719508316573251",
-      "current_tick": "-26998641",
+      "current_sqrt_price": "0.024800658728167277262489199227716199",
+      "current_tick": "-30849274",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -50371,14 +50371,14 @@
         {
           "token": {
             "denom": "ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E",
-            "amount": "8752808"
+            "amount": "22050495"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7722"
+            "amount": "3069"
           },
           "weight": "536870912000000"
         }
@@ -50403,14 +50403,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "480487851323"
+            "amount": "478214243974"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/956AEF1DA92F70584266E87978C3F30A43B91EE6ABC62F03D097E79F6B99C4D8",
-            "amount": "3760001671846530835821970"
+            "amount": "3778227190599060244157855"
           },
           "weight": "536870912000000"
         }
@@ -50429,20 +50429,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1732",
-        "amount": "715847247513652640528"
+        "amount": "529726963160102953991"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
-            "amount": "9448011564360300743"
+            "amount": "7575815185295019679"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "72767637"
+            "amount": "49702858"
           },
           "weight": "536870912000000"
         }
@@ -50483,14 +50483,14 @@
         {
           "token": {
             "denom": "ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E",
-            "amount": "1012806523955"
+            "amount": "856432167181"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
-            "amount": "25092446584936286015912549"
+            "amount": "29685994865136203846726378"
           },
           "weight": "536870912000000"
         }
@@ -50509,20 +50509,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1735",
-        "amount": "268162639494366203427"
+        "amount": "241346375544929583084"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
-            "amount": "30571376"
+            "amount": "27514239"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "56757390"
+            "amount": "51081651"
           },
           "weight": "536870912000000"
         }
@@ -50535,15 +50535,15 @@
       "incentives_address": "osmo15k25974jnm7fxa7fjwusq5rqjyjmk7vf0ezkkwzwfqyymth9qeaqly8anf",
       "spread_rewards_address": "osmo10q5t3h9estm4gvrcylfvvh7rc3s9rzqcts9swykgsd8dnwveuhrq3afvgp",
       "id": "1736",
-      "current_tick_liquidity": "226471833005.181904246031226342",
+      "current_tick_liquidity": "29657385297742.251268686404264807",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/cac",
       "token1": "uosmo",
-      "current_sqrt_price": "0.099178985795968894054594686879082049",
-      "current_tick": "-18163529",
+      "current_sqrt_price": "0.097877991613126408862360723853991356",
+      "current_tick": "-18419899",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
-      "last_liquidity_update": "2024-05-15T20:49:42.515078108Z"
+      "last_liquidity_update": "2024-05-17T21:58:33.156140095Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -50563,14 +50563,14 @@
         {
           "token": {
             "denom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/cac",
-            "amount": "93451783915"
+            "amount": "93936388879"
           },
           "weight": "53687091200"
         },
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "91048582"
+            "amount": "90591226"
           },
           "weight": "53687091200"
         }
@@ -50595,14 +50595,14 @@
         {
           "token": {
             "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
-            "amount": "449321086"
+            "amount": "467665532"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "7448397522"
+            "amount": "7167089921"
           },
           "weight": "536870912000000"
         }
@@ -50625,11 +50625,11 @@
       "pool_liquidity": [
         {
           "denom": "ibc/A23E590BA7E0D808706FB5085A449B3B9D6864AE4DDE7DAF936243CEBB2A3D43",
-          "amount": "1728000000000000000"
+          "amount": "1688866260233210493"
         },
         {
           "denom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-          "amount": "1728000000000000000"
+          "amount": "1767368547832870041"
         }
       ],
       "scaling_factors": [
@@ -50705,15 +50705,15 @@
       "incentives_address": "osmo1la0zpyndcvwr6f7z3m2nx7gxm05th5merpsdr8my29qju4pm8n9q6q38hk",
       "spread_rewards_address": "osmo1gg762d2glmex9w7rjc56hcld7actvmernwm36yd0enn7px50axpsyyaysp",
       "id": "1742",
-      "current_tick_liquidity": "1825761233806356.308032891151453517",
+      "current_tick_liquidity": "920837740033383.882100529538688065",
       "token0": "ibc/2F21E6D4271DE3F561F20A02CD541DAF7405B1E9CB3B9B07E3C2AC7D8A4338A5",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "0.000059318417204856377491174212269868",
-      "current_tick": "-78481326",
+      "current_sqrt_price": "0.000059991671754026963707497865378603",
+      "current_tick": "-78401000",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T12:33:00.424330252Z"
+      "last_liquidity_update": "2024-05-18T00:10:24.434552880Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -50724,8 +50724,8 @@
       "current_tick_liquidity": "1861020777.425033136691459216",
       "token0": "ibc/698350B8A61D575025F3ED13E9AC9C0F45C89DEFE92F76D5838F1D3C1A7FF7C9",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "3.010397512641460658154714123702561915",
-      "current_tick": "8062493",
+      "current_sqrt_price": "3.099470336206441776000759289552437580",
+      "current_tick": "8606716",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -50781,14 +50781,14 @@
         {
           "token": {
             "denom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
-            "amount": "243321321914"
+            "amount": "245593904415"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "160158499"
+            "amount": "158697426"
           },
           "weight": "536870912000000"
         }
@@ -50845,14 +50845,14 @@
         {
           "token": {
             "denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
-            "amount": "10261327"
+            "amount": "10033165"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "120798150"
+            "amount": "123994950"
           },
           "weight": "536870912000000"
         }
@@ -50943,15 +50943,15 @@
       "incentives_address": "osmo1snn86w7qewxx83cjcuq3mrr26x7zwdx4cz79km4fnthqa59pmg0qfrjh7q",
       "spread_rewards_address": "osmo1v75ascvx6z3h30m753k5mj93yk3aqutavhzpj42f5jp2532g84fqsrqfp4",
       "id": "1750",
-      "current_tick_liquidity": "226331724652.245667746241948387",
+      "current_tick_liquidity": "225843144853.419696868321976181",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/pbb",
       "token1": "uosmo",
-      "current_sqrt_price": "0.174424786478396391200257741724091714",
-      "current_tick": "-15957600",
+      "current_sqrt_price": "0.195112296361973357417829129328164357",
+      "current_tick": "-15193120",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
-      "last_liquidity_update": "2024-05-15T20:46:34.087009211Z"
+      "last_liquidity_update": "2024-05-17T23:59:29.488226035Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -50991,7 +50991,7 @@
       "incentives_address": "osmo1lt2k5g3852qlt2aluwjwctq88wcqykujch72twga42lkq5u4z5ysc9mmh4",
       "spread_rewards_address": "osmo10j83ysvnr9gruqec4xnak8j0wsppvyvjuh4mq8fz2mwzlkjrnkkssytte2",
       "id": "1752",
-      "current_tick_liquidity": "28575059032.299317393765017224",
+      "current_tick_liquidity": "5526939148.205659228121351128",
       "token0": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
       "current_sqrt_price": "0.000001001084687172998150055486746242",
@@ -50999,7 +50999,7 @@
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
-      "last_liquidity_update": "2024-05-14T14:34:12.256958806Z"
+      "last_liquidity_update": "2024-05-16T13:32:25.442720464Z"
     },
     {
       "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
@@ -51010,8 +51010,8 @@
       "current_tick_liquidity": "40468361924544725.747816059600439765",
       "token0": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
       "token1": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-      "current_sqrt_price": "999917.411201377699122745650441040855990270",
-      "current_tick": "107998348",
+      "current_sqrt_price": "1000071.603662924472680423846685883583445221",
+      "current_tick": "108000143",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
@@ -51045,20 +51045,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1755",
-        "amount": "171071494521340196784"
+        "amount": "169346142674752937546"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/FD506CCA1FC574F2A8175FB574C981E9F6351E194AA48AC219BD67FF934E2F33",
-            "amount": "3417210211307"
+            "amount": "3467671047287"
           },
           "weight": "858993459200000"
         },
         {
           "token": {
             "denom": "uosmo",
-            "amount": "604229208"
+            "amount": "541732007"
           },
           "weight": "214748364800000"
         }
@@ -51106,20 +51106,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1757",
-        "amount": "305241242877015176205"
+        "amount": "337902911301087865875"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
-            "amount": "1006184691262"
+            "amount": "1186253919046"
           },
           "weight": "751619276800000"
         },
         {
           "token": {
             "denom": "ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5",
-            "amount": "175017877907"
+            "amount": "169208670644"
           },
           "weight": "322122547200000"
         }
@@ -51138,20 +51138,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1758",
-        "amount": "5614341068588291703010"
+        "amount": "2584865085342323853232"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/072E5B3D6F278B3E6A9C51D7EAD1A737148609512C5EBE8CBCB5663264A0DDB7",
-            "amount": "110558200775"
+            "amount": "51305916399"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "185002435"
+            "amount": "84532418"
           },
           "weight": "536870912000000"
         }
@@ -51176,14 +51176,14 @@
         {
           "token": {
             "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
-            "amount": "477416"
+            "amount": "463930"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
-            "amount": "203634042830"
+            "amount": "209553907627"
           },
           "weight": "536870912000000"
         }
@@ -51202,20 +51202,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1760",
-        "amount": "103486046858326856000"
+        "amount": "110359033185565166575"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
-            "amount": "157463555"
+            "amount": "159353320"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-            "amount": "1384975720"
+            "amount": "1558718580"
           },
           "weight": "536870912000000"
         }
@@ -51240,14 +51240,14 @@
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "133280959"
+            "amount": "127885160"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/FD506CCA1FC574F2A8175FB574C981E9F6351E194AA48AC219BD67FF934E2F33",
-            "amount": "225282807119"
+            "amount": "234831537485"
           },
           "weight": "536870912000000"
         }
@@ -51327,8 +51327,8 @@
       "current_tick_liquidity": "1209516111784.982567244297525198",
       "token0": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
       "token1": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-      "current_sqrt_price": "1.166175841078833031927224862572599487",
-      "current_tick": "359966",
+      "current_sqrt_price": "1.165205023174887489355898186094963395",
+      "current_tick": "357702",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -51343,8 +51343,8 @@
       "current_tick_liquidity": "247410935830.646001002045074682",
       "token0": "ibc/79A676508A2ECA1021EDDC7BB9CF70CEEC9514C478DA526A5A8B3E78506C2206",
       "token1": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
-      "current_sqrt_price": "1.130747128893002300940255107522116689",
-      "current_tick": "278589",
+      "current_sqrt_price": "1.133352325528906869315787455918727648",
+      "current_tick": "284487",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -51359,8 +51359,8 @@
       "current_tick_liquidity": "13227878706.674364840540745628",
       "token0": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
       "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-      "current_sqrt_price": "1.014461105317024348390969634656025017",
-      "current_tick": "29131",
+      "current_sqrt_price": "1.036088949505096277071021773290920555",
+      "current_tick": "73480",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
@@ -51378,20 +51378,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1769",
-        "amount": "2198901788194680236"
+        "amount": "2501236604518838164"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
-            "amount": "9532546034"
+            "amount": "11329173250"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-            "amount": "36390413"
+            "amount": "39683899"
           },
           "weight": "536870912000000"
         }
@@ -51404,15 +51404,15 @@
       "incentives_address": "osmo1xvdn8c8q3ty4ug34ejaa694hcmzrrccaf4p2xv4je6klfjpsmz0sr4e5p2",
       "spread_rewards_address": "osmo1pdfx5m3sv8acryszgw4np74lr33e29hm7kc7yx460h5wseztul3qenf63l",
       "id": "1770",
-      "current_tick_liquidity": "238043986789.896811181007548532",
+      "current_tick_liquidity": "248959193523.448761908136308296",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/shitmos",
       "token1": "uosmo",
-      "current_sqrt_price": "0.149784983111241242597686870784187999",
-      "current_tick": "-16756446",
+      "current_sqrt_price": "0.153815449394325903337029623454296052",
+      "current_tick": "-16634081",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.001000000000000000",
-      "last_liquidity_update": "2024-05-16T00:06:17.949102325Z"
+      "last_liquidity_update": "2024-05-17T18:00:58.568959394Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -51426,20 +51426,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1771",
-        "amount": "433333333333333333300"
+        "amount": "214727768013256462826"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/0D62E47FDEBBC199D4E1853C0708F0F9337AC62D95B719585C9700E466060995",
-            "amount": "1171"
+            "amount": "628"
           },
           "weight": "214748364800000"
         },
         {
           "token": {
             "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
-            "amount": "339664627913"
+            "amount": "165092592537"
           },
           "weight": "858993459200000"
         }
@@ -51455,8 +51455,8 @@
       "current_tick_liquidity": "189692483137.928099061403229952",
       "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/crazyhorse",
       "token1": "uosmo",
-      "current_sqrt_price": "0.076064001559984375101523858166568878",
-      "current_tick": "-22214268",
+      "current_sqrt_price": "0.073417366958218851643529704071312251",
+      "current_tick": "-22609891",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.010000000000000000",
@@ -51468,15 +51468,15 @@
       "incentives_address": "osmo1jaa3p0ld0y9crmdvsjr5eartcn2cscgcl3tltyt5d56uuprrkw6q0zzjgh",
       "spread_rewards_address": "osmo1rfucsl7zqmxxht556zpjcse7v4pycdrcjnrsjq7g0xenwatjlgaqt4q64j",
       "id": "1773",
-      "current_tick_liquidity": "0.000000000000000000",
+      "current_tick_liquidity": "136232.865538739507052629",
       "token0": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "token1": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-      "current_sqrt_price": "0.000000000000000000000000000000000000",
-      "current_tick": "0",
+      "current_sqrt_price": "0.019416487838947599000000000000000000",
+      "current_tick": "-33230000",
       "tick_spacing": "100",
       "exponent_at_price_one": "-6",
       "spread_factor": "0.000500000000000000",
-      "last_liquidity_update": "2024-05-15T13:01:28.004239182Z"
+      "last_liquidity_update": "2024-05-16T09:20:39.522131972Z"
     },
     {
       "@type": "/osmosis.gamm.v1beta1.Pool",
@@ -51490,20 +51490,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1774",
-        "amount": "100000000000000000000"
+        "amount": "163395445821586874366"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/884EBC228DFCE8F1304D917A712AA9611427A6C1ECC3179B2E91D7468FB091A2",
-            "amount": "11604886717344"
+            "amount": "21236333387503"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
-            "amount": "40542539749"
+            "amount": "59164641609"
           },
           "weight": "536870912000000"
         }
@@ -51522,20 +51522,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1775",
-        "amount": "100000000000000000000"
+        "amount": "243473092727774009746"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/183C0BB962D2F57C957E0B134CFA0AC9D6F755C02DE9DC2A59089BA23009DEC3",
-            "amount": "603663769"
+            "amount": "1409326069"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/C12C353A83CD1005FC38943410B894DBEC5F2ABC97FC12908F0FB03B970E8E1B",
-            "amount": "894101645"
+            "amount": "2270426662"
           },
           "weight": "536870912000000"
         }
@@ -51554,20 +51554,20 @@
       "future_pool_governor": "24h",
       "total_shares": {
         "denom": "gamm/pool/1776",
-        "amount": "101199713010552124343"
+        "amount": "104769096747391934837"
       },
       "pool_assets": [
         {
           "token": {
             "denom": "ibc/38ADC6FFDDDB7D70B72AD0322CEA8844CB18FAA0A23400DBA8A99D43E18B3748",
-            "amount": "258907864120"
+            "amount": "253617985004"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
-            "amount": "729023562"
+            "amount": "798300364"
           },
           "weight": "536870912000000"
         }
@@ -51592,14 +51592,14 @@
         {
           "token": {
             "denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
-            "amount": "28129297598"
+            "amount": "25659610907"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
-            "amount": "1503365810"
+            "amount": "1649091154"
           },
           "weight": "536870912000000"
         }
@@ -51624,14 +51624,190 @@
         {
           "token": {
             "denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
-            "amount": "24922000000"
+            "amount": "22528864840"
           },
           "weight": "536870912000000"
         },
         {
           "token": {
             "denom": "ibc/C12C353A83CD1005FC38943410B894DBEC5F2ABC97FC12908F0FB03B970E8E1B",
-            "amount": "10840000000"
+            "amount": "11996641772"
+          },
+          "weight": "536870912000000"
+        }
+      ],
+      "total_weight": "1073741824000000"
+    },
+    {
+      "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
+      "address": "osmo15v9p0kuqvxfrcvw9jzpn7gjtfxnkvl5dzhtts7qjycq90t875u7sr49gae",
+      "incentives_address": "osmo1scmfem0nnntxzsuytg9jm769d97twl26khdzsvu0l5tqlpyvdxyscxr5mk",
+      "spread_rewards_address": "osmo15xwqqxslez2rt7pnk55dx4teq8rgnp93whmvn0nlfwe3v9ckr8qsn97agz",
+      "id": "1779",
+      "current_tick_liquidity": "190387613825.666254337293183420",
+      "token0": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/wiha",
+      "token1": "uosmo",
+      "current_sqrt_price": "0.078844294347588098102278782941873007",
+      "current_tick": "-21783578",
+      "tick_spacing": "100",
+      "exponent_at_price_one": "-6",
+      "spread_factor": "0.010000000000000000",
+      "last_liquidity_update": "2024-05-16T21:03:07.414286166Z"
+    },
+    {
+      "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
+      "address": "osmo18gu8evr92f7ntkd27hkh3nvyys5aewyxq4mgc7e65kyez3mjgdgqzjhhry",
+      "incentives_address": "osmo1tr8l266hfqjjv7g6erfpp2sdw47vx3c2t88tycqn5kkavcpgw3ksa7r0j7",
+      "spread_rewards_address": "osmo1hnqwr0f2ln500rxkxy9pw7n4cl4r4gsx0jkau48w6ljd0jcpud5q6kz8va",
+      "id": "1780",
+      "current_tick_liquidity": "19725586706.460935825864472311",
+      "token0": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
+      "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "current_sqrt_price": "0.168085153222079808575462951028443190",
+      "current_tick": "-16174739",
+      "tick_spacing": "100",
+      "exponent_at_price_one": "-6",
+      "spread_factor": "0.010000000000000000",
+      "last_liquidity_update": "2024-05-17T13:25:12.206421495Z"
+    },
+    {
+      "@type": "/osmosis.concentratedliquidity.v1beta1.Pool",
+      "address": "osmo1e0zmmpp79xf6y6sh0uqkemfxudyufv2fv9nl5c5cqlk85se3gzzqvlwxzq",
+      "incentives_address": "osmo1kq0e5ffcfje5tlxhuccvyycfdll5gkssw9kh0js879t8hcf3p7as3lz0ap",
+      "spread_rewards_address": "osmo1c3ltvefs5p3sy8xyl6aevrpdhnpwacwppx787ay4pex3hgsnxwnsh4vaea",
+      "id": "1781",
+      "current_tick_liquidity": "12948150.259673146029301828",
+      "token0": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+      "token1": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "current_sqrt_price": "0.271926508857437934439797814819165699",
+      "current_tick": "-11605598",
+      "tick_spacing": "100",
+      "exponent_at_price_one": "-6",
+      "spread_factor": "0.000500000000000000",
+      "last_liquidity_update": "2024-05-17T15:19:01.391384926Z"
+    },
+    {
+      "@type": "/osmosis.gamm.v1beta1.Pool",
+      "address": "osmo1hpxqq76yh424ujwp7yqyla0kxd9vlqp7y3thq5da9av30t9xz99qx0946j",
+      "id": "1782",
+      "pool_params": {
+        "swap_fee": "0.002000000000000000",
+        "exit_fee": "0.000000000000000000",
+        "smooth_weight_change_params": null
+      },
+      "future_pool_governor": "24h",
+      "total_shares": {
+        "denom": "gamm/pool/1782",
+        "amount": "100000000000000000000"
+      },
+      "pool_assets": [
+        {
+          "token": {
+            "denom": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
+            "amount": "110894"
+          },
+          "weight": "536870912000000"
+        },
+        {
+          "token": {
+            "denom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
+            "amount": "7821488747"
+          },
+          "weight": "536870912000000"
+        }
+      ],
+      "total_weight": "1073741824000000"
+    },
+    {
+      "@type": "/osmosis.gamm.v1beta1.Pool",
+      "address": "osmo13utqp556k0nfflaxpxjq0lel9wfq6jtlj3e8wxxnvjw9txn46ekqqjtnqk",
+      "id": "1783",
+      "pool_params": {
+        "swap_fee": "0.025000000000000000",
+        "exit_fee": "0.000000000000000000",
+        "smooth_weight_change_params": null
+      },
+      "future_pool_governor": "24h",
+      "total_shares": {
+        "denom": "gamm/pool/1783",
+        "amount": "8394633926239710"
+      },
+      "pool_assets": [
+        {
+          "token": {
+            "denom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
+            "amount": "42739356"
+          },
+          "weight": "536870912000000"
+        },
+        {
+          "token": {
+            "denom": "uosmo",
+            "amount": "170898"
+          },
+          "weight": "536870912000000"
+        }
+      ],
+      "total_weight": "1073741824000000"
+    },
+    {
+      "@type": "/osmosis.gamm.v1beta1.Pool",
+      "address": "osmo1pe6hl2kxafj3k9jgnvjyaxtaf3f0urdchm8t8f9mr7m6n9aq2hkqk4sx25",
+      "id": "1784",
+      "pool_params": {
+        "swap_fee": "0.025000000000000000",
+        "exit_fee": "0.000000000000000000",
+        "smooth_weight_change_params": null
+      },
+      "future_pool_governor": "24h",
+      "total_shares": {
+        "denom": "gamm/pool/1784",
+        "amount": "7588680643364619971231"
+      },
+      "pool_assets": [
+        {
+          "token": {
+            "denom": "ibc/0D62E47FDEBBC199D4E1853C0708F0F9337AC62D95B719585C9700E466060995",
+            "amount": "436"
+          },
+          "weight": "32212254720000"
+        },
+        {
+          "token": {
+            "denom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+            "amount": "831909454499"
+          },
+          "weight": "1041529569280000"
+        }
+      ],
+      "total_weight": "1073741824000000"
+    },
+    {
+      "@type": "/osmosis.gamm.v1beta1.Pool",
+      "address": "osmo1kwfhvtt5aj70u79nlyd9j6ux8zsxslf9d4eh376qwr2ea3uyxpyqwfx57t",
+      "id": "1785",
+      "pool_params": {
+        "swap_fee": "0.025000000000000000",
+        "exit_fee": "0.000000000000000000",
+        "smooth_weight_change_params": null
+      },
+      "future_pool_governor": "24h",
+      "total_shares": {
+        "denom": "gamm/pool/1785",
+        "amount": "100000000000000000000"
+      },
+      "pool_assets": [
+        {
+          "token": {
+            "denom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
+            "amount": "501763521067"
+          },
+          "weight": "536870912000000"
+        },
+        {
+          "token": {
+            "denom": "uosmo",
+            "amount": "2152048234"
           },
           "weight": "536870912000000"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "assetlists",
+  "name": "osmosis-labs-assetlists",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Description

See:
- IBCX/PHMN Pool 1254
- ATOM/PHMN Pool 1255
- WEIRD/PHMN Pool 1776
- PHMN/OSMO Pool 1738

## Checklist

### Upgrading Asset to Verified

If upgrading an Asset to Verified, please see the requirements specified at [LISTING](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md#upgrade-asset-to-verified-status-permissioned), and ensure the following:
- [x] Asset is defined thoroughly at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - [x] A meaningful `description` and `extended_description`.
   - [x] Associated `socials`, including `website` and `twitter`.
   - [x] Logo Image has a square Aspect Ratio and < 250 KB file size.
- [x] This pool contains contains at least $1k USD-worth of liquidity of the asset (Provide Pool ID): 1255

'Verified' Status Validation Checklist (to be completed by Osmosis Zone maintainers):
- [x] Verify appearance and metadata
- [x] Accurate Price
- [x] Trading and routing functionality
- [x] Withdraw and Deposit
   - [x] Deposit Transaction URL (if in-app)

