### PR TITLE
deprecate berlin token

### DIFF
--- a/osmosis-1/osmosis-1.assetlist.json
+++ b/osmosis-1/osmosis-1.assetlist.json
@@ -13889,7 +13889,7 @@
       ]
     },
     {
-      "description": "The token of Teledisko DAO.",
+      "description": "The legacy token of Teledisko DAO.",
       "denom_units": [
         {
           "denom": "ibc/2BF9656CAB0384A31167DB9B0254F0FB1CB4346A229BD7E5CBDCBB911C3740F7",
@@ -13899,16 +13899,16 @@
           ]
         },
         {
-          "denom": "berlin",
+          "denom": "berlin-legacy",
           "exponent": 18
         }
       ],
       "type_asset": "ics20",
       "address": "0x1cFc8f1FE8D5668BAFF2724547EcDbd6f013a280",
       "base": "ibc/2BF9656CAB0384A31167DB9B0254F0FB1CB4346A229BD7E5CBDCBB911C3740F7",
-      "name": "Teledisko DAO",
-      "display": "berlin",
-      "symbol": "BERLIN",
+      "name": "Teledisko DAO - Legacy",
+      "display": "berlin-legacy",
+      "symbol": "BERLIN-legacy",
       "traces": [
         {
           "type": "ibc",


### PR DESCRIPTION
WIth this PR, we are deprecating the BERLIN token, as in the future we will release a new EVMOS based token with a technology that will allow us to have a native IBC token.