### PR TITLE
Update INJ Deposit/Withdraw URLs

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -648,8 +648,8 @@
         {
           "name": "Injective Hub",
           "type": "external_interface",
-          "deposit_url": "https://hub.injective.network/bridge/?destination=osmosis&origin=injective&token=inj",
-          "withdraw_url": "https://hub.injective.network/bridge/?destination=injective&origin=osmosis&token=inj"
+          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=injective-1&chainTo=osmosis-1&token0=inj&token1=ibc%2F64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2F64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273&token1=inj"
         }
       ],
       "categories": [


### PR DESCRIPTION
Current INJ deposit/withdraw urls seems broken. Updated to pro.osmosis.zone urls.

https://hub.injective.network/bridge/?destination=osmosis&origin=injective&token=inj
https://hub.injective.network/bridge/?destination=injective&origin=osmosis&token=inj
