### PR TITLE
Update Injective Bridge URLs

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -642,14 +642,13 @@
       "chain_name": "injective",
       "base_denom": "inj",
       "path": "transfer/channel-122/inj",
-      "twitter_URL": "https://twitter.com/Injective_",
       "osmosis_verified": true,
       "transfer_methods": [
         {
           "name": "Injective Hub",
           "type": "external_interface",
-          "deposit_url": "https://hub.injective.network/bridge/?destination=osmosis&origin=injective&token=inj",
-          "withdraw_url": "https://hub.injective.network/bridge/?destination=injective&origin=osmosis&token=inj"
+          "deposit_url": "https://bridge.injective.network/",
+          "withdraw_url": "https://bridge.injective.network/"
         }
       ],
       "categories": [


### PR DESCRIPTION
## Description

Update Injective Bridge URLs to https://bridge.injective.network/
Olds ones no longer work

Closes #1639
Pending https://github.com/osmosis-labs/osmosis-frontend/pull/3312