### PR TITLE
Remove integrated_bridge as a type of transfer_method

### DIFF
--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -797,26 +797,6 @@ export function setTransferMethods(asset_data) {
       transferMethod.withdrawUrl = transferMethod.withdrawUrl ?? transferMethod.withdraw_url;
       delete transferMethod.withdraw_url;
 
-    } else if (transferMethod.type === bridge) {
-
-      transferMethod.counterparty.forEach((counterparty) => {
-        asset_data.zone_config.evm_chains.some((evm_chain) => {
-          if (evm_chain.chain_name === counterparty.chain_name) {
-            counterparty.evmChainId = evm_chain.chain_id;
-          }
-        });
-        asset_data.zone_config.providers.some((provider) => {
-          if (provider.integration === transferMethod.name) {
-            provider.api_keys?.sourceChainIds?.some((sourceChainId) => {
-              if (sourceChainId.chain_name === counterparty.chain_name) {
-                counterparty.sourceChainId = sourceChainId.sourceChainId;
-              }
-            });
-          }
-        });
-        delete counterparty.chain_name;
-      });
-
     }
 
   });

--- a/osmo-test-5/generated/frontend/assetlist.json
+++ b/osmo-test-5/generated/frontend/assetlist.json
@@ -351,16 +351,6 @@
       "categories": [],
       "transferMethods": [
         {
-          "name": "Nitro Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "unwrappedAssetId": "0x5425890298aed601595a70ab815c96711a31bc65"
-            }
-          ],
-          "unwrappedAssetId": "uusdc"
-        },
-        {
           "name": "Osmosis IBC Transfer",
           "type": "ibc",
           "counterparty": {

--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -52,20 +52,7 @@
       "override_properties": {
         "coingecko_id": "usd-coin"
       },
-      "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Nitro Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "chain_name": "avalanchetestnet",
-              "unwrappedAssetId": "0x5425890298aed601595a70ab815c96711a31bc65"
-            }
-          ],
-          "unwrappedAssetId": "uusdc"
-        }
-      ]
+      "osmosis_verified": true
     },
     {
       "chain_name": "akashtestnet",

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -71,33 +71,6 @@
       "pegMechanism": "collateralized",
       "transferMethods": [
         {
-          "name": "Axelar Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "unwrappedAssetId": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-              "evmChainId": 1,
-              "sourceChainId": "Ethereum"
-            },
-            {
-              "unwrappedAssetId": "0xfab550568C688d5d8a52c7d794cb93edc26ec0ec",
-              "evmChainId": 43114,
-              "sourceChainId": "Avalanche"
-            },
-            {
-              "unwrappedAssetId": "0xca01a1d0993565291051daff390892518acfad3a",
-              "evmChainId": 1284,
-              "sourceChainId": "Moonbeam"
-            },
-            {
-              "unwrappedAssetId": "0x750e4c4984a9e0f12978ea6742bc1c5d248f40ed",
-              "evmChainId": 137,
-              "sourceChainId": "Polygon"
-            }
-          ],
-          "unwrappedAssetId": "uusdc"
-        },
-        {
           "name": "Satellite",
           "type": "external_interface",
           "depositUrl": "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=uusdc",
@@ -169,20 +142,6 @@
       },
       "categories": [],
       "transferMethods": [
-        {
-          "name": "Axelar Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "wrappedAssetId": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-              "unwrappedAssetId": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
-              "evmChainId": 1,
-              "sourceChainId": "Ethereum"
-            }
-          ],
-          "wrappedAssetId": "weth-wei",
-          "unwrappedAssetId": "eth"
-        },
         {
           "name": "Satellite",
           "type": "external_interface",
@@ -3374,8 +3333,8 @@
         {
           "name": "Injective Hub",
           "type": "external_interface",
-          "depositUrl": "https://hub.injective.network/bridge/?destination=osmosis&origin=injective&token=inj",
-          "withdrawUrl": "https://hub.injective.network/bridge/?destination=injective&origin=osmosis&token=inj"
+          "depositUrl": "https://bridge.injective.network/",
+          "withdrawUrl": "https://bridge.injective.network/"
         },
         {
           "name": "Osmosis IBC Transfer",
@@ -5201,18 +5160,6 @@
         "defi"
       ],
       "transferMethods": [
-        {
-          "name": "Axelar Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "unwrappedAssetId": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
-              "evmChainId": 1,
-              "sourceChainId": "Ethereum"
-            }
-          ],
-          "unwrappedAssetId": "rai-wei"
-        },
         {
           "name": "Satellite",
           "type": "external_interface",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -29,29 +29,6 @@
       "osmosis_verified": true,
       "transfer_methods": [
         {
-          "name": "Axelar Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "chain_name": "ethereum",
-              "unwrappedAssetId": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-            },
-            {
-              "chain_name": "avalanche",
-              "unwrappedAssetId": "0xfab550568C688d5d8a52c7d794cb93edc26ec0ec"
-            },
-            {
-              "chain_name": "moonbeam",
-              "unwrappedAssetId": "0xca01a1d0993565291051daff390892518acfad3a"
-            },
-            {
-              "chain_name": "polygon",
-              "unwrappedAssetId": "0x750e4c4984a9e0f12978ea6742bc1c5d248f40ed"
-            }
-          ],
-          "unwrappedAssetId": "uusdc"
-        },
-        {
           "name": "Satellite",
           "type": "external_interface",
           "deposit_url": "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=uusdc",
@@ -86,19 +63,6 @@
         "base_denom": "wei"
       },
       "transfer_methods": [
-        {
-          "name": "Axelar Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "chain_name": "ethereum",
-              "wrappedAssetId": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-              "unwrappedAssetId": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
-            }
-          ],
-          "wrappedAssetId": "weth-wei",
-          "unwrappedAssetId": "eth"
-        },
         {
           "name": "Satellite",
           "type": "external_interface",
@@ -1022,17 +986,6 @@
         "base_denom": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919"
       },
       "transfer_methods": [
-        {
-          "name": "Axelar Bridge",
-          "type": "integrated_bridge",
-          "counterparty": [
-            {
-              "chain_name": "ethereum",
-              "unwrappedAssetId": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919"
-            }
-          ],
-          "unwrappedAssetId": "rai-wei"
-        },
         {
           "name": "Satellite",
           "type": "external_interface",

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -117,7 +117,6 @@
             },
             "oneOf": [
               { "$ref": "#/$defs/external_interface" },
-              { "$ref": "#/$defs/integrated_bridge" },
               { "$ref": "#/$defs/fiat_onramp" }
             ]
           }
@@ -218,68 +217,6 @@
           "description": "The URL of the interface used for withdrawing the asset to this chain."
         }
       }
-    },
-    "integrated_bridge": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "const": "integrated_bridge"
-        },
-        "counterparty": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "chain_name": {
-                "type": "string"
-              },
-              "unwrappedAssetId": {
-                "type": "string"
-              },
-              "wrappedAssetId": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "chain_name"
-            ],
-            "anyOf": [
-              {
-                "required": [
-                  "unwrappedAssetId"
-                ]
-              },
-              {
-                "required": [
-                  "wrappedAssetId"
-                ]
-              }
-            ]
-          }
-        },
-        "unwrappedAssetId": {
-          "type": "string"
-        },
-        "wrappedAssetId": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "type",
-        "counterparty"
-      ],
-      "anyOf": [
-        {
-          "required": [
-            "unwrappedAssetId"
-          ]
-        },
-        {
-          "required": [
-            "wrappedAssetId"
-          ]
-        }
-      ]
     },
     "fiat_onramp": {
       "type": "object",


### PR DESCRIPTION
## Description

Remove integrated_bridge as a type of transfer_method
Simplifies transfer_methods--removes embedded counterparty arrays within transfer_methods