### PR TITLE
Update Property Override Mechanism

### DIFF
--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -574,11 +574,7 @@ export function setName(asset_data) {
 
 
     //but use chain name instead if it's the staking token...
-    if (
-      //chain_reg.getFileProperty(asset_data.canonical_asset.chain_name, "chain", "staking")?.staking_tokens[0]?.denom ==
-      //asset_data.canonical_asset.base_denom
-      getAssetProperty(asset_data.canonical_asset, "is_staking")
-    ) {
+    if (getAssetProperty(asset_data.canonical_asset, "is_staking")) {
       name = chain_reg.getFileProperty(asset_data.canonical_asset.chain_name, "chain", "pretty_name");
     }
 
@@ -964,32 +960,29 @@ export function setDescription(asset_data) {
   
   let description, extended_description;
 
-  //for Chain registry
-  description = getAssetProperty(asset_data.local_asset, "description") || getAssetProperty(asset_data.canonical_asset, "description");
-  if (description) {
-    asset_data.chain_reg.description = description;
-  }
+  asset_data.chain_reg.description = getAssetProperty(asset_data.local_asset, "description");
   asset_data.chain_reg.extended_description = getAssetProperty(asset_data.local_asset, "extended_description");
 
-  //for Asset Detail
-  extended_description = asset_data.zone_asset?.override_properties?.description;
-  if (extended_description) {
-    asset_data.asset_detail.description = extended_description;
-    return;
-  }
-  extended_description =
-    getAssetProperty(asset_data.local_asset, "extended_description") ||
-    getAssetProperty(asset_data.canonical_asset, "extended_description");
-  if (!extended_description) {
-    if (getAssetProperty(asset_data.canonical_asset, "is_staking")) {
-      extended_description = chain_reg.getFileProperty(
-        asset_data.canonical_asset.chain_name,
-        "chain",
-        "description"
-      );
+  if (asset_data.zone_asset?.override_properties?.description) {
+    description = asset_data.zone_asset?.override_properties?.description;
+  } else {
+    description =
+      getAssetProperty(asset_data.local_asset, "description") ||
+      getAssetProperty(asset_data.canonical_asset, "description");
+    extended_description =
+      getAssetProperty(asset_data.local_asset, "extended_description") ||
+      getAssetProperty(asset_data.canonical_asset, "extended_description");
+    if (!extended_description) {
+      if (getAssetProperty(asset_data.canonical_asset, "is_staking")) {
+        extended_description = chain_reg.getFileProperty(
+          asset_data.canonical_asset.chain_name,
+          "chain",
+          "description"
+        );
+      }
     }
+    description = (description ?? "") + (description && extended_description ? "\n\n" : "") + (extended_description ?? "");
   }
-  description = (description ?? "") + (description && extended_description ? "\n\n" : "") + (extended_description ?? "");
   asset_data.asset_detail.description = description;
 
 }

--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -561,52 +561,55 @@ export function setName(asset_data) {
 
   let name;
 
+  asset_data.chain_reg.name =
+    getAssetProperty(asset_data.local_asset, "name") ??
+    getAssetProperty(asset_data.canonical_asset, "name");
+
+
   if (asset_data.zone_asset?.override_properties?.name) {
     name = asset_data.zone_asset?.override_properties?.name;
-    asset_data.frontend.name = name;
-    asset_data.chain_reg.name = name;
-    asset_data.asset_detail.name = name;
-    return;
-  }
-
-  //  but use chain name instead if it's the staking token...
-  if (
-    chain_reg.getFileProperty(asset_data.canonical_asset.chain_name, "chain", "staking")?.staking_tokens[0]?.denom ==
-    asset_data.canonical_asset.base_denom
-  ) {
-    name = chain_reg.getFileProperty(asset_data.canonical_asset.chain_name, "chain", "pretty_name");
   } else {
-    name = getAssetProperty(asset_data.canonical_asset, "name");
-  }
 
-  const traces = getAssetProperty(asset_data.canonical_asset, "traces");
-  if (!traces) {
-    asset_data.frontend.name = name;
-    asset_data.chain_reg.name = name;
-    return;
-  }
+    name = asset_data.chain_reg.name;
 
-  const trace_types = [
-    "ibc",
-    "ibc-cw20"
-  ];
 
-  let bridge_provider;
-
-  for (let i = traces?.length - 1; i >= 0; i--) {
-    if (trace_types.includes(traces[i].type)) { continue; }
-    if (traces[i].type === "bridge") {
-      bridge_provider = traces[i].provider;
+    //but use chain name instead if it's the staking token...
+    if (
+      //chain_reg.getFileProperty(asset_data.canonical_asset.chain_name, "chain", "staking")?.staking_tokens[0]?.denom ==
+      //asset_data.canonical_asset.base_denom
+      getAssetProperty(asset_data.canonical_asset, "is_staking")
+    ) {
+      name = chain_reg.getFileProperty(asset_data.canonical_asset.chain_name, "chain", "pretty_name");
     }
-    break;
-  }
 
-  if (bridge_provider && !name.includes(bridge_provider)) {
-    name = name + " " + "(" + bridge_provider + ")";
+
+    //append provider name in parentheses
+    const traces = getAssetProperty(asset_data.canonical_asset, "traces");
+    if (!traces) {
+      asset_data.frontend.name = name;
+      asset_data.chain_reg.name = name;
+      return;
+    }
+    const trace_types = [
+      "ibc",
+      "ibc-cw20"
+    ];
+    let bridge_provider;
+    for (let i = traces?.length - 1; i >= 0; i--) {
+      if (trace_types.includes(traces[i].type)) { continue; }
+      if (traces[i].type === "bridge") {
+        bridge_provider = traces[i].provider;
+      }
+      break;
+    }
+    if (bridge_provider && !name.includes(bridge_provider)) {
+      name = name + " " + "(" + bridge_provider + ")";
+    }
+
   }
   asset_data.frontend.name = name;
-  asset_data.chain_reg.name = name;
   asset_data.asset_detail.name = name;
+  
 
 }
 

--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -245,40 +245,32 @@ export function setSymbol(asset_data) {
 
   let symbol;
 
-  if (asset_data.zone_asset.override_properties?.symbol) {
+  asset_data.chain_reg.symbol =
+    getAssetProperty(asset_data.local_asset, "symbol") ??
+    getAssetProperty(asset_data.canonical_asset, "symbol");
+
+
+  if (asset_data.zone_asset?.override_properties?.symbol) {
     symbol = asset_data.zone_asset.override_properties.symbol;
-    asset_data.frontend.symbol = symbol;
-    asset_data.chain_reg.symbol = symbol;
-    asset_data.asset_detail.symbol = symbol;
-    return;
-  }
-
-  asset_data.canonical_asset.symbol = chain_reg.getAssetProperty(
-    asset_data.canonical_asset.chain_name,
-    asset_data.canonical_asset.base_denom,
-    "symbol"
-  );
-
-  symbol = asset_data.canonical_asset.symbol;
-
-  const traces = getAssetProperty(asset_data.canonical_asset, "traces");
-
-  for (let i = (traces?.length || 0) - 1; i >= 0; i--) {
-    if (traces[i].type === "bridge") {
-      const bridge_provider = asset_data.zone_config.providers.find(
-        provider =>
-          provider.provider === traces[i].provider && provider.suffix
-      );
-      if (bridge_provider) {
-        symbol = symbol + bridge_provider.suffix;
-        break;
+  } else {
+    symbol = asset_data.chain_reg.symbol;
+    const traces = getAssetProperty(asset_data.canonical_asset, "traces");
+    for (let i = (traces?.length || 0) - 1; i >= 0; i--) {
+      if (traces[i].type === "bridge") {
+        const bridge_provider = asset_data.zone_config.providers.find(
+          provider =>
+            provider.provider === traces[i].provider && provider.suffix
+        );
+        if (bridge_provider) {
+          symbol = symbol + bridge_provider.suffix;
+          break;
+        }
       }
     }
   }
-
   asset_data.frontend.symbol = symbol;
-  asset_data.chain_reg.symbol = symbol;
   asset_data.asset_detail.symbol = symbol;
+  
 
 }
 
@@ -442,23 +434,9 @@ export function setCoinGeckoId(asset_data) {
 
 export function setKeywords(asset_data) {
 
-  let keywords = getAssetProperty(asset_data.canonical_asset, "keywords") || [];
-
-  //--Update Keywords--
-  if (asset_data.zone_asset?.osmosis_unstable) {
-    addArrayItem("osmosis_unstable", keywords);
-  }
-  if (asset_data.zone_asset?.osmosis_unlisted) {
-    addArrayItem("osmosis_unlisted", keywords);
-  }
-  if (asset_data.zone_asset?.verified) {
-    addArrayItem("osmosis_verified", keywords);
-  }
-  if (!keywords.length) {
-    keywords = undefined;
-  }
-
-  asset_data.chain_reg.keywords = keywords;
+  asset_data.chain_reg.keywords =
+    getAssetProperty(asset_data.local_asset, "keywords")
+    getAssetProperty(asset_data.canonical_asset, "keywords");
 
 }
 

--- a/osmo-test-5/generated/chain_registry/assetlist.json
+++ b/osmo-test-5/generated/chain_registry/assetlist.json
@@ -565,7 +565,6 @@
       ]
     },
     {
-      "description": "The native token of Chain4Energy",
       "denom_units": [
         {
           "denom": "ibc/539BC2B6E70117D220834D6DF8E27307655D1325C0CADF7E3AF90AB00D9F8D69",
@@ -654,7 +653,6 @@
       ]
     },
     {
-      "description": "The native staking token of the Xion network.",
       "denom_units": [
         {
           "denom": "ibc/5C274155106FEB0C093F76A12BB67222E479E1EBE043F319CE4463E54F7A357C",

--- a/osmo-test-5/generated/chain_registry/assetlist.json
+++ b/osmo-test-5/generated/chain_registry/assetlist.json
@@ -581,7 +581,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/539BC2B6E70117D220834D6DF8E27307655D1325C0CADF7E3AF90AB00D9F8D69",
-      "name": "Chain4Energy Testnet",
+      "name": "Chain4Energy",
       "display": "c4e",
       "symbol": "C4E",
       "traces": [
@@ -674,7 +674,7 @@
       ],
       "type_asset": "ics20",
       "base": "ibc/5C274155106FEB0C093F76A12BB67222E479E1EBE043F319CE4463E54F7A357C",
-      "name": "Xion Testnet",
+      "name": "xion",
       "display": "XION",
       "symbol": "XION",
       "traces": [

--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -22,7 +22,10 @@
       "chain_name": "axelartestnet",
       "base_denom": "uausdc",
       "path": "transfer/channel-4170/uausdc",
-      "osmosis_verified": true
+      "osmosis_verified": true,
+      "override_properties": {
+        "symbol": "aUSDC.axl"
+      }
     },
     {
       "chain_name": "axelartestnet",


### PR DESCRIPTION
## Description

Update Mechanism for Override_Properties
Now only registered properties are generated for the Chain Registry, while modified name, description, and symbol are used for the Osmosis Zone frontend.
Osmosis Zone-specific Keywords are no longer added to the Chain Registry. 