### PR TITLE
Update Bitcanna, Quicksilver Explorer TX URL

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -166,7 +166,7 @@
       "chain_name": "bitcanna",
       "rpc": "https://rpc.bitcanna.io",
       "rest": "https://lcd.bitcanna.io",
-      "explorer_tx_url": "https://www.mintscan.io/bitcanna/txs/${txHash}",
+      "explorer_tx_url": "https://ping.pub/bitcanna/tx/${txHash}",
       "keplr_features": [
         "ibc-transfer",
         "ibc-go"
@@ -760,7 +760,7 @@
       "chain_name": "quicksilver",
       "rpc": "https://rpc-quicksilver.keplr.app",
       "rest": "https://lcd-quicksilver.keplr.app",
-      "explorer_tx_url": "https://www.mintscan.io/quicksilver/txs/${txHash}",
+      "explorer_tx_url": "https://ezstaking.app/quicksilver/txs/${txHash}",
       "keplr_features": [
         "ibc-transfer",
         "ibc-go"


### PR DESCRIPTION
## Description

Update Bitcanna, Quicksilver Explorer TX URL
because Mintscan is removing these