### PR TITLE
Add WETH from Arbitrum, Base, Polygon via Axelar

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -44,13 +44,6 @@
       "base_denom": "weth-wei",
       "path": "transfer/channel-208/weth-wei",
       "osmosis_verified": true,
-      "override_properties": {
-        "symbol": "ETH",
-        "name": "Ether",
-        "logo_URIs": {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
-        }
-      },
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "wei"
@@ -4091,6 +4084,75 @@
       "osmosis_verified": false,
       "listing_date_time_utc": "2024-06-29T21:00:00Z",
       "_comment": "Rakoff Token $RAKOFF"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "arbitrum-weth-wei",
+      "path": "transfer/channel-208/arbitrum-weth-wei",
+      "osmosis_verified": false,
+      "override_properties": {
+        "symbol": "ETH.arb.axl",
+        "name": "Wrapped Ether (Arbitrum via Axelar)"
+        "logo_URIs": {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.arb.axl.svg"
+        }
+      }
+      "transfer_methods": [
+        {
+          "name": "Satellite",
+          "type": "external_interface",
+          "deposit_url": "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=arbitrum-weth-wei",
+          "withdraw_url": "https://satellite.money/?source=osmosis&destination=ethereum&asset_denom=arbitrum-weth-wei"
+        }
+      ],
+      "listing_date_time_utc": "2024-07-03T19:00:00Z",
+      "_comment": "Wrapped Ether (Arbitrum via Axelar) $ETH.arb.axl"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "base-weth-wei",
+      "path": "transfer/channel-208/base-weth-wei",
+      "osmosis_verified": false,
+      "override_properties": {
+        "symbol": "ETH.base.axl",
+        "name": "Wrapped Ether (Base via Axelar)"
+        "logo_URIs": {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.base.axl.svg"
+        }
+      }
+      "transfer_methods": [
+        {
+          "name": "Satellite",
+          "type": "external_interface",
+          "deposit_url": "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=base-weth-wei",
+          "withdraw_url": "https://satellite.money/?source=osmosis&destination=ethereum&asset_denom=base-weth-wei"
+        }
+      ],
+      "listing_date_time_utc": "2024-07-03T19:00:00Z",
+      "_comment": "Wrapped Ether (Base via Axelar) $ETH.base.axl"
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "polygon-weth-wei",
+      "path": "transfer/channel-208/polygon-weth-wei",
+      "osmosis_verified": false,
+      "override_properties": {
+        "symbol": "ETH.matic.axl",
+        "name": "Wrapped Ether (Polygon via Axelar)"
+        "logo_URIs": {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.matic.axl.svg"
+        }
+      }
+      "transfer_methods": [
+        {
+          "name": "Satellite",
+          "type": "external_interface",
+          "deposit_url": "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=polygon-weth-wei",
+          "withdraw_url": "https://satellite.money/?source=osmosis&destination=ethereum&asset_denom=polygon-weth-wei"
+        }
+      ],
+      "listing_date_time_utc": "2024-07-03T19:00:00Z",
+      "_comment": "Wrapped Ether (Polygon via Axelar) $ETH.matic.axl"
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4092,7 +4092,7 @@
       "osmosis_verified": false,
       "override_properties": {
         "symbol": "ETH.arb.axl",
-        "name": "Wrapped Ether (Arbitrum via Axelar)"
+        "name": "Wrapped Ether (Arbitrum via Axelar)",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.arb.axl.svg"
         }
@@ -4115,7 +4115,7 @@
       "osmosis_verified": false,
       "override_properties": {
         "symbol": "ETH.base.axl",
-        "name": "Wrapped Ether (Base via Axelar)"
+        "name": "Wrapped Ether (Base via Axelar)",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.base.axl.svg"
         }
@@ -4138,7 +4138,7 @@
       "osmosis_verified": false,
       "override_properties": {
         "symbol": "ETH.matic.axl",
-        "name": "Wrapped Ether (Polygon via Axelar)"
+        "name": "Wrapped Ether (Polygon via Axelar)",
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.matic.axl.svg"
         }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4096,7 +4096,7 @@
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.arb.axl.svg"
         }
-      }
+      },
       "transfer_methods": [
         {
           "name": "Satellite",
@@ -4119,7 +4119,7 @@
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.base.axl.svg"
         }
-      }
+      },
       "transfer_methods": [
         {
           "name": "Satellite",
@@ -4142,7 +4142,7 @@
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/eth.matic.axl.svg"
         }
-      }
+      },
       "transfer_methods": [
         {
           "name": "Satellite",


### PR DESCRIPTION
## Description

Add WETH from Arbitrum, Base, Polygon via Axelar.

Removed the override for (ethereum) WETH to use the PNG version (now should pull in the svg version, too).

Pending registration of badged logos (so we can see where they come from)