### PR TITLE
Update Picasso Chain Logo Data

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -908,7 +908,17 @@
       "keplr_features": [
         "ibc-transfer",
         "ibc-go"
-      ]
+      ],
+      "override_properties": {
+        "images": [
+          {
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/pica.svg",
+            "theme": {
+              "primary_color_hex": "#ff8500"
+            }
+          }
+        ]
+      }
     },
     {
       "chain_name": "realio",


### PR DESCRIPTION
## Description

Update Picasso Chain Logo Data
Add chain logo override to add theme data. (use the organe dot as the color instead of black.