### PR TITLE
Override wstETH.axl symbol to wstETH.eth.axl

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1968,7 +1968,8 @@
       "override_properties": {
         "logo_URIs": {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wstETH.axl.svg"
-        }
+        },
+        "symbol": "wstETH.eth.axl"
       },
       "origin": {
         "chain_name": "ethereum",


### PR DESCRIPTION
Override wstETH.axl symbol to wstETH.eth.axl
because the frontend has the wrong symbol hardcoded