### PR TITLE
Add quotesDisabled to Frontend Assetlist

### DIFF
--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -868,7 +868,7 @@ export function setUnstableStatus(asset_data) {
 
 export function setDisabledStatus(asset_data) {
 
-  asset_data.frontend.disabled = asset_data.zone_asset?.osmosis_disabled || asset_data.zone_asset?.osmosis_unstable;
+  asset_data.frontend.disabled = asset_data.zone_asset?.osmosis_disabled;
 
 }
 
@@ -1340,6 +1340,12 @@ export function setContract(asset_data) {
 
 }
 
+export function setQuotesDisabled(asset_data) {
+
+  asset_data.frontend.quotes_disabled = asset_data.zone_asset.quotes_disabled;
+
+}
+
 export function setDescription(asset_data) {
   
   let description, extended_description;
@@ -1418,6 +1424,7 @@ export function reformatFrontendAsset(asset_data) {
     verified: asset_data.frontend.verified ?? false,
     unstable: asset_data.frontend.unstable ?? false,
     disabled: asset_data.frontend.disabled ?? false,
+    quotesDisabled: asset_data.frontend.quotesDisabled ?? false,
     preview: asset_data.frontend.preview ?? false,
     tooltipMessage: asset_data.frontend.tooltipMessage,
     sortWith: asset_data.frontend.sortWith,

--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -1342,7 +1342,15 @@ export function setContract(asset_data) {
 
 export function setQuotesDisabled(asset_data) {
 
-  asset_data.frontend.quotes_disabled = asset_data.zone_asset.quotes_disabled;
+  if (asset_data.zone_asset?.base_denom === "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372") {
+    console.log(asset_data.zone_asset?.base_denom);
+    console.log(asset_data.zone_asset?.quotes_disabled);
+  }
+  asset_data.frontend.quotesDisabled = asset_data.zone_asset?.quotes_disabled;
+  if (asset_data.zone_asset?.base_denom === "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372") {
+    console.log(asset_data.zone_asset?.base_denom);
+    console.log(asset_data.frontend.quotesDisabled);
+  }
 
 }
 

--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -106,6 +106,7 @@ const generateAssets = async (
     assetlist.setKeywords(asset_data);
     assetlist.setTypeAsset(asset_data);
 
+    assetlist.setQuotesDisabled(asset_data)
     assetlist.setIsAlloyed(asset_data);
     assetlist.setContract(asset_data);
 

--- a/.github/workflows/utility/generate_assetlist_new.mjs
+++ b/.github/workflows/utility/generate_assetlist_new.mjs
@@ -106,7 +106,7 @@ const generateAssets = async (
     assetlist.setKeywords(asset_data);
     assetlist.setTypeAsset(asset_data);
 
-    assetlist.setQuotesDisabled(asset_data)
+    assetlist.setQuotesDisabled(asset_data);
     assetlist.setIsAlloyed(asset_data);
     assetlist.setContract(asset_data);
 

--- a/language_files/en.json
+++ b/language_files/en.json
@@ -62,6 +62,9 @@
     },
     "USDC(dot)e(dot)matic(dot)axl": {
       "description": "USDC is a fully collateralized US Dollar stablecoin developed by CENTRE, the open source project with Circle being the first of several forthcoming issuers."
+    },
+    "MARS(dot)mars": {
+      "description": "Mars Protocol token (pre-migration)\n\nLend, borrow and earn with an autonomous credit protocol in the Cosmos universe. Open to all, closed to none."
     }
   },
   "osmosistestnet": {

--- a/osmo-test-5/generated/chain_registry/assetlist.json
+++ b/osmo-test-5/generated/chain_registry/assetlist.json
@@ -324,8 +324,8 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
       },
       "images": [
         {
@@ -333,8 +333,8 @@
             "chain_name": "marstestnet",
             "base_denom": "umars"
           },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
         }
       ]
     },

--- a/osmo-test-5/generated/frontend/assetlist.json
+++ b/osmo-test-5/generated/frontend/assetlist.json
@@ -25,6 +25,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -51,6 +52,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -106,6 +108,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -165,6 +168,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -238,6 +242,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -294,6 +299,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -303,8 +309,8 @@
       "symbol": "MARS",
       "decimals": 6,
       "logoURIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
       },
       "categories": [],
       "transferMethods": [
@@ -334,8 +340,8 @@
           "symbol": "MARS",
           "decimals": 6,
           "logoURIs": {
-            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
           }
         }
       ],
@@ -345,6 +351,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -395,6 +402,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -446,6 +454,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -501,6 +510,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -555,6 +565,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -608,6 +619,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -664,6 +676,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -713,6 +726,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -768,6 +782,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -823,6 +838,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -878,6 +894,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -927,6 +944,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     }
   ]

--- a/osmosis-1/generated/asset_detail/assetlist.json
+++ b/osmosis-1/generated/asset_detail/assetlist.json
@@ -928,10 +928,9 @@
       "description": "USDC is a fully collateralized US Dollar stablecoin developed by CENTRE, the open source project with Circle being the first of several forthcoming issuers."
     },
     {
-      "name": "Mars Hub",
-      "symbol": "MARS",
-      "description": "Mars protocol token\n\nLend, borrow and earn with an autonomous credit protocol in the Cosmos universe. Open to all, closed to none.",
-      "coingeckoID": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
+      "name": "Mars Protocol token (Mars Hub)",
+      "symbol": "MARS.mars",
+      "description": "Mars Protocol token (pre-migration)\n\nLend, borrow and earn with an autonomous credit protocol in the Cosmos universe. Open to all, closed to none.",
       "websiteURL": "https://www.marsprotocol.io/",
       "twitterURL": "https://twitter.com/mars_protocol"
     },

--- a/osmosis-1/generated/chain_registry/assetlist.json
+++ b/osmosis-1/generated/chain_registry/assetlist.json
@@ -8209,7 +8209,7 @@
       ]
     },
     {
-      "description": "Mars protocol token",
+      "description": "Mars Protocol token (pre-migration)",
       "denom_units": [
         {
           "denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
@@ -8219,16 +8219,24 @@
           ]
         },
         {
-          "denom": "mars",
+          "denom": "MARS.old",
           "exponent": 6
         }
       ],
       "type_asset": "ics20",
       "base": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
       "name": "Mars Hub",
-      "display": "mars",
-      "symbol": "MARS",
+      "display": "MARS.old",
+      "symbol": "MARS.old",
       "traces": [
+        {
+          "type": "legacy-mintage",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS"
+          },
+          "provider": "Mars Hub"
+        },
         {
           "type": "ibc",
           "counterparty": {
@@ -8243,8 +8251,8 @@
         }
       ],
       "logo_URIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.svg"
       },
       "images": [
         {
@@ -8252,10 +8260,10 @@
             "chain_name": "mars",
             "base_denom": "umars"
           },
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.svg",
           "theme": {
-            "primary_color_hex": "#d43c3f"
+            "primary_color_hex": "#FFFFFF"
           }
         }
       ]
@@ -22804,6 +22812,58 @@
         "website": "https://github.com/raphaellafar/Cosmo",
         "twitter": "https://x.com/CosmoClub84"
       }
+    },
+    {
+      "description": "Mars Protocol is a cross-collateralized Money Market Protocol on Neutron and Osmosis",
+      "denom_units": [
+        {
+          "denom": "ibc/B67DF59507B3755EEDE0866C449445BD54B4DA82CCEBA89D775E53DC35664255",
+          "exponent": 0,
+          "aliases": [
+            "umars"
+          ]
+        },
+        {
+          "denom": "MARS",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/B67DF59507B3755EEDE0866C449445BD54B4DA82CCEBA89D775E53DC35664255",
+      "name": "Mars Hub",
+      "display": "MARS",
+      "symbol": "MARS",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS",
+            "channel_id": "channel-10"
+          },
+          "chain": {
+            "channel_id": "channel-874",
+            "path": "transfer/channel-874/factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
+      },
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "neutron",
+            "base_denom": "factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS"
+          },
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg",
+          "theme": {
+            "primary_color_hex": "#ef4136"
+          }
+        }
+      ]
     }
   ]
 }

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -27,6 +27,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -56,6 +57,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -129,6 +131,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -214,6 +217,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -286,6 +290,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -357,6 +362,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -427,6 +433,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -498,6 +505,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -554,6 +562,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -608,6 +617,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -690,6 +700,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -771,6 +782,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -850,6 +862,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -914,6 +927,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -970,6 +984,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1048,6 +1063,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -1114,6 +1130,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1170,6 +1187,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1228,6 +1246,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1288,6 +1307,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1346,6 +1366,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1404,6 +1425,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1462,6 +1484,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1545,6 +1568,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1605,6 +1629,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1661,6 +1686,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1720,6 +1746,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1776,6 +1803,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1834,6 +1862,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1892,6 +1921,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -1950,6 +1980,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2008,6 +2039,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2064,6 +2096,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2120,6 +2153,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2178,6 +2212,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2234,6 +2269,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2290,6 +2326,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2348,6 +2385,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2406,6 +2444,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2464,6 +2503,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2520,6 +2560,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2587,7 +2628,8 @@
       "isAlloyed": false,
       "verified": true,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2646,6 +2688,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2699,7 +2742,8 @@
       "isAlloyed": false,
       "verified": true,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2758,6 +2802,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2816,6 +2861,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2871,7 +2917,8 @@
       "isAlloyed": false,
       "verified": true,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2930,6 +2977,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -2988,6 +3036,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3046,6 +3095,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3101,6 +3151,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3165,6 +3216,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3222,7 +3274,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3281,6 +3334,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3339,6 +3393,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3395,6 +3450,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3459,6 +3515,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3517,6 +3574,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3574,7 +3632,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3633,6 +3692,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3689,6 +3749,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3744,6 +3805,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3812,6 +3874,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3881,6 +3944,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -3954,6 +4018,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "gravitybridge",
@@ -4042,6 +4107,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "gravitybridge",
@@ -4121,6 +4187,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4195,6 +4262,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "gravitybridge",
@@ -4275,6 +4343,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "gravitybridge",
@@ -4334,6 +4403,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4392,6 +4462,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4447,6 +4518,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4502,6 +4574,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4559,6 +4632,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4617,6 +4691,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4670,6 +4745,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4723,6 +4799,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4779,6 +4856,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4835,6 +4913,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4889,6 +4968,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -4947,6 +5027,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5018,6 +5099,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5072,7 +5154,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5137,6 +5220,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -5201,6 +5285,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -5269,6 +5354,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5344,6 +5430,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-29T20:12:00.000Z"
     },
@@ -5413,6 +5500,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -5476,6 +5564,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5532,6 +5621,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5591,6 +5681,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5649,6 +5740,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5703,7 +5795,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5758,7 +5851,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5813,6 +5907,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5895,6 +5990,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -5965,6 +6061,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6022,6 +6119,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6080,6 +6178,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6134,7 +6233,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6191,6 +6291,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6249,6 +6350,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6308,6 +6410,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6364,6 +6467,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6423,6 +6527,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6478,6 +6583,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6529,6 +6635,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6587,6 +6694,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6645,6 +6753,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6703,6 +6812,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6758,6 +6868,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6813,6 +6924,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6871,6 +6983,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6927,6 +7040,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -6983,6 +7097,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7041,6 +7156,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7099,6 +7215,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7148,6 +7265,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7204,6 +7322,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7268,6 +7387,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7324,6 +7444,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7380,6 +7501,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7441,6 +7563,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7501,6 +7624,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7555,7 +7679,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7619,6 +7744,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7682,6 +7808,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7738,6 +7865,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7799,6 +7927,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7855,6 +7984,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7915,6 +8045,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -7971,6 +8102,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8026,6 +8158,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8082,6 +8215,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8142,6 +8276,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8200,6 +8335,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8258,6 +8394,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8313,6 +8450,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8368,6 +8506,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8430,6 +8569,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8491,6 +8631,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8573,6 +8714,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8629,6 +8771,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8686,6 +8829,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -8748,6 +8892,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -8829,6 +8974,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -8914,6 +9060,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -8924,13 +9071,12 @@
       "chainName": "mars",
       "sourceDenom": "umars",
       "coinMinimalDenom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-      "symbol": "MARS",
+      "symbol": "MARS.mars",
       "decimals": 6,
       "logoURIs": {
-        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.svg"
       },
-      "coingeckoId": "mars-protocol-a7fcbcfb-fd61-4017-92f0-7ee9f9cc6da3",
       "price": {
         "poolId": "1099",
         "denom": "uosmo"
@@ -8963,20 +9109,33 @@
           "sourceDenom": "umars",
           "chainType": "cosmos",
           "chainId": "mars-1",
+          "symbol": "MARS.old",
+          "decimals": 6,
+          "logoURIs": {
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png",
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.svg"
+          }
+        },
+        {
+          "chainName": "neutron",
+          "sourceDenom": "factory/neutron1ndu2wvkrxtane8se2tr48gv7nsm46y5gcqjhux/MARS",
+          "chainType": "cosmos",
+          "chainId": "neutron-1",
           "symbol": "MARS",
           "decimals": 6,
           "logoURIs": {
-            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.png",
-            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+            "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.png",
+            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/mars-token.svg"
           }
         }
       ],
       "variantGroupKey": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-      "name": "Mars Hub",
+      "name": "Mars Protocol token (Mars Hub)",
       "isAlloyed": false,
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9038,6 +9197,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9096,6 +9256,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9154,6 +9315,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9209,6 +9371,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9264,6 +9427,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9321,6 +9485,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -9383,6 +9548,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9440,6 +9606,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -9497,6 +9664,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9553,6 +9721,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9607,7 +9776,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9665,6 +9835,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -9726,6 +9897,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9785,6 +9957,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9838,6 +10011,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9893,6 +10067,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -9946,6 +10121,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10001,6 +10177,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10059,6 +10236,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10112,6 +10290,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10165,6 +10344,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10218,6 +10398,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10271,6 +10452,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10324,6 +10506,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10377,6 +10560,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10430,6 +10614,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10488,6 +10673,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10541,6 +10727,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10594,6 +10781,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10657,6 +10845,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10710,6 +10899,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10763,6 +10953,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10848,6 +11039,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10901,6 +11093,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -10964,6 +11157,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11019,7 +11213,8 @@
       "isAlloyed": false,
       "verified": true,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11089,6 +11284,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11142,6 +11338,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11197,6 +11394,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11268,6 +11466,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11296,6 +11495,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11364,6 +11564,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11432,6 +11633,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11500,6 +11702,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11567,6 +11770,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -11629,6 +11833,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11689,6 +11894,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11747,6 +11953,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11774,6 +11981,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11833,6 +12041,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11892,6 +12101,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -11951,6 +12161,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12007,6 +12218,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12060,6 +12272,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12132,6 +12345,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12212,6 +12426,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12307,6 +12522,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12364,6 +12580,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12420,6 +12637,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12478,6 +12696,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12531,6 +12750,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12589,6 +12809,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12661,6 +12882,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12688,6 +12910,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12750,6 +12973,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12807,6 +13031,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -12867,6 +13092,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -12925,6 +13151,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13011,6 +13238,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13089,6 +13317,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13165,6 +13394,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "solana",
@@ -13245,6 +13475,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13321,6 +13552,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13384,6 +13616,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13437,6 +13670,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13507,6 +13741,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "solana",
@@ -13596,6 +13831,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "solana",
@@ -13806,6 +14042,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13878,6 +14115,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13941,6 +14179,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -13994,6 +14233,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14054,6 +14294,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14117,6 +14358,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14147,6 +14389,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14175,6 +14418,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14233,6 +14477,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14289,6 +14534,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14344,6 +14590,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14399,6 +14646,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14452,6 +14700,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14510,6 +14759,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14566,6 +14816,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14623,6 +14874,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14684,6 +14936,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14739,6 +14992,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14796,6 +15050,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14820,6 +15075,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14870,6 +15126,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14925,6 +15182,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -14993,6 +15251,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15017,6 +15276,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15037,6 +15297,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -15091,6 +15352,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15146,6 +15408,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15201,6 +15464,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15256,6 +15520,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15311,6 +15576,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15367,6 +15633,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15439,6 +15706,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15497,6 +15765,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15526,6 +15795,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15580,7 +15850,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15637,6 +15908,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15679,6 +15951,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15734,6 +16007,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15792,6 +16066,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15847,6 +16122,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15903,6 +16179,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -15955,6 +16232,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -16030,6 +16308,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -16099,6 +16378,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -16161,6 +16441,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-24T10:58:00.000Z"
     },
@@ -16215,6 +16496,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -16267,6 +16549,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -16326,6 +16609,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -16381,6 +16665,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -16436,6 +16721,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -16489,6 +16775,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-17T17:14:00.000Z"
     },
@@ -16545,6 +16832,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-17T17:41:00.000Z"
     },
@@ -16601,6 +16889,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-22T12:50:00.000Z"
     },
@@ -16642,6 +16931,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-29T09:57:00.000Z"
     },
@@ -16698,6 +16988,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-15T14:42:00.000Z"
     },
@@ -16752,6 +17043,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-18T15:42:00.000Z"
     },
@@ -16779,6 +17071,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-22T15:42:00.000Z"
     },
@@ -16804,6 +17097,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-19T15:51:00.000Z"
     },
@@ -16860,6 +17154,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-01-22T21:05:00.000Z"
     },
@@ -16918,6 +17213,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -16980,6 +17276,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -17042,6 +17339,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -17104,6 +17402,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -17185,6 +17484,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-01T20:23:00.000Z"
     },
@@ -17247,6 +17547,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-02-06T08:36:00.000Z"
     },
@@ -17270,6 +17571,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -17339,6 +17641,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-13T17:30:00.000Z"
     },
@@ -17366,6 +17669,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "tooltipMessage": "This asset is NOT affiliated with the Bad Kids NFT collection.",
       "listingDate": "2024-02-13T21:32:00.000Z"
@@ -17453,6 +17757,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "solana",
@@ -17521,6 +17826,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-08T16:25:00.000Z"
     },
@@ -17582,6 +17888,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-07T18:18:00.000Z"
     },
@@ -17639,6 +17946,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-19T19:08:00.000Z"
     },
@@ -17694,6 +18002,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-06T12:52:00.000Z"
     },
@@ -17754,6 +18063,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-02T22:12:00.000Z"
     },
@@ -17832,6 +18142,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-03T21:47:00.000Z"
     },
@@ -17888,6 +18199,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-03T22:27:00.000Z"
     },
@@ -17957,6 +18269,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-21T20:09:00.000Z"
     },
@@ -18022,6 +18335,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-12T23:14:00.000Z"
     },
@@ -18080,6 +18394,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -18139,6 +18454,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-13T15:44:00.000Z"
     },
@@ -18167,6 +18483,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-14T22:20:00.000Z"
     },
@@ -18219,6 +18536,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-15T19:51:00.000Z"
     },
@@ -18291,6 +18609,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "coreum",
@@ -18347,6 +18666,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -18405,6 +18725,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-03-25T19:39:00.000Z"
     },
@@ -18477,6 +18798,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-01T19:35:00.000Z"
     },
@@ -18534,6 +18856,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -18561,6 +18884,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-01T21:57:00.000Z"
     },
@@ -18623,6 +18947,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -18652,6 +18977,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-02T15:53:00.000Z"
     },
@@ -18680,6 +19006,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-15T18:00:00.000Z"
     },
@@ -18753,6 +19080,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-21T16:00:00.000Z"
     },
@@ -18834,6 +19162,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-03T16:09:00.000Z"
     },
@@ -18907,6 +19236,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-03T17:37:00.000Z"
     },
@@ -18966,6 +19296,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-16T17:00:00.000Z"
     },
@@ -19023,6 +19354,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-29T16:37:00.000Z"
     },
@@ -19082,6 +19414,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-09T10:30:00.000Z"
     },
@@ -19138,6 +19471,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-09T16:00:00.000Z"
     },
@@ -19195,6 +19529,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -19250,6 +19585,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -19312,6 +19648,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-15T15:55:00.000Z"
     },
@@ -19335,6 +19672,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -19391,6 +19729,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -19445,6 +19784,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-13T17:50:00.000Z"
     },
@@ -19498,6 +19838,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true,
       "listingDate": "2024-04-13T17:50:00.000Z"
     },
@@ -19574,6 +19915,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "gravitybridge",
@@ -19630,6 +19972,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-14T01:25:00.000Z"
     },
@@ -19657,6 +20000,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-23T02:49:00.000Z"
     },
@@ -19731,6 +20075,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -19799,6 +20144,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -19873,6 +20219,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -19941,6 +20288,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -20011,6 +20359,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -20087,6 +20436,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -20157,6 +20507,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -20231,6 +20582,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-25T15:30:00.000Z"
     },
@@ -20287,6 +20639,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-29T12:00:00.000Z"
     },
@@ -20343,6 +20696,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-29T12:00:00.000Z"
     },
@@ -20381,6 +20735,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-04-30T12:00:00.000Z"
     },
@@ -20451,7 +20806,8 @@
       "isAlloyed": false,
       "verified": false,
       "unstable": true,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-01T18:25:00.000Z"
     },
@@ -20509,6 +20865,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-03T13:00:00.000Z"
     },
@@ -20536,6 +20893,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-06T12:00:00.000Z"
     },
@@ -20592,6 +20950,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-08T18:00:00.000Z"
     },
@@ -20619,6 +20978,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-13T18:41:03.000Z"
     },
@@ -20646,6 +21006,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-13T18:59:11.000Z"
     },
@@ -20700,6 +21061,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-13T19:00:00.000Z"
     },
@@ -20728,6 +21090,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-14T15:45:04.000Z"
     },
@@ -20782,6 +21145,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -20844,6 +21208,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -20906,6 +21271,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -20964,6 +21330,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "quicksilver",
@@ -21038,6 +21405,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21105,6 +21473,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21174,6 +21543,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21241,6 +21611,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21308,6 +21679,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21377,6 +21749,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21446,6 +21819,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21513,6 +21887,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true
     },
     {
@@ -21539,6 +21914,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-16T21:03:04.000Z"
     },
@@ -21566,6 +21942,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-14T22:32:04.000Z"
     },
@@ -21593,6 +21970,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-05-21T11:07:05.000Z"
     },
@@ -21678,6 +22056,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-04T22:00:00.000Z"
     },
@@ -21746,6 +22125,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-04T22:00:00.000Z"
     },
@@ -21814,6 +22194,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-04T22:00:00.000Z"
     },
@@ -21886,6 +22267,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-04T22:00:00.000Z"
     },
@@ -21966,6 +22348,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-04T22:00:00.000Z"
     },
@@ -22062,6 +22445,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-06-17T19:30:00.000Z"
     },
@@ -22132,6 +22516,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-06-05T03:00:00.000Z"
     },
@@ -22159,6 +22544,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-06-15T13:59:04.000Z"
     },
@@ -22199,6 +22585,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -22254,6 +22641,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-06-25T12:00:00.000Z"
     },
@@ -22310,6 +22698,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-06-29T21:00:00.000Z"
     },
@@ -22416,6 +22805,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -22514,6 +22904,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -22611,6 +23002,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -22673,6 +23065,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -22752,6 +23145,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-09T17:30:00.000Z"
     },
@@ -22805,6 +23199,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": true,
       "listingDate": "2024-07-11T14:30:00.000Z"
     },
@@ -22873,6 +23268,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-12T12:00:00.000Z"
     },
@@ -22934,6 +23330,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-16T08:10:00.000Z"
     },
@@ -22961,6 +23358,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-16T04:01:13.000Z"
     },
@@ -23018,6 +23416,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-16T17:42:00.000Z"
     },
@@ -23085,6 +23484,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23122,6 +23522,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23176,12 +23577,13 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-07-30T15:00:00.000Z"
     },
     {
-      "chainName": "penumbra",
-      "sourceDenom": "upenumbra",
+      "chainName": "osmosis",
+      "sourceDenom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
       "coinMinimalDenom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
       "symbol": "UM",
       "decimals": 6,
@@ -23200,30 +23602,13 @@
           "type": "external_interface",
           "depositUrl": "https://stake.with.starlingcyber.net/#/ibc",
           "withdrawUrl": "https://stake.with.starlingcyber.net/#/ibc"
-        },
-        {
-          "name": "Osmosis IBC Transfer",
-          "type": "ibc",
-          "counterparty": {
-            "chainName": "penumbra",
-            "chainId": "penumbra-1",
-            "sourceDenom": "upenumbra",
-            "port": "transfer",
-            "channelId": "channel-4"
-          },
-          "chain": {
-            "port": "transfer",
-            "channelId": "channel-79703",
-            "path": "transfer/channel-79703/upenumbra"
-          }
         }
       ],
       "counterparty": [
         {
           "chainName": "penumbra",
           "sourceDenom": "upenumbra",
-          "chainType": "cosmos",
-          "chainId": "penumbra-1",
+          "chainType": "non-cosmos",
           "symbol": "UM",
           "decimals": 6,
           "logoURIs": {
@@ -23237,7 +23622,8 @@
       "isAlloyed": false,
       "verified": true,
       "unstable": false,
-      "disabled": true,
+      "disabled": false,
+      "quotesDisabled": true,
       "preview": false,
       "listingDate": "2024-07-31T20:00:00.000Z"
     },
@@ -23279,6 +23665,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-07T18:30:00.000Z"
     },
@@ -23388,6 +23775,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-07T18:30:00.000Z"
     },
@@ -23446,6 +23834,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-02T22:20:00.000Z"
     },
@@ -23504,6 +23893,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "stride",
@@ -23531,6 +23921,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-06T14:30:00.000Z"
     },
@@ -23567,6 +23958,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-06T18:00:00.000Z"
     },
@@ -23622,6 +24014,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-07T17:30:00.000Z"
     },
@@ -23659,6 +24052,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23729,6 +24123,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "sortWith": {
         "chainName": "axelar",
@@ -23769,6 +24164,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23805,6 +24201,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23841,6 +24238,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23876,6 +24274,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23910,6 +24309,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false
     },
     {
@@ -23988,6 +24388,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-12T23:00:00.000Z"
     },
@@ -24044,6 +24445,7 @@
       "verified": false,
       "unstable": false,
       "disabled": false,
+      "quotesDisabled": false,
       "preview": false,
       "listingDate": "2024-08-15T12:00:00.000Z"
     }

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -23582,8 +23582,8 @@
       "listingDate": "2024-07-30T15:00:00.000Z"
     },
     {
-      "chainName": "osmosis",
-      "sourceDenom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
+      "chainName": "penumbra",
+      "sourceDenom": "upenumbra",
       "coinMinimalDenom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
       "symbol": "UM",
       "decimals": 6,
@@ -23602,13 +23602,30 @@
           "type": "external_interface",
           "depositUrl": "https://stake.with.starlingcyber.net/#/ibc",
           "withdrawUrl": "https://stake.with.starlingcyber.net/#/ibc"
+        },
+        {
+          "name": "Osmosis IBC Transfer",
+          "type": "ibc",
+          "counterparty": {
+            "chainName": "penumbra",
+            "chainId": "penumbra-1",
+            "sourceDenom": "upenumbra",
+            "port": "transfer",
+            "channelId": "channel-4"
+          },
+          "chain": {
+            "port": "transfer",
+            "channelId": "channel-79703",
+            "path": "transfer/channel-79703/upenumbra"
+          }
         }
       ],
       "counterparty": [
         {
           "chainName": "penumbra",
           "sourceDenom": "upenumbra",
-          "chainType": "non-cosmos",
+          "chainType": "cosmos",
+          "chainId": "penumbra-1",
           "symbol": "UM",
           "decimals": 6,
           "logoURIs": {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4657,6 +4657,7 @@
       "chain_name": "osmosis",
       "base_denom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
       "osmosis_verified": true,
+      "quotes_disabled": true,
       "listing_date_time_utc": "2024-07-31T20:00:00Z",
       "canonical": {
         "chain_name": "penumbra",

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -152,9 +152,9 @@
             "hybrid"
           ]
         },
-        "twitter_URL": {
-          "type": "string",
-          "pattern": "^https://(twitter\\.com|x\\.com)/.*$"
+        "quotes_disabled": {
+          "type": "boolean",
+          "description": "Whether quotes from Osmosis Zone's integrated providers should be ignored( and only show external URL transfer methods defined at the assetlist)."
         },
         "override_properties": {
           "type": "object",


### PR DESCRIPTION
## Description

Add quotesDisabled to Frontend Assetlist
Makes Penumbra UM quotesDisabled: true
before, unstabled flag resulted in BOTH unstable AND disabled to be true, but now it just applies to unstable.
"disabled" is effectively unused at this point.
both "disabled" and "quotesDisabled" are two separate properties, and both exist.