### PR TITLE
Remove POL Symbol override to MATIC

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -154,8 +154,7 @@
       "path": "transfer/channel-208/wmatic-wei",
       "osmosis_verified": true,
       "override_properties": {
-        "name": "Polygon",
-        "symbol": "MATIC"
+        "name": "Polygon"
       },
       "canonical": {
         "chain_name": "polygon",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -159,7 +159,8 @@
       "canonical": {
         "chain_name": "polygon",
         "base_denom": "wei"
-      }
+      },
+      "_comment": "Polygon $POL (formerly $MATIC)"
     },
     {
       "chain_name": "axelar",


### PR DESCRIPTION
## Description

Remove POL Symbol override to MATIC
needed this temporarily due to hardcoding of symbols