### PR TITLE
Add Pryzm's Osmo Yield Pool Token

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5312,7 +5312,7 @@
       "base_denom": "lp:8:uosmo",
       "path": "transfer/channel-75755/lp:8:uosmo",
       "osmosis_verified": false,
-      "listing_date_time_utc": "2024-10-12T18:00:00Z",
+      "listing_date_time_utc": "2024-10-15T18:00:00Z",
       "_comment": "Pryzm's Osmo Yield LP",
       "categories": [
         "defi"

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5274,6 +5274,17 @@
       "osmosis_unlisted": true,
       "listing_date_time_utc": "2024-10-20T12:00:00Z",
       "_comment": "Stratos native token (STOS)"
+    },
+    {
+      "chain_name": "pryzm",
+      "base_denom": "lp:8:uosmo",
+      "path": "transfer/channel-75755/lp:8:uosmo",
+      "osmosis_verified": false,
+      "listing_date_time_utc": "2024-10-12T18:00:00Z",
+      "_comment": "Pryzm's Osmo Yield LP",
+      "categories": [
+        "defi"
+      ]
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1419,6 +1419,18 @@
         "ibc-go",
         "ibc-transfer"
       ]
+    },
+    {
+      "chain_name": "pryzm",
+      "rpc": "https://rpc.pryzm.zone",
+      "rest": "https://api.pryzm.zone",
+      "explorer_tx_url": "https://chainsco.pe/pryzm/tx/${txHash}",
+      "keplr_features": [
+        "ibc-transfer",
+        "ibc-go",
+        "cosmwasm",
+        "wasmd_0.24+"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding chain: Pryzm
Adding token: OSMO Yield LP
See the [token](https://app.pryzm.zone/tokens/lp%3A8%3Auosmo?mode=normal) and the [pool](https://app.pryzm.zone/pools/8)

## Checklist

<!-- The following checklist can be ticked after Creating the PR -->

### Adding Assets

<!-- If NOT adding a new asset, please remove this 'Adding Chains' section. -->
If adding a new asset, please ensure the following:
- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (unless native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [x] `listing_date_time_utc` is specified and accurate
   - [x] Optional: `transfer_methods`, `peg_mechanism`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

<!-- If NOT adding a new chain, please remove this 'Adding Chains' section. -->
If adding a new chain, please ensure the following:
- [x] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - Chain's registration must have `staking` defined, with at least one `staking_token` denom specified.
   - Chain's registration must have `fees` defined; at least one fee token has low, average, and high gas prices defined.
- [x] IBC Connection between chain and Osmosis is registered.
- [x] Add chain to bottom of `zone_chains.json`
   - [x] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [x] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.


