### PR TITLE
Make $STOS Visible

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5271,8 +5271,7 @@
       "base_denom": "wei",
       "path": "transfer/channel-81016/wei",
       "osmosis_verified": false,
-      "osmosis_unlisted": true,
-      "listing_date_time_utc": "2024-10-20T12:00:00Z",
+      "listing_date_time_utc": "2024-10-16T18:00:00Z",
       "_comment": "Stratos native token (STOS)"
     },
     {


### PR DESCRIPTION
## Description

Make $STOS Visible
because it cannot be verified while it's untradeable