### PR TITLE
Add DGN and Dungeonchain to osmosis assetlist

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5613,8 +5613,8 @@
     {
       "chain_name": "dungeon",
       "base_denom": "udgn",
-      "twitter_URL": "https://x.com/cryptodungeonma",
       "path": "transfer/channel-85791/udgn",
       "osmosis_verified": false,
-      "osmosis_unlisted": true
+      "osmosis_unlisted": true,
+      "_comment": "Dungeon $DGN"
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5616,6 +5616,5 @@
       "twitter_URL": "https://x.com/cryptodungeonma",
       "path": "transfer/channel-85791/udgn",
       "osmosis_verified": false,
-      "osmosis_unlisted": false
-  ]
+      "osmosis_unlisted": true
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5617,4 +5617,6 @@
       "osmosis_verified": false,
       "osmosis_unlisted": true,
       "_comment": "Dungeon $DGN"
+    }
+  ]
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5609,6 +5609,13 @@
       "path": "transfer/channel-199/factory/omniflix1fwphj5p6qd8gtkehkzfgac38eur4uqzgz97uwvf6hsc0vjl004gqfj0xnv/ygata",
       "osmosis_verified": false,
       "_comment": "GATA Yield DAO $YGATA"
-    }
+    },
+    {
+      "chain_name": "dungeon",
+      "base_denom": "udgn",
+      "twitter_URL": "https://x.com/cryptodungeonma",
+      "path": "transfer/channel-85791/udgn",
+      "osmosis_verified": false,
+      "osmosis_unlisted": false
   ]
 }

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1461,6 +1461,16 @@
       "keplr_features": [
         "ibc-transfer"
       ]
+      },
+    {
+      "chain_name": "dungeon",
+      "rpc": "https://rpc-dungeonchain.apeironnodes.com",
+      "rest": "https://api-dungeonchain.apeironnodes.com",
+      "explorer_tx_url": "https://ping.pub/Dungeomchain/tx/${txHash}",
+      "keplr_features": [
+        "ibc-go",
+        "ibc-transfer"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Adding Assets
- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [x] Optional: `transfer_methods`, `peg_mechanism`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

<!-- If NOT adding a new chain, please remove this 'Adding Chains' section. -->
If adding a new chain, please ensure the following:
- [x] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - Chain's registration must have `staking` defined, with at least one `staking_token` denom specified.
   - Chain's registration must have `fees` defined; at least one fee token has low, average, and high gas prices defined.
- [x] IBC Connection between chain and Osmosis is registered.
- [x] Add chain to bottom of `zone_chains.json`
   - [x] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [x] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.
