### PR TITLE
Adjust CoinGecko Query Params

### DIFF
--- a/.github/workflows/utility/generateCoinGeckoUpdates.mjs
+++ b/.github/workflows/utility/generateCoinGeckoUpdates.mjs
@@ -23,9 +23,9 @@ const stateFileName = "state.json";
 const coinGeckoDirName = "coingecko";
 const coinGeckoDir = path.join(zone.externalDir, coinGeckoDirName);
 
-const numberOfUnseenAssetsToQuery = 50;
-const numberOfPendingAssetsToCheck = 0;
-const querySleepTime = 20000;
+const numberOfUnseenAssetsToQuery = 3;
+const numberOfPendingAssetsToCheck = 1;
+const querySleepTime = 2000;
 
 async function queryCoinGeckoId(id) {
   const coinGeckoAPI = "https://api.coingecko.com/api/v3/coins/";


### PR DESCRIPTION
## Description

Adjust CoinGecko Query Params

so that it only queries 3 new assets and 1 pending asset