### PR TITLE
Add Localization Workflow to the Generate All Action

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Run code to Generate Zone Assets Comments
         working-directory: ./.github/workflows/utility
         run: node generateComments.mjs
+
+      - name: Run localization
+        working-directory: ./.github/workflows/utility
+        run: npx pnpm inlang machine translate --force
+
+      - name: Run post-localization code
+        working-directory: ./.github/workflows/utility
+        run: node localization_post.mjs
       
       - name: Add Commit Push
         uses: devops-infra/action-commit-push@master


### PR DESCRIPTION
## Description

Add Localization Workflow to the Generate All Action
so that we don't need to trigger a separate localization worflow after the 'generate_al' workflow; might as well do it all at the same time.