### PR TITLE
Update Coreum bridge URL

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3563,8 +3563,8 @@
         {
           "name": "Sologenic Coreum Bridge",
           "type": "external_interface",
-          "deposit_url": "https://sologenic.org/bridge",
-          "withdraw_url": "https://sologenic.org/bridge"
+          "deposit_url": "https://sologenic.org/bridge/coreum-bridge",
+          "withdraw_url": "https://sologenic.org/bridge/coreum-bridge"
         }
       ],
       "_comment": "Ripple (Coreum) $XRP.core"

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3563,8 +3563,8 @@
         {
           "name": "Sologenic Coreum Bridge",
           "type": "external_interface",
-          "deposit_url": "https://sologenic.org/coreum-bridge",
-          "withdraw_url": "https://sologenic.org/coreum-bridge"
+          "deposit_url": "https://sologenic.org/bridge",
+          "withdraw_url": "https://sologenic.org/bridge"
         }
       ],
       "_comment": "Ripple (Coreum) $XRP.core"


### PR DESCRIPTION
## Description
https://sologenic.org/coreum-bridge was used previously, this returns 404

https://sologenic.org/bridge works on Firefox, but errors on Chrome. Reported to team but best interface currently.

https://sologenic.org/bridge/coreum-bridge goes directly to the IBC bridge