### PR TITLE
Remove unlisted for MOBX

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5801,7 +5801,6 @@
       "_comment": "Toncoin (Int3) $TON.int3"
     },
     {
-      "osmosis_unlisted": true,
       "chain_name": "fetchhub",
       "base_denom": "nanomobx",
       "path": "transfer/channel-229/nanomobx",


### PR DESCRIPTION
We accidentally left the boolean unlisted as "true".  We're correcting this now so that we can access the asset in the UI and open a pool.