### PR TITLE
Set REBUS to Unstable

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1278,6 +1278,7 @@
       "base_denom": "arebus",
       "path": "transfer/channel-355/arebus",
       "osmosis_verified": false,
+      "osmosis_unstable": true,
       "_comment": "Rebus $REBUS"
     },
     {


### PR DESCRIPTION
## Description

Set REBUS to Unstable
because the IBC client has expired.