### PR TITLE
Add Chihuahua coin $CHIHUAHUA on osmosis.zone

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5844,6 +5844,14 @@
       "path": "transfer/channel-91254/uaaron",
       "osmosis_verified": false,
       "_comment": "Aaron Network $AARON"
+    },
+	  {
+     "chain_name": "chihuahua",
+     "base_denom": "factory/chihuahua1mzcfzh4ufk2cta59pm9a6wdyvv8c4v5epqzj46/Chihuahua",
+     "path": "transfer/channel-113/factory/chihuahua1mzcfzh4ufk2cta59pm9a6wdyvv8c4v5epqzj46/Chihuahua",
+     "osmosis_verified": false,
+     "categories": ["meme"],
+     "_comment": "Chihuahua coin $CHIHUAHUA"
     }
   ]
 }


### PR DESCRIPTION
On branch add_CHIHUAHUA_coin
Changes to be committed:
modified:   osmosis-1/osmosis.zone_assets.json

## Description

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->

## Checklist

<!-- The following checklist can be ticked after Creating the PR -->

### Adding Assets

<!-- If NOT adding a new asset, please remove this 'Adding Chains' section. -->
If adding a new asset, please ensure the following:
- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [x] Optional: `transfer_methods`, `peg_mechanism`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

<!-- If NOT adding a new chain, please remove this 'Adding Chains' section. -->
If adding a new chain, please ensure the following:
- [x] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - Chain's registration must have `staking` defined, with at least one `staking_token` denom specified.
   - Chain's registration must have `fees` defined; at least one fee token has low, average, and high gas prices defined.
- [x] IBC Connection between chain and Osmosis is registered.
- [x] Add chain to bottom of `zone_chains.json`
   - [x] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [x] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.
