### PR TITLE
Fix URL Link and Typo Corrections in Documentation

### DIFF
--- a/LISTING.md
+++ b/LISTING.md
@@ -69,7 +69,7 @@ To propose that an asset should be upgraded to Verified status, please submit a 
 
 ### Full Integration for Best Experience (recommended)
 
-Osmosis Frontend aims to foster a polished and complete user experience when users intereact with an asset. This is best provided when the asset has all metadata registered correctly and thoroughly, as well as be recognized by key external interfaces, and have sufficient and efficient liquidity on Osmosis.
+Osmosis Frontend aims to foster a polished and complete user experience when users interact with an asset. This is best provided when the asset has all metadata registered correctly and thoroughly, as well as be recognized by key external interfaces, and have sufficient and efficient liquidity on Osmosis.
 
 Registered Asset Metadata at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry):
  - The correct `coingecko_id`:
@@ -91,7 +91,7 @@ Integrations with Key Apps:
    - Celatone (Assets are added at [Celatone's Data Repository](https://github.com/alleslabs/aldus/blob/main/data/assets.json))
  - Recognition by key Data Aggregators:
    - CoinGecko (See: [How to list new Cryptocurrencies on CoinGecko](https://support.coingecko.com/hc/en-us/articles/7291312302617-How-to-list-new-cryptocurrencies-on-CoinGecko))
-     - Has Price, Supply, and Market Capitzalization Data
+     - Has Price, Supply, and Market Capitalization Data
      - Includes Osmosis Market(s)
        - I.E., Osmosis Pools containing the asset should be discoverable from the asset's CoinGecko page. E.G.:
          ![image](https://github.com/JeremyParish69/assetlists/assets/95667791/34ea402b-1a0f-4e43-9bfc-b750c9ab9430)

--- a/LISTING.md
+++ b/LISTING.md
@@ -87,7 +87,7 @@ Registered Asset Metadata at the [Cosmos Chain Registry](https://github.com/cosm
 
 Integrations with Key Apps:
  - Recognition by key Block Explorers:
-   - Mintscan (Assets are added at [Cosmostation's Chainlist](https://github.com/cosmostation/chainlist/blob/main/chain/osmosis/assets.json))
+   - Mintscan (Assets are added at [Cosmostation's Chainlist](https://github.com/cosmostation/chainlist/blob/main/chain/osmosis/assets_2.json))
    - Celatone (Assets are added at [Celatone's Data Repository](https://github.com/alleslabs/aldus/blob/main/data/assets.json))
  - Recognition by key Data Aggregators:
    - CoinGecko (See: [How to list new Cryptocurrencies on CoinGecko](https://support.coingecko.com/hc/en-us/articles/7291312302617-How-to-list-new-cryptocurrencies-on-CoinGecko))

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5841,7 +5841,7 @@
     {
       "chain_name": "aaronetwork",
       "base_denom": "uaaron",
-      "path": "transfer/channel-91254/uaaron",
+      "path": "transfer/channel-91942/uaaron",
       "osmosis_verified": false,
       "_comment": "Aaron Network $AARON"
     },


### PR DESCRIPTION
### 1. URL Update for Mintscan Assets:

Before:
(https://github.com/cosmostation/chainlist/blob/main/chain/osmosis/assets.json))
After:
( https://github.com/cosmostation/chainlist/blob/main/chain/osmosis/assets_2.json ))
Reason: Updated the link to correctly point to assets_2.json instead of assets.json, ensuring the documentation reflects the accurate resource.

### Corrected two typographical errors::
**intereact - interact
Capitzalization - Capitalization**
