### PR TITLE
Fix AtomOne REST endpoint + use Mintscan explorer

### DIFF
--- a/osmosis-1/osmosis-1.chainlist.json
+++ b/osmosis-1/osmosis-1.chainlist.json
@@ -9431,13 +9431,13 @@
         ],
         "rest": [
           {
-            "address": "https://atomone-grpc.allinbits.com"
+            "address": "https://atomone-api.allinbits.com"
           }
         ]
       },
       "explorers": [
         {
-          "tx_page": "https://explorer.allinbits.com/atomone/tx/${txHash}"
+          "tx_page": "https://www.mintscan.com/atomone/tx/${txHash}"
         }
       ],
       "logoURIs": {

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1236,7 +1236,7 @@
       "keplr_features": [
         "ibc-transfer",
         "ibc-go"
-        ]
+      ]
     },
     {
       "chain_name": "aioz",
@@ -1267,10 +1267,10 @@
       "rest": "https://rest.cvn.io:443",
       "explorer_tx_url": "https://ping.pub/conscious/tx/${txHash}",
       "keplr_features": [
-          "ibc-transfer",
-          "ibc-go",
-          "eth-address-gen",
-          "eth-key-sign"
+        "ibc-transfer",
+        "ibc-go",
+        "eth-address-gen",
+        "eth-key-sign"
       ]
     },
     {
@@ -1410,7 +1410,7 @@
       "rest": "https://api.kima.network/",
       "explorer_tx_url": "https://explorer.kima.network/transactions/${txHash}",
       "keplr_features": [
-        "ibc-go", 
+        "ibc-go",
         "ibc-transfer"
       ]
     },
@@ -1460,12 +1460,12 @@
     {
       "chain_name": "atomone",
       "rpc": "https://atomone-rpc.allinbits.com",
-      "rest": "https://atomone-grpc.allinbits.com",
-      "explorer_tx_url": "https://explorer.allinbits.com/atomone/tx/${txHash}",
+      "rest": "https://atomone-api.allinbits.com",
+      "explorer_tx_url": "https://www.mintscan.com/atomone/tx/${txHash}",
       "keplr_features": [
         "ibc-transfer"
       ]
-      },
+    },
     {
       "chain_name": "dungeon",
       "rpc": "https://dungeon-wallet.rpc.quasarstaking.ai",


### PR DESCRIPTION
## Description

For some reason, the GRPC server was previously entered as REST endpoint.
Fixing this issue so that Deposit works on Osmosis.

Also, using preferred Mintscan explorer.