### PR TITLE
Add recent qassets to Osmosis

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5939,6 +5939,66 @@
         "defi"
       ],
       "_comment": "Kopi $XKP"
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "aqarch",
+      "path": "transfer/channel-522/aqarch",
+      "osmosis_verified": false,
+      "categories": [
+        "liquid_staking"
+      ],
+      "_comment": "Quicksilver Liquid Staked ARCH $qARCH"
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "pqpica",
+      "path": "transfer/channel-522/pqpica",
+      "osmosis_verified": false,
+      "categories": [
+        "liquid_staking"
+      ],
+      "_comment": "Quicksilver Liquid Staked PICA $qPICA"
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqtia",
+      "path": "transfer/channel-522/uqtia",
+      "osmosis_verified": false,
+      "categories": [
+        "liquid_staking"
+      ],
+      "_comment": "Quicksilver Liquid Staked TIA $qTIA"
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqflix",
+      "path": "transfer/channel-522/uqflix",
+      "osmosis_verified": false,
+      "categories": [
+        "liquid_staking"
+      ],
+      "_comment": "Quicksilver Liquid Staked FLIX $qFLIX"
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "uqluna",
+      "path": "transfer/channel-522/uqluna",
+      "osmosis_verified": false,
+      "categories": [
+        "liquid_staking"
+      ],
+      "_comment": "Quicksilver Liquid Staked LUNA $qLUNA"
+    },
+    {
+      "chain_name": "quicksilver",
+      "base_denom": "qinj",
+      "path": "transfer/channel-522/qinj",
+      "osmosis_verified": false,
+      "categories": [
+        "liquid_staking"
+      ],
+      "_comment": "Quicksilver Liquid Staked INJ $qINJ"
     }
   ]
 }


### PR DESCRIPTION


## Description

Add Quicksilver LSTs qTIA, qARCH, qFLIX, qLUNA, qINJ and qPICA to Osmosis.

## Checklist

### Adding Assets

If adding a new asset, please ensure the following:
- [PR - not yet merged] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [x] Optional: `transfer_methods`, `peg_mechanism`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

