### PR TITLE
Revert "Update Passage Nodes (back to Vitwit)"

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -986,8 +986,8 @@
     },
     {
       "chain_name": "passage",
-      "rpc": "https://rpc.passage.vitwit.com",
-      "rest": "https://api.passage.vitwit.com",
+      "rpc": "https://passage-rpc.staketab.org:443",
+      "rest": "https://rest-passage.ecostake.com",
       "explorer_tx_url": "https://www.mintscan.io/passage/transactions/${txHash}",
       "keplr_features": [
         "ibc-transfer",


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#2178

Turns out Vitwit's isn't working