### PR TITLE
Revert "Update DYDX, FET, AIOZ IBC tokens as local ibc assets"

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -588,8 +588,8 @@
       "_comment": "Cerberus $CRBRUS"
     },
     {
-      "chain_name": "osmosis",
-      "base_denom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+      "chain_name": "fetchhub",
+      "base_denom": "afet",
       "path": "transfer/channel-229/afet",
       "osmosis_verified": true,
       "categories": [
@@ -2809,8 +2809,8 @@
       "_comment": "Celestia $TIA"
     },
     {
-      "chain_name": "osmosis",
-      "base_denom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
+      "chain_name": "dydx",
+      "base_denom": "adydx",
       "path": "transfer/channel-6787/adydx",
       "osmosis_verified": true,
       "override_properties": {
@@ -3496,8 +3496,8 @@
       "_comment": "Basket $BSKT"
     },
     {
-      "chain_name": "osmosis",
-      "base_denom": "ibc/BB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F",
+      "chain_name": "aioz",
+      "base_denom": "attoaioz",
       "path": "transfer/channel-779/attoaioz",
       "osmosis_verified": true,
       "transfer_methods": [


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#2227


The last PR caused build errors. The chains in the chainlist still need valid currecies, and somehow that change removed the coin minimal denoms. 