### PR TITLE
Upgrade NBZ to Verified - fix

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5877,7 +5877,7 @@
       "chain_name": "injective",
       "base_denom": "factory/inj1llr45x92t7jrqtxvc02gpkcqhqr82dvyzkr4mz/NBZ",
       "path": "transfer/channel-122/factory/inj1llr45x92t7jrqtxvc02gpkcqhqr82dvyzkr4mz/NBZ",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "categories": [
         "gaming"
       ],

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5886,7 +5886,7 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo10c4y9csfs8q7mtvfg4p9gd8d0acx0hpc2mte9xqzthd7rd3348tsfhaesm/dogecoin-native-DOGE",
-      "osmosis_verified": true,
+      "osmosis_verified": false,
       "transfer_methods": [
         {
           "name": "Omnity Bridge",


### PR DESCRIPTION
This PR is related to: https://github.com/osmosis-labs/assetlists/pull/2239 and commits:
https://github.com/osmosis-labs/assetlists/commit/f7a996297bcf9c389f538b4af19457f61432ffcf

In the previous PR, I mistakenly marked the wrong token as verified. This PR corrects the mistake by:

Marking the correct token as verified.
Reverting the mistakenly verified token to its original state.
