### PR TITLE
Update Side Chain Fees to put `sat` first

### DIFF
--- a/osmosis-1/osmosis-1.chainlist.json
+++ b/osmosis-1/osmosis-1.chainlist.json
@@ -10322,18 +10322,18 @@
       "fees": {
         "fee_tokens": [
           {
-            "denom": "uside",
-            "fixed_min_gas_price": 0.0006,
-            "low_gas_price": 0.0006,
-            "average_gas_price": 0.0008,
-            "high_gas_price": 0.001
-          },
-          {
             "denom": "sat",
             "fixed_min_gas_price": 0.000001,
             "low_gas_price": 0.000001,
             "average_gas_price": 0.0000015,
             "high_gas_price": 0.000002
+          },
+          {
+            "denom": "uside",
+            "fixed_min_gas_price": 0.0006,
+            "low_gas_price": 0.0006,
+            "average_gas_price": 0.0008,
+            "high_gas_price": 0.001
           }
         ]
       },


### PR DESCRIPTION
## Description

Update Side Chain Fees to put `sat` first
Currently tRPC cannot seem to find sufficient alternative balance for tx fees, but the fees are there onchain. I suspect that the D/W flow needs to default fee to be working, and then it can be changes to an alternative in the wallet, but since SIDE, the current default has no price, there is no resolution of fees.