### PR TITLE
Remove DYDX and FET from New Assets

### DIFF
--- a/osmosis-1/generated/state/state.json
+++ b/osmosis-1/generated/state/state.json
@@ -1098,11 +1098,11 @@
     },
     {
       "base_denom": "factory/osmo1zem8r6dv6u38f6qpg546zy30946av8h5srgug0s4gcyy6cfecf3seac083/alloyed/allDYDX",
-      "listingDate": "2025-03-01T06:38:34.907Z"
+      "legacy_asset": true
     },
     {
       "base_denom": "factory/osmo1mdvn6lmykp2z345ncpf647dztslyll8cyhwj9pltrc0lf7nva3cqvrp6qs/alloyed/allFET",
-      "listingDate": "2025-03-01T06:38:34.907Z"
+      "legacy_asset": true
     }
   ],
   "chains": [


### PR DESCRIPTION
## Description

Remove DYDX and FET from New Assets
Removed the listing date, and changed them to legacyAsset (which matches FET and DYDX ibc assets)