### PR TITLE
add manifest testnet and manifest token MFX to asset list and chain config

### DIFF
--- a/osmo-test-5/osmo-test-5.chainlist.json
+++ b/osmo-test-5/osmo-test-5.chainlist.json
@@ -114,9 +114,7 @@
           "tx_page": "https://mintscan.io/osmosis-testnet/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer"
-      ]
+      "features": ["ibc-transfer"]
     },
     {
       "chain_name": "junotestnet",
@@ -168,12 +166,7 @@
           "tx_page": "https://mintscan.io/juno-testnet/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer",
-        "ibc-go",
-        "cosmwasm",
-        "wasmd_0.24+"
-      ]
+      "features": ["ibc-transfer", "ibc-go", "cosmwasm", "wasmd_0.24+"]
     },
     {
       "chain_name": "marstestnet",
@@ -230,10 +223,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-icon.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-icon.svg"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "axelartestnet",
@@ -285,11 +275,7 @@
           "tx_page": "https://testnet.axelarscan.io/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer",
-        "ibc-go",
-        "axelar-evm-bridge"
-      ]
+      "features": ["ibc-transfer", "ibc-go", "axelar-evm-bridge"]
     },
     {
       "chain_name": "nobletestnet",
@@ -345,10 +331,7 @@
           "tx_page": "https://mintscan.io/noble-testnet/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "akashtestnet",
@@ -405,10 +388,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "kyvetestnet",
@@ -461,10 +441,7 @@
           "tx_page": "https://mintscan.io/kyve-testnet/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "quicksilvertestnet",
@@ -519,10 +496,7 @@
       "logoURIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.svg"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "chain4energytestnet",
@@ -578,10 +552,7 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/chain4energytestnet/images/c4e.png"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "composabletestnet",
@@ -634,10 +605,7 @@
           "tx_page": "https://explorer.nodexcapital.com/composable-3/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "persistencetestnet2",
@@ -693,10 +661,7 @@
           "tx_page": "https://mintscan.io/persistence-testnet/tx/${txHash}"
         }
       ],
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "xiontestnet",
@@ -753,10 +718,7 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt.png"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "sagatestnet",
@@ -812,10 +774,7 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga.png"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "impacthubtestnet",
@@ -872,10 +831,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.svg"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go"
-      ]
+      "features": ["ibc-transfer", "ibc-go"]
     },
     {
       "chain_name": "archwaytestnet",
@@ -931,11 +887,7 @@
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/archwaytestnet/images/ArchwayBrandmark.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/archwaytestnet/images/ArchwayBrandmark.svg"
       },
-      "features": [
-        "ibc-transfer",
-        "ibc-go",
-        "cosmwasm"
-      ]
+      "features": ["ibc-transfer", "ibc-go", "cosmwasm"]
     },
     {
       "chain_name": "symphonytestnet",
@@ -991,12 +943,7 @@
       "logoURIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/symphonytestnet/images/symphony_logo.png"
       },
-      "features": [
-        "ibc-go",
-        "ibc-transfer",
-        "cosmwasm",
-        "wasmd_0.24+"
-      ]
+      "features": ["ibc-go", "ibc-transfer", "cosmwasm", "wasmd_0.24+"]
     },
     {
       "chain_name": "kimanetworktestnet",
@@ -1052,10 +999,7 @@
           "tx_page": "https://explorer-testnet.kima.finance/transactions/${txHash}"
         }
       ],
-      "features": [
-        "ibc-go",
-        "ibc-transfer"
-      ]
+      "features": ["ibc-go", "ibc-transfer"]
     },
     {
       "chain_name": "nomictestnet",
@@ -1124,10 +1068,60 @@
           "primary_color_hex": "#6404fc"
         }
       },
-      "features": [
-        "ibc-go",
-        "ibc-transfer"
-      ]
+      "features": ["ibc-go", "ibc-transfer"]
+    },
+    {
+      "chainId": "manifest-ledger-testnet",
+      "chainName": "Manifest Testnet",
+      "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/manifest-ledger-testnet/chain.png",
+      "rpc": "https://nodes.liftedinit.tech/manifest/testnet/rpc",
+      "rest": "https://nodes.liftedinit.tech/manifest/testnet/api",
+      "nodeProvider": {
+        "name": "Lifted Initiative",
+        "email": "infra@liftedinit.org",
+        "website": "https://liftedinit.org/"
+      },
+      "bip44": {
+        "coinType": 118
+      },
+      "bech32Config": {
+        "bech32PrefixAccAddr": "manifest",
+        "bech32PrefixAccPub": "manifestpub",
+        "bech32PrefixValAddr": "manifestvaloper",
+        "bech32PrefixValPub": "manifestvaloperpub",
+        "bech32PrefixConsAddr": "manifestvalcons",
+        "bech32PrefixConsPub": "manifestvalconspub"
+      },
+      "currencies": [
+        {
+          "coinDenom": "MFX",
+          "coinMinimalDenom": "umfx",
+          "coinDecimals": 6
+        },
+        {
+          "coinDenom": "POA",
+          "coinMinimalDenom": "upoa",
+          "coinDecimals": 6
+        }
+      ],
+      "feeCurrencies": [
+        {
+          "coinDenom": "MFX",
+          "coinMinimalDenom": "umfx",
+          "coinDecimals": 6,
+          "gasPriceStep": {
+            "low": 0.01,
+            "average": 0.025,
+            "high": 0.03
+          }
+        }
+      ],
+      "stakeCurrency": {
+        "coinDenom": "POA",
+        "coinMinimalDenom": "upoa",
+        "coinDecimals": 6
+      },
+      "features": ["ibc-go", "ibc-transfer", "cosmwasm", "wasmd_0.24+"]
     }
   ]
 }

--- a/osmo-test-5/osmo-test-5.chainlist.json
+++ b/osmo-test-5/osmo-test-5.chainlist.json
@@ -1069,59 +1069,6 @@
         }
       },
       "features": ["ibc-go", "ibc-transfer"]
-    },
-    {
-      "chainId": "manifest-ledger-testnet",
-      "chainName": "Manifest Testnet",
-      "chainSymbolImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/manifest-ledger-testnet/chain.png",
-      "rpc": "https://nodes.liftedinit.tech/manifest/testnet/rpc",
-      "rest": "https://nodes.liftedinit.tech/manifest/testnet/api",
-      "nodeProvider": {
-        "name": "Lifted Initiative",
-        "email": "infra@liftedinit.org",
-        "website": "https://liftedinit.org/"
-      },
-      "bip44": {
-        "coinType": 118
-      },
-      "bech32Config": {
-        "bech32PrefixAccAddr": "manifest",
-        "bech32PrefixAccPub": "manifestpub",
-        "bech32PrefixValAddr": "manifestvaloper",
-        "bech32PrefixValPub": "manifestvaloperpub",
-        "bech32PrefixConsAddr": "manifestvalcons",
-        "bech32PrefixConsPub": "manifestvalconspub"
-      },
-      "currencies": [
-        {
-          "coinDenom": "MFX",
-          "coinMinimalDenom": "umfx",
-          "coinDecimals": 6
-        },
-        {
-          "coinDenom": "POA",
-          "coinMinimalDenom": "upoa",
-          "coinDecimals": 6
-        }
-      ],
-      "feeCurrencies": [
-        {
-          "coinDenom": "MFX",
-          "coinMinimalDenom": "umfx",
-          "coinDecimals": 6,
-          "gasPriceStep": {
-            "low": 0.01,
-            "average": 0.025,
-            "high": 0.03
-          }
-        }
-      ],
-      "stakeCurrency": {
-        "coinDenom": "POA",
-        "coinMinimalDenom": "upoa",
-        "coinDecimals": 6
-      },
-      "features": ["ibc-go", "ibc-transfer", "cosmwasm", "wasmd_0.24+"]
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -159,6 +159,13 @@
           }
         }
       }
+    },
+    {
+      "chain_name": "manifesttestnet",
+      "base_denom": "umfx",
+      "path": "transfer/channel-10183/umfx",
+      "osmosis_verified": false,
+      "_comment": "Manifest Testnet $MFX"
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone_chains.json
+++ b/osmo-test-5/osmosis.zone_chains.json
@@ -6,7 +6,13 @@
       "rpc": "https://rpc.osmotest5.osmosis.zone/",
       "rest": "https://lcd.osmotest5.osmosis.zone/",
       "explorer_tx_url": "https://mintscan.io/osmosis-testnet/tx/${txHash}",
-      "keplr_features": ["ibc-go", "ibc-transfer", "cosmwasm", "wasmd_0.24+", "osmosis-txfees"]
+      "keplr_features": [
+        "ibc-go",
+        "ibc-transfer",
+        "cosmwasm",
+        "wasmd_0.24+",
+        "osmosis-txfees"
+      ]
     },
     {
       "chain_name": "cosmoshubtestnet",
@@ -133,6 +139,13 @@
       "rest": "https://testnet-api.nomic.io:8443",
       "explorer_tx_url": "https://${txHash}",
       "keplr_features": ["ibc-go", "ibc-transfer"]
+    },
+    {
+      "chain_name": "manifesttestnet",
+      "rpc": "https://nodes.liftedinit.tech/manifest/testnet/rpc",
+      "rest": "https://nodes.liftedinit.tech/manifest/testnet/api",
+      "explorer_tx_url": "https://testnet.manifest.explorers.guru/transactions/${txHash}",
+      "keplr_features": ["ibc-go", "ibc-transfer", "cosmwasm", "wasmd_0.24+"]
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding chain: Manifest Testnet
Adding token: MFX from chain Manifest Testnet
See MFX/OSMO Pool 920
See MFX/USDC Pool 919

## Checklist

### Adding Assets

If adding a new asset, please ensure the following:
- [X] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [X] Add asset to bottom of `zone_assets.json`.
   - [X] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [X] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [X] `osmosis_verified` is set to `false`
   - [X] Optional: `transfer_methods`, `peg_mechanism`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [X] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

If adding a new chain, please ensure the following:
- [X] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - Chain's registration must have `staking` defined, with at least one `staking_token` denom specified.
   - Chain's registration must have `fees` defined; at least one fee token has low, average, and high gas prices defined.
- [X] IBC Connection between chain and Osmosis is registered.
- [X] Add chain to bottom of `zone_chains.json`
   - [X] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [X] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.

