### PR TITLE
Re-add MARS

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1644,13 +1644,15 @@
       "_comment": "USD Coin (Avalanche) $USDC.avax.axl"
     },
     {
-      "chain_name": "osmosis",
-      "base_denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+      "chain_name": "mars",
+      "base_denom": "umars",
+      "path": "transfer/channel-557/umars",
       "osmosis_verified": true,
       "categories": [
         "defi",
         "built_on_osmosis"
       ],
+      "osmosis_disabled": true,
       "_comment": "Mars Protocol token (Mars Hub) $MARS.mars"
     },
     {


### PR DESCRIPTION
## Description

because it's needed as a currency for wallets that add Mars Hub