### PR TITLE
add Dungeon DGN token

### DIFF
--- a/osmosis-1/osmosis-1.chainlist.json
+++ b/osmosis-1/osmosis-1.chainlist.json
@@ -9981,55 +9981,6 @@
       ]
     },
     {
-      "chain_name": "dungeon",
-      "status": "live",
-      "network_type": "mainnet",
-      "pretty_name": "Dungeon Chain",
-      "chain_id": "dungeon-1",
-      "bech32_prefix": "dungeon",
-      "bech32_config": {
-        "bech32PrefixAccAddr": "dungeon",
-        "bech32PrefixAccPub": "dungeonpub",
-        "bech32PrefixValAddr": "dungeonvaloper",
-        "bech32PrefixValPub": "dungeonvaloperpub",
-        "bech32PrefixConsAddr": "dungeonvalcons",
-        "bech32PrefixConsPub": "dungeonvalconspub"
-      },
-      "slip44": 118,
-      "fees": {
-        "fee_tokens": [
-          {
-            "denom": "udgn",
-            "fixed_min_gas_price": 0.05,
-            "low_gas_price": 0.05,
-            "average_gas_price": 0.07,
-            "high_gas_price": 0.09
-          }
-        ]
-      },
-      "apis": {
-        "rpc": [
-          {
-            "address": "https://dungeon-wallet.rpc.quasarstaking.ai"
-          }
-        ],
-        "rest": [
-          {
-            "address": "https://dungeon-wallet.api.quasarstaking.ai"
-          }
-        ]
-      },
-      "explorers": [
-        {
-          "tx_page": "https://ping.pub/Dungeonchain/tx/${txHash}"
-        }
-      ],
-      "features": [
-        "ibc-go",
-        "ibc-transfer"
-      ]
-    },
-    {
       "chain_name": "synternet",
       "status": "live",
       "network_type": "mainnet",

--- a/osmosis-1/osmosis-1.chainlist.json
+++ b/osmosis-1/osmosis-1.chainlist.json
@@ -9981,6 +9981,55 @@
       ]
     },
     {
+      "chain_name": "dungeon",
+      "status": "live",
+      "network_type": "mainnet",
+      "pretty_name": "Dungeon Chain",
+      "chain_id": "dungeon-1",
+      "bech32_prefix": "dungeon",
+      "bech32_config": {
+        "bech32PrefixAccAddr": "dungeon",
+        "bech32PrefixAccPub": "dungeonpub",
+        "bech32PrefixValAddr": "dungeonvaloper",
+        "bech32PrefixValPub": "dungeonvaloperpub",
+        "bech32PrefixConsAddr": "dungeonvalcons",
+        "bech32PrefixConsPub": "dungeonvalconspub"
+      },
+      "slip44": 118,
+      "fees": {
+        "fee_tokens": [
+          {
+            "denom": "udgn",
+            "fixed_min_gas_price": 0.05,
+            "low_gas_price": 0.05,
+            "average_gas_price": 0.07,
+            "high_gas_price": 0.09
+          }
+        ]
+      },
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://dungeon-wallet.rpc.quasarstaking.ai"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://dungeon-wallet.api.quasarstaking.ai"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "tx_page": "https://ping.pub/Dungeonchain/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "ibc-transfer"
+      ]
+    },
+    {
       "chain_name": "synternet",
       "status": "live",
       "network_type": "mainnet",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5718,6 +5718,13 @@
       "base_denom": "udgn",
       "path": "transfer/channel-85791/udgn",
       "osmosis_verified": true,
+      "_comment": "OLD Dragon Coin (Dungeon Chain) $DGN.dungeon"
+    },
+    {
+      "chain_name": "dungeon",
+      "base_denom": "udgn",
+      "path": "transfer/channel-101249/udgn",
+      "osmosis_verified": false,
       "_comment": "Dragon Coin (Dungeon Chain) $DGN.dungeon"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5718,14 +5718,22 @@
       "base_denom": "udgn",
       "path": "transfer/channel-85791/udgn",
       "osmosis_verified": true,
-      "_comment": "OLD Dragon Coin (Dungeon Chain) $DGN.dungeon"
+      "override_properties": {
+        "name": "Dragon Coin (old)",
+        "symbol": "DGN.old"
+      },
+      "_comment": "Dragon Coin (old) $DGN.old"
     },
     {
       "chain_name": "dungeon",
       "base_denom": "udgn",
       "path": "transfer/channel-101249/udgn",
       "osmosis_verified": false,
-      "_comment": "Dragon Coin (Dungeon Chain) $DGN.dungeon"
+      "override_properties": {
+        "name": "Dragon Coin",
+        "symbol": "DGN"
+      },
+      "_comment": "Dragon Coin (Dungeon Chain) $DGN"
     },
     {
       "chain_name": "synternet",

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1477,6 +1477,16 @@
       ]
     },
     {
+      "chain_name": "dungeon",
+      "rpc": "https://dungeon-wallet.rpc.quasarstaking.ai",
+      "rest": "https://dungeon-wallet.api.quasarstaking.ai",
+      "explorer_tx_url": "https://ping.pub/Dungeonchain/tx/${txHash}",
+      "keplr_features": [
+        "ibc-go",
+        "ibc-transfer"
+      ]
+    },
+    {
       "chain_name": "synternet",
       "rpc": "https://rpc.synternet.com",
       "rest": "https://api.synternet.com",


### PR DESCRIPTION
## Description

<!-- Please specify added token and its corresponding chain. (recommended one token at a time) -->
<!-- E.g., Adding chain: Bar  -->
<!-- E.g., Adding token: FOO from chain Bar  -->
<!-- E.g., See FOO/OSMO Pool 1000 -->

## Checklist

<!-- The following checklist can be ticked after Creating the PR -->

### Adding Assets

<!-- If NOT adding a new asset, please remove this 'Adding Chains' section. -->
If adding a new asset, please ensure the following:
- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [ ] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [x] Optional: `transfer_methods`, `peg_mechanism`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

<!-- If NOT adding a new chain, please remove this 'Adding Chains' section. -->
If adding a new chain, please ensure the following:
- [x] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - Chain's registration must have `staking` defined, with at least one `staking_token` denom specified.
   - Chain's registration must have `fees` defined; at least one fee token has low, average, and high gas prices defined.
- [x] IBC Connection between chain and Osmosis is registered.
- [ ] Add chain to bottom of `zone_chains.json`
   - [x] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [x] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.


