### PR TITLE
Verify DYM, POL, MOVE, MOVE.eth.axl

### DIFF
--- a/osmosis-1/generated/state/state.json
+++ b/osmosis-1/generated/state/state.json
@@ -49,6 +49,10 @@
       "legacyAsset": true
     },
     {
+      "base_denom": "factory/osmo1fg7y3j86fkp93yxpq5q8lk8c64k8wxj3qw8us49msgpr2gsgddjqxpgr9m/alloyed/allPOL",
+      "legacyAsset": true
+    },
+    {
       "base_denom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
       "legacyAsset": true
     },
@@ -750,6 +754,10 @@
     },
     {
       "base_denom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
+      "listingDate": "2024-02-06T08:36:00.000Z"
+    },
+    {
+      "base_denom": "factory/osmo12cf6l99qrchfppmjp80gvkpnle2tuxpck2cf6fz030w74mq49u4qm3dh4d/alloyed/allDYM",
       "listingDate": "2024-02-06T08:36:00.000Z"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6250,7 +6250,7 @@
       "chain_name": "axelar",
       "base_denom": "unit-move",
       "path": "transfer/channel-208/unit-move",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "transfer_methods": [
         {
           "name": "Satellite",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6203,7 +6203,7 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo12cf6l99qrchfppmjp80gvkpnle2tuxpck2cf6fz030w74mq49u4qm3dh4d/alloyed/allDYM",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "is_alloyed": true,
       "canonical": {
         "chain_name": "dymension",
@@ -6214,7 +6214,7 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1fg7y3j86fkp93yxpq5q8lk8c64k8wxj3qw8us49msgpr2gsgddjqxpgr9m/alloyed/allPOL",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "is_alloyed": true,
       "canonical": {
         "chain_name": "polygon",
@@ -6272,7 +6272,7 @@
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1v90ezcqkv5utjc52vg4w2gztmcpt7l4vqxzuryj6zl3qr8wy539quxeafk/alloyed/allMOVE",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "is_alloyed": true,
       "canonical": {
         "chain_name": "movement",


### PR DESCRIPTION
## Description

Verify allPOL, allDYM, allMOVE, MOVE.eth.axl (which was pending the alloy).
Also overwrote the listing date for POL and DYM so they don't show up under New

## Checklist


### Upgrading Asset to Verified

<!-- If NOT upgrading asset status, please remove this 'Upgrading Asset to Verified' section. -->

If upgrading an Asset to Verified, please see the requirements specified at [LISTING](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md#upgrade-asset-to-verified-status-permissioned), and ensure the following:
- [x] Asset is defined thoroughly at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - [x] A meaningful `description` (and `extended_description`, unless: meme or variant/derivative asset).
   - [x] Associated `socials`, including `website` and `twitter` (unless: meme or variant/derivative asset).
   - [x] **Logo Image** has a square Aspect Ratio, < 250 KB file size, and appropriate visual contrast with Osmosis Zone's colors.
- [x]  **Liquidity**: This pool meets the liquidity requirements, and has a +-2% depth of $50 (~$5k full range liq.) (Provide Pool ID): ______ (Skip if alloy constituent)

'Verified' Status Validation Checklist (to be completed by Osmosis Zone maintainers):
- [x] Verify appearance and metadata
- [x] Accurate Price
- [x] Trading and routing functionality
   - [x] $50 USDC offer yields at least $49-worth of this Asset
- [ ] Withdraw and Deposit
   - [ ] Deposit Transaction URL (if in-app)

