### PR TITLE
Set allFET to disabled (disabled Deposits and Withdrawals)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6133,7 +6133,8 @@
       "canonical": {
         "chain_name": "fetchhub",
         "base_denom": "afet"
-      }
+      },
+      "osmosis_disabled": true
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## Description

Set allFET to disabled (disabled Deposits and Withdrawals)

as per advisement from FE, because Skip (the only provider able to do Withdrawals) is not able to attach IBC memos on Fetchhub, so they cannot serve Deposits.