### PR TITLE
Disable DOGE alloy

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5641,7 +5641,7 @@
       "chain_name": "osmosis",
       "base_denom": "factory/osmo10pk4crey8fpdyqd62rsau0y02e3rk055w5u005ah6ly7k849k5tsf72x40/alloyed/allDOGE",
       "osmosis_verified": true,
-      "osmosis_disabled": false,
+      "osmosis_disabled": true,
       "is_alloyed": true,
       "canonical": {
         "chain_name": "dogecoin",


### PR DESCRIPTION
## Description

Disable DOGE alloy
so that int3face is recommended (they to end-to-end Alloy to DOGE transfers)