### PR TITLE
Manually Remove USDT.sol.pica from Generated Chainlist

### DIFF
--- a/osmosis-1/generated/frontend/chainlist.json
+++ b/osmosis-1/generated/frontend/chainlist.json
@@ -172,14 +172,6 @@
           "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoin/images/btc.png"
         },
         {
-          "coinDenom": "USDT.sol.pica",
-          "chainSuggestionDenom": "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
-          "coinMinimalDenom": "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
-          "coinDecimals": 6,
-          "coinGeckoId": "tether",
-          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usdt.solana.pica.png"
-        },
-        {
           "coinDenom": "SAGA",
           "chainSuggestionDenom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
           "coinMinimalDenom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",


### PR DESCRIPTION
## Description

Manually Remove USDT.sol.pica from Generated Chainlist
just to rule out the off chance the the frontend is looking at this file instead.