### PR TITLE
Change canonical source for LBTC

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6313,8 +6313,8 @@
       ],
       "override_properties": {},
       "canonical": {
-        "chain_name": "lombardledger",
-        "base_denom": "uclbtc"
+        "chain_name": "ethereum",
+        "base_denom": "0x8236a87084f8B84306f72007F36F2618A5634494"
       },
       "_comment": "Lombard Staked Bitcoin (Lombard Ledger) $LBTC.lom"
     },

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6316,7 +6316,7 @@
         "chain_name": "ethereum",
         "base_denom": "0x8236a87084f8B84306f72007F36F2618A5634494"
       },
-      "_comment": "Lombard Staked Bitcoin (Lombard Ledger) $LBTC.lom"
+      "_comment": "Lombard Staked Bitcoin $LBTC"
     },
     {
       "chain_name": "cosmoshub",


### PR DESCRIPTION
## Description

Changes canonical source for LBTC to Ethereum, triggering generation as LBTC rather than LBTC.lom

Bridging confirmed to be bi-directional via Eureka and Lombard Chain.