### PR TITLE
Add Omnity Bridge to allDOGE transfer_methods

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5670,6 +5670,12 @@
           "type": "external_interface",
           "deposit_url": "https://app.int3face.zone/bridge",
           "withdraw_url": "https://app.int3face.zone/bridge"
+        },
+        {
+          "name": "Omnity Bridge",
+          "type": "external_interface",
+          "deposit_url": "https://bridge.omnity.network/doge",
+          "withdraw_url": "https://bridge.omnity.network/doge"
         }
       ],
       "_comment": "Dogecoin $DOGE"


### PR DESCRIPTION
## Description

Add Omnity Bridge to allDOGE transfer_methods
because ckDOGE is now part of the alloy.