### PR TITLE
verify bitbadges "ubadge"

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6241,7 +6241,7 @@
       "chain_name": "bitbadges",
       "base_denom": "ubadge",
       "path": "transfer/channel-104311/ubadge",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "_comment": "BitBadges $BADGE"
     },
     {

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1603,8 +1603,8 @@
     },
     {
       "chain_name": "bitbadges",
-      "rpc": "https://node.bitbadges.io/rpc",
-      "rest": "https://node.bitbadges.io/api",
+      "rpc": "https://rpc.bitbadges.io",
+      "rest": "https://lcd.bitbadges.io",
       "explorer_tx_url": "https://explorer.bitbadges.io/BitBadges%20Mainnet/tx/${txHash}",
       "keplr_features": [
         "ibc-go",


### PR DESCRIPTION
## Description

Add verified status for BitBadges "ubadge".

Pending approval from [https://github.com/cosmos/chain-registry/pull/6402](https://github.com/cosmos/chain-registry/pull/6402), I believe we should have everything checked. If there are issues, let me know.

We are just looking for Osmosis verification status, and we will pursue CoinGecko listing later on.

### Upgrading Asset to Verified

If upgrading an Asset to Verified, please see the requirements specified at [LISTING](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md#upgrade-asset-to-verified-status-permissioned), and ensure the following:
- [x] Asset is defined thoroughly at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - [x] A meaningful `description` (and `extended_description`, unless: meme or variant/derivative asset).
   - [x] Associated `socials`, including `website` and `twitter` (unless: meme or variant/derivative asset).
   - [x] **Logo Image** has a square Aspect Ratio, < 250 KB file size, and appropriate visual contrast with Osmosis Zone's colors.
- [x]  **Liquidity**: This pool meets the liquidity requirements, and has a +-2% depth of $50 (~$5k full range liq.) (Pool ID: 3004, https://app.osmosis.zone/pool/3004)

'Verified' Status Validation Checklist (to be completed by Osmosis Zone maintainers):
- [x] Verify appearance and metadata
- [x] Accurate Price
- [ ] Trading and routing functionality
   - [ ] $50 USDC offer yields at least $49-worth of this Asset (result: yields over $48 but not quite $49 USDC)
- [ ] Withdraw and Deposit (result: Cannot find balance--needed to send a Deposit tx)
   - [ ] Deposit Transaction URL (if in-app)

