### PR TITLE
Remove Most Override Data

### DIFF
--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -637,7 +637,8 @@ export function setSymbol(asset_data) {
         last_suffix_is_network = true;
       }
     } else { //is IBC
-      accumulative_suffix = accumulative_suffix + "." + getNetworkSymbolSuffix(hop.network, asset_data);
+      //accumulative_suffix = accumulative_suffix + "." + getNetworkSymbolSuffix(hop.network, asset_data);
+      accumulative_suffix = accumulative_suffix + "." + getNetworkSymbolSuffix(asset_data.source_asset.chain_name, asset_data);
       last_suffix_is_network = true;
     }
   });
@@ -650,6 +651,12 @@ export function setSymbol(asset_data) {
     accumulative_suffix.endsWith(ending)
   ) {
     accumulative_suffix = accumulative_suffix.slice(0, -ending.length);
+  }
+
+  //check for special long paths
+  let picasso_ending = ".composablepolkadot.pica.pica";
+  if (accumulative_suffix.endsWith(picasso_ending)) {
+    accumulative_suffix = accumulative_suffix.slice(0, -picasso_ending.length) + ".pica";
   }
 
   symbol = symbol + accumulative_suffix;
@@ -772,7 +779,7 @@ export function setName(asset_data) {
       this_suffix_is_network = true;
       accumulative_suffix = appendNameSuffix(
         accumulative_suffix,
-        getNetworkName(hop.network, asset_data),
+        getNetworkName(asset_data.identity_asset.chain_name, asset_data),
         this_suffix_is_network,
         last_suffix_is_network
       );
@@ -788,6 +795,12 @@ export function setName(asset_data) {
     accumulative_suffix.endsWith(ending)
   ) {
     accumulative_suffix = accumulative_suffix.slice(0, -ending.length);
+  }
+
+  //check for special long paths
+  let picasso_ending = " (composablepolkadot via Picasso) (Picasso)";
+  if (accumulative_suffix.endsWith(picasso_ending)) {
+    accumulative_suffix = accumulative_suffix.slice(0, -picasso_ending.length) + " (Picasso)";
   }
 
   name = name + accumulative_suffix;

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -93,7 +93,6 @@
       "base_denom": "busd-wei",
       "path": "transfer/channel-208/busd-wei",
       "osmosis_verified": true,
-      "override_properties": {},
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0x4fabb145d64652a948d72533023f6e7a623c7c53"
@@ -108,9 +107,6 @@
       "base_denom": "uatom",
       "path": "transfer/channel-0/uatom",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Cosmos Hub"
-      },
       "_comment": "Cosmos Hub $ATOM"
     },
     {
@@ -143,10 +139,6 @@
           "withdraw_url": "https://satellite.money/?source=osmosis&destination=polygon&asset_denom=matic"
         }
       ],
-      "override_properties": {
-        "symbol": "POL.axl",
-        "name": "Polygon (Axelar)"
-      },
       "_comment": "Polygon (Axelar) $POL.axl"
     },
     {
@@ -154,9 +146,6 @@
       "base_denom": "wavax-wei",
       "path": "transfer/channel-208/wavax-wei",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Avalanche"
-      },
       "canonical": {
         "chain_name": "avalanche",
         "base_denom": "wei"
@@ -168,9 +157,6 @@
       "base_denom": "uluna",
       "path": "transfer/channel-72/uluna",
       "osmosis_verified": true,
-      "override_properties": {
-        "use_asset_name": true
-      },
       "transfer_methods": [
         {
           "name": "Terra Bridge",
@@ -566,10 +552,6 @@
       "categories": [
         "ai"
       ],
-      "override_properties": {
-        "name": "Fetch.ai (Fetch.ai)",
-        "symbol": "FET.fet"
-      },
       "_comment": "Fetch.ai (Fetch.ai) $FET.fet"
     },
     {
@@ -634,9 +616,6 @@
       "base_denom": "rowan",
       "path": "transfer/channel-47/rowan",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Sifchain"
-      },
       "categories": [
         "defi"
       ],
@@ -683,9 +662,6 @@
       "base_denom": "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "path": "transfer/channel-144/gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Wrapped Bitcoin (Gravity Bridge)"
-      },
       "transfer_methods": [
         {
           "name": "Gravity Bridge",
@@ -701,9 +677,6 @@
       "base_denom": "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "path": "transfer/channel-144/gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Ether (Gravity Bridge)"
-      },
       "transfer_methods": [
         {
           "name": "Gravity Bridge",
@@ -720,9 +693,6 @@
       "path": "transfer/channel-144/gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "USDC (Gravity Bridge)"
-      },
       "transfer_methods": [
         {
           "name": "Gravity Bridge",
@@ -742,9 +712,6 @@
       "path": "transfer/channel-144/gravity0x6B175474E89094C44Da98b954EedeAC495271d0F",
       "peg_mechanism": "collateralized",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "DAI Stablecoin (Gravity Bridge)"
-      },
       "transfer_methods": [
         {
           "name": "Gravity Bridge",
@@ -764,9 +731,6 @@
       "path": "transfer/channel-144/gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Tether USD (Gravity Bridge)"
-      },
       "transfer_methods": [
         {
           "name": "Gravity Bridge",
@@ -850,9 +814,6 @@
       "base_denom": "uluna",
       "path": "transfer/channel-251/uluna",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Luna"
-      },
       "_comment": "Luna $LUNA"
     },
     {
@@ -1057,9 +1018,6 @@
       "base_denom": "wglmr-wei",
       "path": "transfer/channel-208/wglmr-wei",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Moonbeam"
-      },
       "canonical": {
         "chain_name": "moonbeam",
         "base_denom": "Wei"
@@ -1387,9 +1345,6 @@
       "base_denom": "cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
       "path": "transfer/channel-169/cw20:juno1cltgm8v842gu54srmejewghnd6uqa26lzkpa635wzra9m9xuudkqa2gtcz",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "FURY.legacy"
-      },
       "_comment": "FURY.legacy $FURY.juno"
     },
     {
@@ -1514,9 +1469,6 @@
       "base_denom": "wftm-wei",
       "path": "transfer/channel-208/wftm-wei",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Fantom"
-      },
       "canonical": {
         "chain_name": "fantom",
         "base_denom": "wei"
@@ -1567,9 +1519,6 @@
       "path": "transfer/channel-208/avalanche-uusdc",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "USD Coin (Avalanche)"
-      },
       "categories": [
         "stablecoin"
       ],
@@ -1998,9 +1947,6 @@
       "base_denom": "wsteth-wei",
       "path": "transfer/channel-208/wsteth-wei",
       "osmosis_verified": true,
-      "override_properties": {
-        "symbol": "wstETH.eth.axl"
-      },
       "origin": {
         "chain_name": "ethereum",
         "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
@@ -2126,9 +2072,6 @@
         "chain_name": "picasso",
         "base_denom": "ppica"
       },
-      "override_properties": {
-        "name": "Picasso"
-      },
       "categories": [
         "bridges"
       ],
@@ -2167,10 +2110,6 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=POLKADOT"
         }
       ],
-      "override_properties": {
-        "symbol": "DOT.pica",
-        "name": "Polkadot (Picasso)"
-      },
       "_comment": "Polkadot (Picasso) $DOT.pica"
     },
     {
@@ -2667,10 +2606,6 @@
       "base_denom": "adydx",
       "path": "transfer/channel-6787/adydx",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "dYdX Protocol (dYdX Protocol)",
-        "symbol": "DYDX.dydx"
-      },
       "categories": [
         "defi"
       ],
@@ -2877,9 +2812,6 @@
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
       "osmosis_verified": true,
-      "override_properties": {
-        "traces": []
-      },
       "categories": [
         "liquid_staking",
         "built_on_osmosis"
@@ -3155,9 +3087,6 @@
       "base_denom": "peggy0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2",
       "path": "transfer/channel-122/peggy0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Gelotto (Injective)"
-      },
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2"
@@ -3187,10 +3116,6 @@
           "deposit_url": "https://portal.dymension.xyz/ibc/transfer?sourceId=dymension_1100-1&destinationId=osmosis-1"
         }
       ],
-      "override_properties": {
-        "symbol": "DYM.dym",
-        "name": "Dymension (Dymension Hub)"
-      },
       "_comment": "Dymension (Dymension Hub) $DYM.dym"
     },
     {
@@ -3365,10 +3290,6 @@
           "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=aioz_168-1&chainTo=osmosis-1&token0=attoaioz&token1=ibc%2FBB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F"
         }
       ],
-      "override_properties": {
-        "name": "AIOZ Network (AIOZ Network)",
-        "symbol": "AIOZ.aioz"
-      },
       "categories": [
         "ai",
         "dweb"
@@ -3419,9 +3340,6 @@
       "base_denom": "drop-core1zhs909jp9yktml6qqx9f0ptcq2xnhhj99cja03j3lfcsp2pgm86studdrz",
       "path": "transfer/channel-2188/drop-core1zhs909jp9yktml6qqx9f0ptcq2xnhhj99cja03j3lfcsp2pgm86studdrz",
       "osmosis_verified": true,
-      "override_properties": {
-        "name": "Ripple (Coreum)"
-      },
       "transfer_methods": [
         {
           "name": "Sologenic Coreum Bridge",
@@ -3715,9 +3633,6 @@
       "base_denom": "gravity0x45804880De22913dAFE09f4980848ECE6EcbAf78",
       "path": "transfer/channel-144/gravity0x45804880De22913dAFE09f4980848ECE6EcbAf78",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Paxos Gold (Gravity Bridge)"
-      },
       "transfer_methods": [
         {
           "name": "Gravity Bridge",
@@ -4342,9 +4257,6 @@
       "base_denom": "arbitrum-weth-wei",
       "path": "transfer/channel-208/arbitrum-weth-wei",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Wrapped Ether (Arbitrum via Axelar)"
-      },
       "transfer_methods": [
         {
           "name": "Satellite",
@@ -4360,9 +4272,6 @@
       "base_denom": "base-weth-wei",
       "path": "transfer/channel-208/base-weth-wei",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Wrapped Ether (Base via Axelar)"
-      },
       "transfer_methods": [
         {
           "name": "Satellite",
@@ -4378,9 +4287,6 @@
       "base_denom": "polygon-weth-wei",
       "path": "transfer/channel-208/polygon-weth-wei",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Wrapped Ether (Polygon via Axelar)"
-      },
       "transfer_methods": [
         {
           "name": "Satellite",
@@ -4769,11 +4675,7 @@
           "deposit_url": "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
-      ],
-      "override_properties": {
-        "name": "Unicorn (Picasso)",
-        "symbol": "UWU.pica"
-      }
+      ]
     },
     {
       "chain_name": "haqq",
@@ -4811,10 +4713,6 @@
       "path": "transfer/channel-122/peggy0xdAC17F958D2ee523a2206206994597C13D831ec7",
       "peg_mechanism": "collateralized",
       "osmosis_verified": true,
-      "override_properties": {
-        "symbol": "USDT.inj",
-        "name": "Tether USD (Injective)"
-      },
       "_comment": "Tether USD (Injective) $USDT.inj",
       "categories": [
         "stablecoin"
@@ -5220,10 +5118,6 @@
       "base_denom": "cbbtc-satoshi",
       "path": "transfer/channel-208/cbbtc-satoshi",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Coinbase Wrapped BTC (Base via Axelar)",
-        "symbol": "cbBTC.base.axl"
-      },
       "_comment": "Coinbase Wrapped BTC (Base via Axelar) $cbBTC.base.axl"
     },
     {
@@ -5370,8 +5264,7 @@
       "path": "transfer/channel-101249/udgn",
       "osmosis_verified": true,
       "override_properties": {
-        "name": "Dragon Coin",
-        "symbol": "DGN"
+        "use_asset_name": true
       },
       "_comment": "Dragon Coin $DGN"
     },
@@ -5453,9 +5346,6 @@
       "base_denom": "uxion",
       "path": "transfer/channel-89321/uxion",
       "osmosis_verified": true,
-      "override_properties": {
-        "use_asset_name": true
-      },
       "_comment": "xion $XION"
     },
     {
@@ -5877,10 +5767,6 @@
           "withdraw_url": "https://satellite.money/?source=osmosis&destination=ethereum&asset_denom=unit-move"
         }
       ],
-      "override_properties": {
-        "symbol": "MOVE.eth.axl",
-        "name": "Movement (Ethereum via Axelar)"
-      },
       "_comment": "Movement (Ethereum via Axelar) $MOVE.eth.axl"
     },
     {
@@ -5925,7 +5811,6 @@
       "categories": [
         "liquid_staking"
       ],
-      "override_properties": {},
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0x8236a87084f8B84306f72007F36F2618A5634494"
@@ -5940,7 +5825,6 @@
       "categories": [
         "liquid_staking"
       ],
-      "override_properties": {},
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0x7a56e1c57c7475ccf742a1832b028f0456652f97"

--- a/osmosis-1/osmosis.zone_config.json
+++ b/osmosis-1/osmosis.zone_config.json
@@ -52,7 +52,7 @@
       },
       {
         "provider": "Gravity Bridge",
-        "name_suffix": "Gravity",
+        "name_suffix": "Gravity Bridge",
         "symbol_suffix": ".grv",
         "token": {
           "chain_name": "gravitybridge",


### PR DESCRIPTION
## Description

Remove Most Override Data
This bulk cleanup is mostly about removing the manual override data for asset names and symbols

There are a few symbols and names may change just a little bit, mostly for the better, because the old manual overrides were stale and not following current naming methods. However, one notable change is that if an asset has multiple issuances, then it doesn't play favorites with the original, and it always mentions the mintage network (e.g.,:
now
USDT (Ethereum via Axelar)
instead of 
USDT (Axelar)


Some override data is still used for very custom situations:
- LVN.ki (clashes with Levana), XRP.xrplevm (their bech32 prefix .ethm isn't very informative)
- setting assets to use the asset name instead of the network name (toncoin, binance coin, dragon coin, babylon)
- use white or circular logo images (e.g., for saga and dydx)
- adding additional counterparty networks (e.g., USDT.rt)