### PR TITLE
Set DOT.pica to Unlisted/Preview Asset

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2102,6 +2102,7 @@
       "path": "transfer/channel-1279/transfer/channel-2/transfer/channel-15/79228162514264337593543950342",
       "osmosis_verified": true,
       "osmosis_unstable": true,
+      "osmosis_unlisted": true,
       "transfer_methods": [
         {
           "name": "Picasso App",


### PR DESCRIPTION
## Description

Set DOT.pica to Unlisted/Preview Asset
to prevent more users from accidentally converting to DOT.pica, and then being unable to convert back to the alloy.