### PR TITLE
Disable TIA transfers

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2600,6 +2600,7 @@
       "base_denom": "utia",
       "path": "transfer/channel-6994/utia",
       "osmosis_verified": true,
+      "osmosis_disabled": true,
       "_comment": "Celestia $TIA"
     },
     {


### PR DESCRIPTION
Disabling TIA transfers temporarily due to upgrade breaking IBC transfers