### PR TITLE
Adding token: **LUME (ulume)** from chain **Lumera Testnet** (`lumeratestnet`)

### DIFF
--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -159,6 +159,24 @@
       "path": "transfer/channel-10183/umfx",
       "osmosis_verified": false,
       "_comment": "Manifest Testnet Token $MFX"
+    },
+    {
+      "chain_name": "lumeratestnet",
+      "base_denom": "ulume",
+      "path": "transfer/channel-10884/ulume",
+      "osmosis_verified": false,
+      "override_properties": {
+        "name": "Lumera",
+        "symbol": "LUME",
+        "display": "LUME",
+        "denom_units": [
+          { "denom": "ulume", "exponent": 0 },
+          { "denom": "lume",  "exponent": 6 }
+        ],
+        "logo_URIs": {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/lumera/images/lumera.png"
+        }
+      }
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone_assets.json
+++ b/osmo-test-5/osmosis.zone_assets.json
@@ -165,18 +165,7 @@
       "base_denom": "ulume",
       "path": "transfer/channel-10884/ulume",
       "osmosis_verified": false,
-      "override_properties": {
-        "name": "Lumera",
-        "symbol": "LUME",
-        "display": "LUME",
-        "denom_units": [
-          { "denom": "ulume", "exponent": 0 },
-          { "denom": "lume",  "exponent": 6 }
-        ],
-        "logo_URIs": {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/lumera/images/lumera.png"
-        }
-      }
+      "_comment": "Lumera Testnet Token $LUME"
     }
   ]
 }

--- a/osmo-test-5/osmosis.zone_chains.json
+++ b/osmo-test-5/osmosis.zone_chains.json
@@ -190,7 +190,7 @@
       ]
     },
     {
-      "chain_name": "lumera",
+      "chain_name": "lumeratestnet",
       "rpc": "https://rpc.testnet.lumera.io",
       "rest": "https://lcd.testnet.lumera.io",
       "explorer_tx_url": "https://portal.testnet.lumera.io/lumera-testnet-2/tx/${txHash}",

--- a/osmo-test-5/osmosis.zone_chains.json
+++ b/osmo-test-5/osmosis.zone_chains.json
@@ -188,6 +188,16 @@
         "cosmwasm",
         "wasmd_0.24+"
       ]
+    },
+    {
+      "chain_name": "lumera",
+      "rpc": "https://rpc.testnet.lumera.io",
+      "rest": "https://lcd.testnet.lumera.io",
+      "explorer_tx_url": "https://portal.testnet.lumera.io/lumera-testnet-2/tx/${txHash}",
+      "keplr_features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding token: **LUME (ulume)** from chain **Lumera Testnet** (`lumeratestnet`)  
Planned liquidity: 50/50 **LUME/OSMO** pool on `osmo-test-5`.

> Note: Lumera testnet is already registered in the Cosmos Chain Registry (`testnets/lumeratestnet`). This PR adds the asset + chain entries to Osmosis’ testnet assetlists.

## Checklist

<!-- The following checklist can be ticked after Creating the PR -->

### Adding Assets

- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - x ] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry (`lumeratestnet` / `ulume`).
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [ ] Optional: `transfer_methods`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

- [x] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
  - [x] `staking` defined with `ulume` as a staking token.
  - [x] `fees` defined with gas prices.
- [x] IBC Connection between chain and Osmosis is registered.
- [x] Add chain to bottom of `zone_chains.json`
   - [x] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [x] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.

