### PR TITLE
Add Lumera chain and asset details to Osmosis configuration

### DIFF
--- a/osmosis-1/osmosis-1.chainlist.json
+++ b/osmosis-1/osmosis-1.chainlist.json
@@ -10847,6 +10847,65 @@
       "features": [
         "ibc-go"
       ]
-    }
-  ]
+    },
+    {
+    "chain_name": "lumera",
+    "status": "live",
+    "network_type": "mainnet",
+    "pretty_name": "Lumera",
+    "chain_id": "lumera-mainnet-1",
+    "bech32_prefix": "lumera",
+    "bech32_config": {
+      "bech32PrefixAccAddr": "lumera",
+      "bech32PrefixAccPub": "lumerapub",
+      "bech32PrefixValAddr": "lumeravaloper",
+      "bech32PrefixValPub": "lumeravaloperpub",
+      "bech32PrefixConsAddr": "lumeravalcons",
+      "bech32PrefixConsPub": "lumeravalconspub"
+    },
+    "slip44": 118,
+    "fees": {
+      "fee_tokens": [
+        {
+          "denom": "ulume",
+          "fixed_min_gas_price": 0.025,
+          "low_gas_price": 0.025,
+          "average_gas_price": 0.025,
+          "high_gas_price": 0.025
+        }
+      ]
+    },
+    "staking": {
+      "staking_tokens": [
+        {
+          "denom": "ulume"
+        }
+      ]
+    },
+    "apis": {
+      "rpc": [
+        {
+          "address": "https://rpc.lumera.io"
+        }
+      ],
+      "rest": [
+        {
+          "address": "https://lcd.lumera.io"
+        }
+      ]
+    },
+    "explorers": [
+      {
+        "tx_page": "https://portal.lumera.io/lumera-mainnet-1/tx/${txHash}"
+      }
+    ],
+    "logoURIs": {
+      "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumera/images/lumera.png"
+    },
+    "features": [
+      "ibc-go",
+      "cosmwasm"
+    ]
+  }
+]
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6323,6 +6323,13 @@
         "stablecoin"
       ],
       "_comment": "Sunrise USDrise $USDrise"
+    },
+    {
+      "chain_name": "lumera",
+      "base_denom": "ulume",
+      "path": "transfer/channel-106313/ulume",
+      "osmosis_verified": false,
+      "_comment": "Lumera $LUME"
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1430,6 +1430,16 @@
       "keplr_features": [
         "ibc-go"      
       ]
+    },
+    {
+      "chain_name": "lumera",
+      "rpc": "https://rpc.lumera.io",
+      "rest": "https://lcd.lumera.io",
+      "explorer_tx_url": "https://portal.lumera.io/lumera-mainnet-1/tx/${txHash}",
+      "keplr_features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description  

Adding token: **LUME** (native token of the Lumera chain) as an IBC asset on Osmosis.  

- Chain: `lumera`  
- Base denom: `ulume` (native on Lumera)  
- IBC path on Osmosis: `transfer/channel-106313/ulume`  
- IBC hash on Osmosis: `ibc/32C4AEE2B3C4F767A351FA821AB0140B10CB690CDED27D9FCC857859B44432B9`  
- Counterparty channel (Lumera side): `channel-0`  

Example: See planned Lumera/OSMO pool.  

---

## Checklist  

### Adding Assets  

- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry) under `lumera`.  
- [x] Added asset entry to bottom of `zone_assets.json`.  
  - [x] `chain_name` = `lumera`  
  - [x] `base_denom` = `ulume`  
  - [x] `path` = `transfer/channel-106313/ulume`  
  - [x] `osmosis_verified` set to `false`  
- [ ] Optional: Add `categories` once pools are live.  

---

### Adding Chains  
N/A (Lumera chain already registered in the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry)).  

---

### Upgrading Asset to Verified  
N/A (initial addition only; verification may be proposed later once liquidity and volume requirements are met).  
