### PR TITLE
Update osmosis.zone_assets.json

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2726,6 +2726,7 @@
       "base_denom": "usource",
       "path": "transfer/channel-8945/usource",
       "osmosis_verified": true,
+      "osmosis_disabled": true,
       "_comment": "Source $SOURCE"
     },
     {


### PR DESCRIPTION
$SOURCE set "osmosis_disabled": true,
      
Reason: ibc down, discord invite's server name indicates the team rugged.