### PR TITLE
Add fee tokens override for atomone chain

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1215,7 +1215,18 @@
       "chain_name": "atomone",
       "rpc": "https://atomone-rpc.allinbits.com",
       "rest": "https://atomone-api.allinbits.com",
-      "explorer_tx_url": "https://www.mintscan.io/atomone/tx/${txHash}"
+      "explorer_tx_url": "https://www.mintscan.io/atomone/tx/${txHash}",
+      "fees": {
+        "fee_tokens": [
+          {
+            "denom": "uphoton",
+            "fixed_min_gas_price": 0.225,
+            "low_gas_price": 0.225,
+            "average_gas_price": 0.3,
+            "high_gas_price": 0.5
+          }
+        ]
+      }
     },
     {
       "chain_name": "dungeon1",


### PR DESCRIPTION
Added fee structure for atomone chain. 

## Description

This only includes uphoton, and excludes uatone fees which was getting generated from the cosmos chain registry, breaking our deposit flow.
