### PR TITLE
Update AtomOne configuration with fee properties

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5207,7 +5207,20 @@
       "base_denom": "uatone",
       "path": "transfer/channel-94814/uatone",
       "osmosis_verified": true,
-      "_comment": "AtomOne $ATONE"
+      "_comment": "AtomOne $ATONE",
+      "override_properties": [
+        "fees": {
+          "fee_tokens": [
+            {
+              "denom": "uphoton",
+              "fixed_min_gas_price": 0.225,
+              "low_gas_price": 0.225,
+              "average_gas_price": 0.3,
+              "high_gas_price": 0.5
+            }
+          ]
+        }
+      ]
     },
     {
       "chain_name": "osmosis",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5208,7 +5208,7 @@
       "path": "transfer/channel-94814/uatone",
       "osmosis_verified": true,
       "_comment": "AtomOne $ATONE",
-      "override_properties": [
+      "override_properties": {
         "fees": {
           "fee_tokens": [
             {
@@ -5220,7 +5220,7 @@
             }
           ]
         }
-      ]
+      }
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
Added override properties for fees in AtomOne configuration.

## Description

This is necessary because the generated files pull Atone as a fee token from cosmos chain registry. We don't want that, as it is incorrect fee token for deposit type transactions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `override_properties.fees` for AtomOne `uatone` to use `uphoton` as the fee token with specified gas prices.
> 
> - **AtomOne (`atomone`)**:
>   - `assets[... 'uatone' ...]`: Add `override_properties.fees.fee_tokens` to use `uphoton` with `fixed_min_gas_price=0.225`, `low=0.225`, `avg=0.3`, `high=0.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71035c693eacf538491491df127953bd13e4ac25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->