### PR TITLE
Add override properties support to chainlist generation

### DIFF
--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -61,16 +61,32 @@ function generateChains(chains, zone_chains) {
   
     // -- Chain Object --
     let chain = {};
+    
+    // -- Get chain_name (no override - used for registry lookup) --
     chain.chain_name = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "chain_name");
-    chain.status = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "status");
-    chain.network_type = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "network_type");
-    chain.pretty_name = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "pretty_name");
+    
+    // -- Get chain_id (no override - fundamental network identifier) --
     chain.chain_id = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "chain_id");
+
+    // -- Get status with override support --
+    chain.status = zone_chain.override_properties?.status || 
+                   chain_reg.getFileProperty(zone_chain.chain_name, "chain", "status");
+    
+    // -- Get network_type with override support --
+    chain.network_type = zone_chain.override_properties?.network_type || 
+                         chain_reg.getFileProperty(zone_chain.chain_name, "chain", "network_type");
+    
+    // -- Get pretty_name with override support --
+    chain.pretty_name = zone_chain.override_properties?.pretty_name || 
+                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "pretty_name");
     
     
-    // -- Get bech32_config --
-    chain.bech32_prefix = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_prefix");
-    let bech32_config = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_config");
+    // -- Get bech32_config with override support --
+    chain.bech32_prefix = zone_chain.override_properties?.bech32_prefix || 
+                          chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_prefix");
+    
+    let bech32_config = zone_chain.override_properties?.bech32_config || 
+                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_config");
     if (!bech32_config) {
       bech32_config = {};
     }
@@ -81,37 +97,42 @@ function generateChains(chains, zone_chains) {
     chain.bech32_config = bech32_config;
 
 
-    // -- Get SLIP44 --
-    chain.slip44 = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "slip44");
-    chain.alternative_slip44s = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "alternative_slip44s");
+    // -- Get SLIP44 with override support --
+    chain.slip44 = zone_chain.override_properties?.slip44 || 
+                   chain_reg.getFileProperty(zone_chain.chain_name, "chain", "slip44");
+    chain.alternative_slip44s = zone_chain.override_properties?.alternative_slip44s || 
+                               chain_reg.getFileProperty(zone_chain.chain_name, "chain", "alternative_slip44s");
 
 
-    // -- Get Fees --
-    chain.fees = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "fees");
+    // -- Get Fees with override support --
+    chain.fees = zone_chain.override_properties?.fees || 
+                 chain_reg.getFileProperty(zone_chain.chain_name, "chain", "fees");
     
     
-    // -- Get Staking --
-    chain.staking = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "staking");
+    // -- Get Staking with override support --
+    chain.staking = zone_chain.override_properties?.staking || 
+                    chain_reg.getFileProperty(zone_chain.chain_name, "chain", "staking");
 
     
-    // -- Get Description --
-    chain.description = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "description");
+    // -- Get Description with override support --
+    chain.description = zone_chain.override_properties?.description || 
+                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "description");
     
     
-    // -- Get APIs --
+    // -- Get APIs with override support --
     chain.apis = {};
     chain.apis.rpc = [];
     chain.apis.rpc[0] = {};
-    chain.apis.rpc[0].address = zone_chain.rpc;
+    chain.apis.rpc[0].address = zone_chain.override_properties?.rpc || zone_chain.rpc;
     chain.apis.rest = [];
     chain.apis.rest[0] = {};
-    chain.apis.rest[0].address = zone_chain.rest;
+    chain.apis.rest[0].address = zone_chain.override_properties?.rest || zone_chain.rest;
     
     
-    // -- Get Explorer Tx URL --
+    // -- Get Explorer Tx URL with override support --
     chain.explorers = [];
     chain.explorers[0] = {};
-    chain.explorers[0].tx_page = zone_chain.explorer_tx_url;
+    chain.explorers[0].tx_page = zone_chain.override_properties?.explorer_tx_url || zone_chain.explorer_tx_url;
 
 
     // -- Get Images --
@@ -131,12 +152,12 @@ function generateChains(chains, zone_chains) {
     }
     
     
-    // -- Get Keplr Suggest Chain Features --
-    chain.features = zone_chain.keplr_features;
+    // -- Get Keplr Suggest Chain Features with override support --
+    chain.features = zone_chain.override_properties?.keplr_features || zone_chain.keplr_features;
     
     
-    // -- Get Outage Alerts --
-    chain.outage = zone_chain.outage;
+    // -- Get Outage Alerts with override support --
+    chain.outage = zone_chain.override_properties?.outage || zone_chain.outage;
     
     
     // -- Push Chain Object --

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1215,7 +1215,20 @@
       "chain_name": "atomone",
       "rpc": "https://atomone-rpc.allinbits.com",
       "rest": "https://atomone-api.allinbits.com",
-      "explorer_tx_url": "https://www.mintscan.io/atomone/tx/${txHash}"
+      "explorer_tx_url": "https://www.mintscan.io/atomone/tx/${txHash}",
+      "override_properties": {
+        "fees": {
+          "fee_tokens": [
+            {
+              "denom": "uphoton",
+              "fixed_min_gas_price": 0.225,
+              "low_gas_price": 0.225,
+              "average_gas_price": 0.3,
+              "high_gas_price": 0.5
+            }
+          ]
+        }
+      }
     },
     {
       "chain_name": "dungeon1",


### PR DESCRIPTION
## Summary
- Add support for override_properties in chainlist generation workflow
- Configure AtomOne chain with proper fee structure using override properties
- Maintain backward compatibility while enabling per-zone customization

## Changes
- Modified `.github/workflows/utility/generate_chainlist.mjs` to support override_properties for various chain configuration fields
- Added fee configuration for AtomOne chain in `osmosis-1/osmosis.zone_chains.json`

## Test plan
- [x] Verify chainlist generation still works with existing chains (backward compatibility)
- [x] Confirm AtomOne fee configuration is properly applied through override properties
- [ ] Test chainlist generation with the new override properties functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)