### PR TITLE
Fix/move override properties to new chainlist

### DIFF
--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -61,32 +61,16 @@ function generateChains(chains, zone_chains) {
   
     // -- Chain Object --
     let chain = {};
-    
-    // -- Get chain_name (no override - used for registry lookup) --
     chain.chain_name = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "chain_name");
-    
-    // -- Get chain_id (no override - fundamental network identifier) --
+    chain.status = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "status");
+    chain.network_type = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "network_type");
+    chain.pretty_name = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "pretty_name");
     chain.chain_id = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "chain_id");
-
-    // -- Get status with override support --
-    chain.status = zone_chain.override_properties?.status || 
-                   chain_reg.getFileProperty(zone_chain.chain_name, "chain", "status");
-    
-    // -- Get network_type with override support --
-    chain.network_type = zone_chain.override_properties?.network_type || 
-                         chain_reg.getFileProperty(zone_chain.chain_name, "chain", "network_type");
-    
-    // -- Get pretty_name with override support --
-    chain.pretty_name = zone_chain.override_properties?.pretty_name || 
-                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "pretty_name");
     
     
-    // -- Get bech32_config with override support --
-    chain.bech32_prefix = zone_chain.override_properties?.bech32_prefix || 
-                          chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_prefix");
-    
-    let bech32_config = zone_chain.override_properties?.bech32_config || 
-                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_config");
+    // -- Get bech32_config --
+    chain.bech32_prefix = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_prefix");
+    let bech32_config = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_config");
     if (!bech32_config) {
       bech32_config = {};
     }
@@ -97,42 +81,37 @@ function generateChains(chains, zone_chains) {
     chain.bech32_config = bech32_config;
 
 
-    // -- Get SLIP44 with override support --
-    chain.slip44 = zone_chain.override_properties?.slip44 || 
-                   chain_reg.getFileProperty(zone_chain.chain_name, "chain", "slip44");
-    chain.alternative_slip44s = zone_chain.override_properties?.alternative_slip44s || 
-                               chain_reg.getFileProperty(zone_chain.chain_name, "chain", "alternative_slip44s");
+    // -- Get SLIP44 --
+    chain.slip44 = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "slip44");
+    chain.alternative_slip44s = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "alternative_slip44s");
 
 
-    // -- Get Fees with override support --
-    chain.fees = zone_chain.override_properties?.fees || 
-                 chain_reg.getFileProperty(zone_chain.chain_name, "chain", "fees");
+    // -- Get Fees --
+    chain.fees = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "fees");
     
     
-    // -- Get Staking with override support --
-    chain.staking = zone_chain.override_properties?.staking || 
-                    chain_reg.getFileProperty(zone_chain.chain_name, "chain", "staking");
+    // -- Get Staking --
+    chain.staking = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "staking");
 
     
-    // -- Get Description with override support --
-    chain.description = zone_chain.override_properties?.description || 
-                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "description");
+    // -- Get Description --
+    chain.description = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "description");
     
     
-    // -- Get APIs with override support --
+    // -- Get APIs --
     chain.apis = {};
     chain.apis.rpc = [];
     chain.apis.rpc[0] = {};
-    chain.apis.rpc[0].address = zone_chain.override_properties?.rpc || zone_chain.rpc;
+    chain.apis.rpc[0].address = zone_chain.rpc;
     chain.apis.rest = [];
     chain.apis.rest[0] = {};
-    chain.apis.rest[0].address = zone_chain.override_properties?.rest || zone_chain.rest;
+    chain.apis.rest[0].address = zone_chain.rest;
     
     
-    // -- Get Explorer Tx URL with override support --
+    // -- Get Explorer Tx URL --
     chain.explorers = [];
     chain.explorers[0] = {};
-    chain.explorers[0].tx_page = zone_chain.override_properties?.explorer_tx_url || zone_chain.explorer_tx_url;
+    chain.explorers[0].tx_page = zone_chain.explorer_tx_url;
 
 
     // -- Get Images --
@@ -152,12 +131,12 @@ function generateChains(chains, zone_chains) {
     }
     
     
-    // -- Get Keplr Suggest Chain Features with override support --
-    chain.features = zone_chain.override_properties?.keplr_features || zone_chain.keplr_features;
+    // -- Get Keplr Suggest Chain Features --
+    chain.features = zone_chain.keplr_features;
     
     
-    // -- Get Outage Alerts with override support --
-    chain.outage = zone_chain.override_properties?.outage || zone_chain.outage;
+    // -- Get Outage Alerts --
+    chain.outage = zone_chain.outage;
     
     
     // -- Push Chain Object --

--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -61,16 +61,32 @@ function generateChains(chains, zone_chains) {
   
     // -- Chain Object --
     let chain = {};
+    
+    // -- Get chain_name (no override - used for registry lookup) --
     chain.chain_name = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "chain_name");
-    chain.status = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "status");
-    chain.network_type = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "network_type");
-    chain.pretty_name = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "pretty_name");
+    
+    // -- Get chain_id (no override - fundamental network identifier) --
     chain.chain_id = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "chain_id");
+
+    // -- Get status with override support --
+    chain.status = zone_chain.override_properties?.status || 
+                   chain_reg.getFileProperty(zone_chain.chain_name, "chain", "status");
+    
+    // -- Get network_type with override support --
+    chain.network_type = zone_chain.override_properties?.network_type || 
+                         chain_reg.getFileProperty(zone_chain.chain_name, "chain", "network_type");
+    
+    // -- Get pretty_name with override support --
+    chain.pretty_name = zone_chain.override_properties?.pretty_name || 
+                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "pretty_name");
     
     
-    // -- Get bech32_config --
-    chain.bech32_prefix = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_prefix");
-    let bech32_config = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_config");
+    // -- Get bech32_config with override support --
+    chain.bech32_prefix = zone_chain.override_properties?.bech32_prefix || 
+                          chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_prefix");
+    
+    let bech32_config = zone_chain.override_properties?.bech32_config || 
+                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "bech32_config");
     if (!bech32_config) {
       bech32_config = {};
     }
@@ -81,37 +97,42 @@ function generateChains(chains, zone_chains) {
     chain.bech32_config = bech32_config;
 
 
-    // -- Get SLIP44 --
-    chain.slip44 = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "slip44");
-    chain.alternative_slip44s = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "alternative_slip44s");
+    // -- Get SLIP44 with override support --
+    chain.slip44 = zone_chain.override_properties?.slip44 || 
+                   chain_reg.getFileProperty(zone_chain.chain_name, "chain", "slip44");
+    chain.alternative_slip44s = zone_chain.override_properties?.alternative_slip44s || 
+                               chain_reg.getFileProperty(zone_chain.chain_name, "chain", "alternative_slip44s");
 
 
-    // -- Get Fees --
-    chain.fees = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "fees");
+    // -- Get Fees with override support --
+    chain.fees = zone_chain.override_properties?.fees || 
+                 chain_reg.getFileProperty(zone_chain.chain_name, "chain", "fees");
     
     
-    // -- Get Staking --
-    chain.staking = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "staking");
+    // -- Get Staking with override support --
+    chain.staking = zone_chain.override_properties?.staking || 
+                    chain_reg.getFileProperty(zone_chain.chain_name, "chain", "staking");
 
     
-    // -- Get Description --
-    chain.description = chain_reg.getFileProperty(zone_chain.chain_name, "chain", "description");
+    // -- Get Description with override support --
+    chain.description = zone_chain.override_properties?.description || 
+                        chain_reg.getFileProperty(zone_chain.chain_name, "chain", "description");
     
     
-    // -- Get APIs --
+    // -- Get APIs with override support --
     chain.apis = {};
     chain.apis.rpc = [];
     chain.apis.rpc[0] = {};
-    chain.apis.rpc[0].address = zone_chain.rpc;
+    chain.apis.rpc[0].address = zone_chain.override_properties?.rpc || zone_chain.rpc;
     chain.apis.rest = [];
     chain.apis.rest[0] = {};
-    chain.apis.rest[0].address = zone_chain.rest;
+    chain.apis.rest[0].address = zone_chain.override_properties?.rest || zone_chain.rest;
     
     
-    // -- Get Explorer Tx URL --
+    // -- Get Explorer Tx URL with override support --
     chain.explorers = [];
     chain.explorers[0] = {};
-    chain.explorers[0].tx_page = zone_chain.explorer_tx_url;
+    chain.explorers[0].tx_page = zone_chain.override_properties?.explorer_tx_url || zone_chain.explorer_tx_url;
 
 
     // -- Get Images --
@@ -131,12 +152,12 @@ function generateChains(chains, zone_chains) {
     }
     
     
-    // -- Get Keplr Suggest Chain Features --
-    chain.features = zone_chain.keplr_features;
+    // -- Get Keplr Suggest Chain Features with override support --
+    chain.features = zone_chain.override_properties?.keplr_features || zone_chain.keplr_features;
     
     
-    // -- Get Outage Alerts --
-    chain.outage = zone_chain.outage;
+    // -- Get Outage Alerts with override support --
+    chain.outage = zone_chain.override_properties?.outage || zone_chain.outage;
     
     
     // -- Push Chain Object --

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1215,7 +1215,20 @@
       "chain_name": "atomone",
       "rpc": "https://atomone-rpc.allinbits.com",
       "rest": "https://atomone-api.allinbits.com",
-      "explorer_tx_url": "https://www.mintscan.io/atomone/tx/${txHash}"
+      "explorer_tx_url": "https://www.mintscan.io/atomone/tx/${txHash}",
+      "override_properties": {
+        "fees": {
+          "fee_tokens": [
+            {
+              "denom": "uphoton",
+              "fixed_min_gas_price": 0.225,
+              "low_gas_price": 0.225,
+              "average_gas_price": 0.3,
+              "high_gas_price": 0.5
+            }
+          ]
+        }
+      }
     },
     {
       "chain_name": "dungeon1",


### PR DESCRIPTION
## Summary
  - Revert `override_properties` changes from
  `generate_chainlist.mjs` (except pre-existing
  `images` override)
  - Implement comprehensive `override_properties`       
  support in `generate_chainlist_new.mjs`
  - Add override support for: `status`,
  `network_type`, `pretty_name`, `bech32_prefix`,       
  `bech32_config`, `slip44`, `alternative_slip44s`,     
  `fees`, `staking`, `description`, `rpc`, `rest`,      
  `explorer_tx_url`, `keplr_features`, and `outage`     

  ## Context
  The recent commit (078715f7) mistakenly added
  `override_properties` support to the old chainlist    
   generator (`generate_chainlist.mjs`) when it
  should have been added to the new one
  (`generate_chainlist_new.mjs`). This PR corrects      
  that by:

  1. Reverting the incorrect changes from the old       
  generator
  2. Properly implementing the feature in the new       
  generator with similar logic adapted to its
  different function structure

  ## Technical Details
  The new implementation maintains backward
  compatibility using the `||` operator pattern:        
  ```javascript
  chain.property =
  zoneChain.override_properties?.property ||

  chain_reg.getFileProperty(chain_name, "chain",        
  "property");

  This allows zone-specific customization while
  falling back to chain registry values when
  overrides are not specified.

  Test plan

  - Verify that AtomOne configuration still works       
  with fee overrides
  - Confirm chainlist generation produces expected      
  output
  - Check that non-overridden properties still fall     
  back to chain registry values correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add override_properties support across chain metadata in generate_chainlist_new.mjs and define AtomOne fee overrides in osmosis.zone_chains.json.
> 
> - **Generator (`.github/workflows/utility/generate_chainlist_new.mjs`)**:
>   - Add override support (`zoneChain.override_properties`) for: `status`, `network_type`, `pretty_name`, `bech32_prefix`, `bech32_config`, `slip44`, `alternative_slip44s`, `fees`, `staking`, `rpc`, `rest`, `explorer_tx_url`, `description`, `keplr_features`, and `outage`.
>   - Prefer overrides for API endpoints and explorer URLs; propagate overridden Bech32 and SLIP44 settings; include overridden Keplr features.
> - **Zone chains config (`osmosis-1/osmosis.zone_chains.json`)**:
>   - For `chain_name: atomone`, add `override_properties.fees` with `uphoton` gas price settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44d4d289cb76a9251017e61315f96f214c7d88d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->