### PR TITLE
Add missing asset entry for Bostrom

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6350,6 +6350,13 @@
       "path": "transfer/channel-106313/ulume",
       "osmosis_verified": false,
       "_comment": "Lumera $LUME"
+    },
+    {
+      "chain_name": "bostrom",
+      "base_denom": "pool906F3CC4C0F4634031990DB81761BD390890F8A8A80460EBDC6B151254DE7D1D",
+      "path": "transfer/channel-95/pool906F3CC4C0F4634031990DB81761BD390890F8A8A80460EBDC6B151254DE7D1D",
+      "osmosis_verified": false,
+      "_comment": "Bostrom Pooled Ampere/Volt"
     }
   ]
 }


### PR DESCRIPTION
## Description


Adding token: pool906F3CC4C0F4634031990DB81761BD390890F8A8A80460EBDC6B151254DE7D1D from chain Bostrom

Denom trace: https://rest.cosmos.directory/osmosis/ibc/apps/transfer/v1/denom_traces/9BBC8BD41DC282F0DF4709ED7562F5B12F161D8DD391386B79EF179AA50621C3

This is to alleviate the console errors from the frontend: 
<img width="1636" height="329" alt="image" src="https://github.com/user-attachments/assets/fcd10aba-6dea-4f4b-99ab-1b4a2fbb29d4" />


## Checklist

### Adding Assets

If adding a new asset, please ensure the following:
- [ ] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [ ] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [ ] Optional: `transfer_methods`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  
