### PR TITLE
Add optio to zone_assets and zone_chains

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6714,6 +6714,13 @@
       "categories": [
         "meme"
       ]
+    },
+    {
+      "chain_name": "optio",
+      "base_denom": "uOPT",
+      "path": "transfer/channel-108371/uOPT",
+      "osmosis_verified": false,
+      "_comment": "Optio $OPT"
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1453,6 +1453,15 @@
         "ibc-go",
         "cosmwasm"
       ]
+    },
+    {
+      "chain_name": "optio",
+      "rpc": "https://rpc.optio.zone",
+      "rest": "https://api.optio.zone",
+      "explorer_tx_url": "https://https://optioscan.io/optio/transactions/${txHash}",
+      "keplr_features": [
+        "ibc-go"      
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding chain: Optio
Adding token: OPT from chain Optio
See OPT/USDC Pool 3278

## Checklist

### Adding Assets

If adding a new asset, please ensure the following:
- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry (skip if native to Osmosis).
   - [x] `osmosis_verified` is set to `false`
   - [ ] Optional: `transfer_methods`, `override_properties`, `canonical`, `categories`, where necessary (see [README](https://github.com/osmosis-labs/assetlists/tree/main?tab=readme-ov-file#how-to-add-assets) for details).
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo (checklist below).  

### Adding Chains

If adding a new chain, please ensure the following:
- [x] Chain is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - Chain's registration must have `staking` defined, with at least one `staking_token` denom specified.
   - Chain's registration must have `fees` defined; at least one fee token has low, average, and high gas prices defined.
- [x] IBC Connection between chain and Osmosis is registered.
- [x] Add chain to bottom of `zone_chains.json`
   - [x] `rpc` and `rest` does not have any CORS blocking of the Osmosis domain, and RPC node has have WSS enabled.
   - [x] `explorer_tx_url` correctly directs to the transaction when the hash is inserted into the URL.

