### PR TITLE
Change osmosis_verified status to true for intento

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6331,7 +6331,7 @@
       "chain_name": "intento",
       "base_denom": "uinto",
       "path": "transfer/channel-106076/uinto",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "categories": [
         "defi"
       ],


### PR DESCRIPTION
## Description

Change `osmosis_verified` status to `true` for INTO on Osmosis.

## Checklist

<!-- The following checklist can be ticked after Creating the PR -->

### Upgrading Asset to Verified

<!-- If NOT upgrading asset status, please remove this 'Upgrading Asset to Verified' section. -->

If upgrading an Asset to Verified, please see the requirements specified at [LISTING](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md#upgrade-asset-to-verified-status-permissioned), and ensure the following:
- [x] Asset is defined thoroughly at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - [x] A meaningful `description` (and `extended_description`, unless: meme or variant/derivative asset).
   - [x] Associated `socials`, including `website` and `twitter` (unless: meme or variant/derivative asset).
   - [x] **Logo Image** has a square Aspect Ratio, < 250 KB file size, and appropriate visual contrast with Osmosis Zone's colors.
- [x]  **Liquidity**: This pool meets the liquidity requirements, and has a +-2% depth of $50 (~$5k full range liq.) (Provide Pool ID): **3138**

'Verified' Status Validation Checklist (to be completed by Osmosis Zone maintainers):
- [x] Verify appearance and metadata
- [x] Accurate Price
- [x] Trading and routing functionality
   - [x] $50 USDC offer yields at least $49-worth of this Asset
- [x] Withdraw and Deposit
   - [ ] Deposit Transaction URL (if in-app)

