### PR TITLE
Add deploy filter

### DIFF
--- a/.github/workflows/deploy_vercel.yml
+++ b/.github/workflows/deploy_vercel.yml
@@ -8,6 +8,13 @@ on:
   push:
     branches:
       - main
+    # Only run this workflow if one of the four frontend JSON files changed
+    paths:
+      - osmosis-1/generated/frontend/assetlist.json
+      - osmosis-1/generated/frontend/chainlist.json
+      - osmo-test-5/generated/frontend/assetlist.json
+      - osmo-test-5/generated/frontend/chainlist.json
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -34,9 +41,24 @@ jobs:
           done
           echo "Failed to fetch latest commit after $MAX_RETRIES attempts."
           exit 1
+
+      # Preview/Stage (only if osmosis-1 assetlist/chainlist changed)
       - name: Deploy preview
+        if: |
+          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/assetlist.json') ||
+          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/chainlist.json')
         run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_STAGE }}
+
+      # Testnet (only if osmo-test-5 assetlist/chainlist changed)
       - name: Deploy testnet
+        if: |
+          contains(join(github.event.commits.*.modified, ','), 'osmo-test-5/generated/frontend/assetlist.json') ||
+          contains(join(github.event.commits.*.modified, ','), 'osmo-test-5/generated/frontend/chainlist.json')
         run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_TESTNET }}
+
+      # Production (same condition as preview - only osmosis-1 changes)
       - name: Deploy production
+        if: |
+          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/assetlist.json') ||
+          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/chainlist.json')
         run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_PRODUCTION }}


### PR DESCRIPTION
## Description

Stops vercel redeploying on every push - only those that impact the assetlist and chain list.
