### PR TITLE
Split deploy hook to mainnet and testnet

### DIFF
--- a/.github/workflows/deploy_vercel_mainnet.yml
+++ b/.github/workflows/deploy_vercel_mainnet.yml
@@ -1,19 +1,16 @@
-# Description: Triggers Vercel deployment webhooks for preview, testnet, and production
+# Description: Triggers Vercel deployment webhooks for mainnet (preview and production)
 # Included in: NOT included in Generate All Files bundle (deployment only)
-# Trigger: Automatically runs on push to main branch
-# Output: Deploys to Vercel environments via webhooks
+# Trigger: Automatically runs on push to main branch when osmosis-1 frontend files change
+# Output: Deploys to Vercel preview and production environments via webhooks
 
-name: Osmosis Front-End Deployment
+name: Osmosis Front-End Deployment (Mainnet)
 on:
   push:
     branches:
       - main
-    # Only run this workflow if one of the four frontend JSON files changed
     paths:
       - osmosis-1/generated/frontend/assetlist.json
       - osmosis-1/generated/frontend/chainlist.json
-      - osmo-test-5/generated/frontend/assetlist.json
-      - osmo-test-5/generated/frontend/chainlist.json
 
 jobs:
   deploy:
@@ -42,23 +39,8 @@ jobs:
           echo "Failed to fetch latest commit after $MAX_RETRIES attempts."
           exit 1
 
-      # Preview/Stage (only if osmosis-1 assetlist/chainlist changed)
       - name: Deploy preview
-        if: |
-          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/assetlist.json') ||
-          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/chainlist.json')
         run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_STAGE }}
 
-      # Testnet (only if osmo-test-5 assetlist/chainlist changed)
-      - name: Deploy testnet
-        if: |
-          contains(join(github.event.commits.*.modified, ','), 'osmo-test-5/generated/frontend/assetlist.json') ||
-          contains(join(github.event.commits.*.modified, ','), 'osmo-test-5/generated/frontend/chainlist.json')
-        run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_TESTNET }}
-
-      # Production (same condition as preview - only osmosis-1 changes)
       - name: Deploy production
-        if: |
-          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/assetlist.json') ||
-          contains(join(github.event.commits.*.modified, ','), 'osmosis-1/generated/frontend/chainlist.json')
         run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_PRODUCTION }}

--- a/.github/workflows/deploy_vercel_testnet.yml
+++ b/.github/workflows/deploy_vercel_testnet.yml
@@ -1,0 +1,43 @@
+# Description: Triggers Vercel deployment webhook for testnet
+# Included in: NOT included in Generate All Files bundle (deployment only)
+# Trigger: Automatically runs on push to main branch when osmo-test-5 frontend files change
+# Output: Deploys to Vercel testnet environment via webhook
+
+name: Osmosis Front-End Deployment (Testnet)
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - osmo-test-5/generated/frontend/assetlist.json
+      - osmo-test-5/generated/frontend/chainlist.json
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check latest commit matches API
+        id: check_commit
+        run: |
+          MAX_RETRIES=5
+          RETRY_COUNT=0
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            LATEST_COMMIT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/commits/main | jq -r '.sha')
+            if [ "$LATEST_COMMIT" != "" ]; then
+              echo "Latest commit: $LATEST_COMMIT"
+              echo "Workflow commit: ${{ github.sha }}"
+              if [ "$LATEST_COMMIT" != "${{ github.sha }}" ]; then
+                echo "The workflow commit and the latest commit do not match."
+                exit 1
+              fi
+              exit 0
+            fi
+            RETRY_COUNT=$((RETRY_COUNT+1))
+            echo "Failed to fetch latest commit, retrying ($RETRY_COUNT/$MAX_RETRIES)..."
+            sleep 5
+          done
+          echo "Failed to fetch latest commit after $MAX_RETRIES attempts."
+          exit 1
+
+      - name: Deploy testnet
+        run: curl -X POST ${{ secrets.VERCEL_WEBHOOK_DEPLOY_TESTNET }}


### PR DESCRIPTION
## Description

Splits deploy hook into a mainnet and testnet file
This ensures that deploy only runs for mainnet when relevant files are generated and vice versa.