### PR TITLE
Delete 'Sunrise RISE' asset details from JSON

### DIFF
--- a/upcoming/upcoming_assets.json
+++ b/upcoming/upcoming_assets.json
@@ -18,24 +18,6 @@
       "showLaunchDate": true,
       "osmosisAirdrop": false,
       "airdropInfoUrl": ""
-    },
-    {
-      "assetName": "Sunrise RISE",
-      "symbol": "RISE",
-      "chainName": "Sunrise",
-      "images": [
-        {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sunrise/images/sunrise.svg"
-        }
-      ],
-      "socials": {
-        "website": "https://sunriselayer.io/",
-        "twitter": "https://x.com/SunriseLayer"
-      },
-      "estimatedLaunchDateUtc": "Soon",
-      "showLaunchDate": true,
-      "osmosisAirdrop": false,
-      "airdropInfoUrl": ""
     }
   ]
 }


### PR DESCRIPTION
Removed asset information for 'Sunrise RISE' from upcoming assets as it's live now.

<img width="747" height="145" alt="image" src="https://github.com/user-attachments/assets/4839b80d-b6e0-44bd-b191-1cce841ada52" />
