### PR TITLE
Add Lumen chain and LMN asset to Osmosis assetlists

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8876,6 +8876,13 @@
       "path": "transfer/channel-100418/factory/manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj/upwr",
       "osmosis_unstable": true,
       "_comment": "Manifest Power Token $PWR"
+    },
+    {
+      "chain_name": "lumen",
+      "base_denom": "ulmn",
+      "path": "transfer/channel-109674/ulmn",
+      "osmosis_verified": false,
+      "_comment": "Lumen $LMN"
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1546,6 +1546,15 @@
       "rpc": "https://rpc.explorer.shareri.ng",
       "rest": "https://lcd.explorer.shareri.ng/",
       "explorer_tx_url": "https://explorer.shareri.ng/transactions/${txHash}"
+    },
+    {
+      "chain_name": "lumen",
+      "rpc": "https://lumen-rpc.linknode.org",
+      "rest": "https://lumen-api.linknode.org",
+      "explorer_tx_url": "https://explorer.onenov.xyz/lumen/tx/${txHash}",
+      "keplr_features": [
+        "ibc-go"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds Lumen chain metadata and the native LMN asset to the Osmosis assetlists.

Changes:
- add `lumen` to `osmosis-1/osmosis.zone_chains.json`
- add native asset `ulmn` to `osmosis-1/osmosis.zone_assets.json`

## Chain metadata

- chain_name: `lumen`
- rpc: `https://lumen-rpc.linknode.org`
- rest: `https://lumen-api.linknode.org`
- explorer_tx_url: `https://explorer.onenov.xyz/lumen/tx/${txHash}`
- keplr_features: `["ibc-go"]`

## Asset metadata

- chain_name: `lumen`
- base_denom: `ulmn`
- path: `transfer/channel-109674/ulmn`
- osmosis_verified: `false`

## IBC route

Live route verified on-chain:
- Lumen channel: `channel-1`
- Osmosis channel: `channel-109674`

Computed Osmosis denom:
- `ibc/88DBE57372690630D2DD9779C247479CE124E777C5D695FA90699F3140CEC59F`

## Liquidity

There is already an Osmosis pool for LMN:
- Pool ID: `3416`

Current pool pair:
- `LMN / OSMO`