### PR TITLE
Remove Osmosis Pro transfer_methods entries

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1596,13 +1596,6 @@
       "base_denom": "aplanq",
       "path": "transfer/channel-492/aplanq",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=planq_7070-2&token0=aplanq&token1=ibc%2FB1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF"
-        }
-      ],
       "_comment": "Planq $PLQ",
       "osmosis_unstable": true
     },
@@ -2198,14 +2191,6 @@
       "base_denom": "cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
       "path": "transfer/channel-341/cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=phoenix-1&token0=terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv&token1=ibc%2F98BCD43F190C6960D0005BC46BB765C827403A361C9C03C2FF694150A30284B0",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=phoenix-1&token0=ibc%2F98BCD43F190C6960D0005BC46BB765C827403A361C9C03C2FF694150A30284B0&token1=terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv"
-        }
-      ],
       "_comment": "Lion DAO $ROAR"
     },
     {
@@ -2243,14 +2228,6 @@
       "base_denom": "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
       "path": "transfer/channel-341/cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t",
       "osmosis_verified": false,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=phoenix-1&token0=terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t&token1=ibc%2F6F18EFEBF1688AA77F7EAC17065609494DC1BA12AFC78E9AEC832AF70A11BEF3",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=phoenix-1&token0=ibc%2F6F18EFEBF1688AA77F7EAC17065609494DC1BA12AFC78E9AEC832AF70A11BEF3&token1=terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t"
-        }
-      ],
       "_comment": "Lion Cub DAO $CUB"
     },
     {
@@ -2258,14 +2235,6 @@
       "base_denom": "cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
       "path": "transfer/channel-341/cw20:terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584",
       "osmosis_verified": false,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=phoenix-1&token0=terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584&token1=ibc%2FDA961FE314B009C38595FFE3AF41225D8894D663B8C3F6650DCB5B6F8435592E",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=phoenix-1&token0=ibc%2FDA961FE314B009C38595FFE3AF41225D8894D663B8C3F6650DCB5B6F8435592E&token1=terra1gwrz9xzhqsygyr5asrgyq3pu0ewpn00mv2zenu86yvx2nlwpe8lqppv584"
-        }
-      ],
       "_comment": "BLUE CUB DAO $BLUE"
     },
     {
@@ -2367,13 +2336,6 @@
       "base_denom": "umpwr",
       "path": "transfer/channel-1411/umpwr",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=empowerchain-1&token0=umpwr&token1=ibc%2FDD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38"
-        }
-      ],
       "_comment": "EmpowerChain $MPWR"
     },
     {
@@ -2419,14 +2381,6 @@
       "path": "transfer/channel-782/usei",
       "osmosis_verified": true,
       "tooltip_message": "SEI Transfers will be disabled with the upcoming SIP Upgrade, estimated at the end of Q1 2026. For more information see: https://blog.sei.io/announcements/the-sip-3-upgrade-making-way-for-sei-giga/",
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=pacific-1&chainTo=osmosis-1&token0=usei&token1=ibc%2F71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=pacific-1&token0=ibc%2F71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D&token1=usei"
-        }
-      ],
       "_comment": "Sei $SEI"
     },
     {
@@ -3151,14 +3105,6 @@
       "base_denom": "factory/inj1xtel2knkt8hmc9dnzpjz6kdmacgcfmlv5f308w/ninja",
       "path": "transfer/channel-122/factory/inj1xtel2knkt8hmc9dnzpjz6kdmacgcfmlv5f308w/ninja",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=injective-1&chainTo=osmosis-1&token0=factory%2Finj1xtel2knkt8hmc9dnzpjz6kdmacgcfmlv5f308w%2Fninja&token1=ibc%2F183C0BB962D2F57C957E0B134CFA0AC9D6F755C02DE9DC2A59089BA23009DEC3",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2F183C0BB962D2F57C957E0B134CFA0AC9D6F755C02DE9DC2A59089BA23009DEC3&token1=factory%2Finj1xtel2knkt8hmc9dnzpjz6kdmacgcfmlv5f308w%2Fninja"
-        }
-      ],
       "categories": [
         "meme"
       ],
@@ -3339,14 +3285,6 @@
         "chain_name": "ethereum",
         "base_denom": "0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2"
       },
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=injective-1&chainTo=osmosis-1&token0=peggy0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2&token1=ibc%2F072E5B3D6F278B3E6A9C51D7EAD1A737148609512C5EBE8CBCB5663264A0DDB7",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2F072E5B3D6F278B3E6A9C51D7EAD1A737148609512C5EBE8CBCB5663264A0DDB7&token1=peggy0xd73175f9eb15eee81745d367ae59309Ca2ceb5e2"
-        }
-      ],
       "categories": [
         "gaming"
       ],
@@ -3381,14 +3319,6 @@
       "base_denom": "cw20:terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "path": "transfer/channel-21671/cw20:terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=phoenix-1&token0=terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26&token1=ibc%2FC25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=phoenix-1&token0=ibc%2FC25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7&token1=terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
-        }
-      ],
       "categories": [
         "defi"
       ],
@@ -3427,13 +3357,6 @@
       "base_denom": "aheart",
       "path": "transfer/channel-20082/aheart",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=humans_1089-1&chainTo=osmosis-1&token0=aheart&token1=ibc%2F35CECC330D11DD00FACB555D07687631E0BC7D226260CC5F015F6D7980819533"
-        }
-      ],
       "categories": [
         "ai"
       ],
@@ -3474,14 +3397,6 @@
       "base_denom": "cw20:terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq",
       "path": "transfer/channel-341/cw20:terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq",
       "osmosis_verified": false,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=phoenix-1&token0=terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq&token1=ibc%2F7D389F0ABF1E4D45BE6D7BBE36A2C50EA0559C01E076B02F8E381E685EC1F942",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=phoenix-1&token0=ibc%2F7D389F0ABF1E4D45BE6D7BBE36A2C50EA0559C01E076B02F8E381E685EC1F942&token1=terra1sxe8u2hjczlekwfkcq0rs28egt38pg3wqzfx4zcrese4fnvzzupsk9gjkq"
-        }
-      ],
       "_comment": "Bitmos $BMOS"
     },
     {
@@ -3534,13 +3449,6 @@
       "base_denom": "attoaioz",
       "path": "transfer/channel-779/attoaioz",
       "osmosis_verified": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=aioz_168-1&chainTo=osmosis-1&token0=attoaioz&token1=ibc%2FBB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F"
-        }
-      ],
       "categories": [
         "ai",
         "dweb"
@@ -3633,14 +3541,6 @@
         "base_denom": "0xA4426666addBE8c4985377d36683D17FB40c31Be"
       },
       "osmosis_verified": false,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=injective-1&chainTo=osmosis-1&token0=peggy0xA4426666addBE8c4985377d36683D17FB40c31Be&token1=ibc%2FB84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2FB84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000&token1=peggy0xA4426666addBE8c4985377d36683D17FB40c31Be"
-        }
-      ],
       "_comment": "Gelotto BEAST $BEAST"
     },
     {
@@ -3667,14 +3567,6 @@
       "path": "transfer/channel-341/cw20:terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
       "osmosis_verified": false,
       "osmosis_unlisted": true,
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainTo=osmosis-1&chainFrom=phoenix-1&token0=terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3&token1=ibc%2F06EF575844982382F4D1BC3830D294557A30EDB3CD223153AFC8DFEF06349C56",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=phoenix-1&token0=ibc%2F06EF575844982382F4D1BC3830D294557A30EDB3CD223153AFC8DFEF06349C56&token1=terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3"
-        }
-      ],
       "_comment": "sayve $SAYVE"
     },
     {
@@ -5105,14 +4997,6 @@
       "chain_name": "injective",
       "base_denom": "factory/inj1je6n5sr4qtx2lhpldfxndntmgls9hf38ncmcez/COSMO",
       "path": "transfer/channel-122/factory/inj1je6n5sr4qtx2lhpldfxndntmgls9hf38ncmcez/COSMO",
-      "transfer_methods": [
-        {
-          "name": "Osmosis Pro TFM IBC Transfer",
-          "type": "external_interface",
-          "deposit_url": "https://pro.osmosis.zone/ibc?chainFrom=injective-1&chainTo=osmosis-1&token0=factory%2Finj1je6n5sr4qtx2lhpldfxndntmgls9hf38ncmcez%2FCOSMO&token1=ibc%2F4925733868E7999F5822C961ADE9470A7FC5FA4A560BAE1DE102783C3F64C201",
-          "withdraw_url": "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2F4925733868E7999F5822C961ADE9470A7FC5FA4A560BAE1DE102783C3F64C201&token1=factory%2Finj1je6n5sr4qtx2lhpldfxndntmgls9hf38ncmcez%2FCOSMO"
-        }
-      ],
       "categories": [
         "rwa"
       ],


### PR DESCRIPTION
Strip out transfer_methods blocks that reference the Osmosis Pro TFM external_interface (pro.osmosis.zone deposit/withdraw URLs) from osmosis-1/osmosis.zone_assets.json across multiple asset entries. This cleans up obsolete/redundant external transfer metadata for various tokens; no other asset fields were changed.
