### PR TITLE
feat: add QIE IBC asset from QIE chain (channel-109956)

### DIFF
--- a/osmosis-1/keplr_base_template.json
+++ b/osmosis-1/keplr_base_template.json
@@ -52,6 +52,13 @@
       "coinDecimals": 6,
       "coinGeckoId": "namada",
       "coinImageUrl": "https://raw.githubusercontent.com/chainapsis/keplr-chain-registry/main/images/osmosis/ibc/C7110DEC66869DAE9BE9C3C60F4B5313B16A2204AE020C3B0527DD6B322386A3.png"
+    },
+    {
+      "coinDenom": "QIE",
+      "coinMinimalDenom": "ibc/29651CA364AA857248A912B1DEC17EF8AC320728C616FB635338CFE965E18BE3",
+      "coinDecimals": 18,
+      "coinGeckoId": "qie",
+      "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qie/images/qie.png"
     }
   ],
   "feeCurrencies": [

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8828,6 +8828,6 @@
       "path": "transfer/channel-109956/aqie",
       "osmosis_verified": false,
       "_comment": "QIE $QIE"
-}
+    }
   ]
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8821,6 +8821,13 @@
       "path": "transfer/channel-297/ubcre",
       "osmosis_unstable": true,
       "_comment": "Bonded Crescent $bCRE"
-    }
+    },
+    {
+      "chain_name": "qie",
+      "base_denom": "aqie",
+      "path": "transfer/channel-109956/aqie",
+      "osmosis_verified": false,
+      "_comment": "QIE $QIE"
+}
   ]
 }


### PR DESCRIPTION
## Description

Adding chain: QIE
Adding token: QIE from chain QIE
IBC Channel: channel-109956
IBC Denom: ibc/29651CA364AA857248A912B1DEC17EF8AC320728C616FB635338CFE965E18BE3

## Checklist

### Adding Assets

- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
- [x] Add asset to bottom of `zone_assets.json`.
   - [x] `chain_name` and `base_denom` are provided and use values exactly as defined at the Chain Registry.
   - [x] `path` is provided, and the IBC channel referenced is registered at the Chain Registry.
   - [x] `osmosis_verified` is set to `false`
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo.