### PR TITLE
Prefer explorer tx_page template; regen chainlists

### DIFF
--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -334,8 +334,14 @@ async function getSuggestionChainProperties(minimalChain, zoneChain = {}) {
   if (!rpc) return false;
 
   // -- Get Explorer Tx URL with override support --
+  // Chain Registry uses tx_page (snake_case). Prefer an explorer whose tx_page
+  // contains the {txHash} template (matches the zone schema's required pattern);
+  // fall back to the first explorer that has any tx_page at all.
   let explorers = chain_reg.getFileProperty(chain.chain_name, "chain", "explorers");
-  let explorer = zoneChain.override_properties?.explorer_tx_url || zoneChain.explorer_tx_url || explorers?.[0]?.txPage;
+  let registryExplorerTxPage =
+    explorers?.find((e) => e?.tx_page?.includes("{txHash}"))?.tx_page ||
+    explorers?.find((e) => e?.tx_page)?.tx_page;
+  let explorer = zoneChain.override_properties?.explorer_tx_url || zoneChain.explorer_tx_url || registryExplorerTxPage;
   if (!explorer) return false;
 
   // -- By this point, we have the minimum required data to be able to suggest the chain --

--- a/osmo-test-5/generated/frontend/chainlist.json
+++ b/osmo-test-5/generated/frontend/chainlist.json
@@ -2474,19 +2474,2971 @@
     },
     {
       "chain_name": "osmosis",
+      "status": "live",
+      "networkType": "mainnet",
       "prettyName": "Osmosis",
+      "chain_id": "osmosis-1",
+      "bech32Prefix": "osmo",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "osmo",
+        "bech32PrefixAccPub": "osmopub",
+        "bech32PrefixValAddr": "osmovaloper",
+        "bech32PrefixValPub": "osmovaloperpub",
+        "bech32PrefixConsAddr": "osmovalcons",
+        "bech32PrefixConsPub": "osmovalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "OSMO",
+        "coinMinimalDenom": "uosmo",
+        "coinDecimals": 6,
+        "coinGeckoId": "osmosis",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "OSMO",
+          "coinMinimalDenom": "uosmo",
+          "coinDecimals": 6,
+          "coinGeckoId": "osmosis",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+          "gasPriceStep": {
+            "low": 0.03,
+            "average": 0.1,
+            "high": 0.16
+          }
+        },
+        {
+          "coinDenom": "ICP",
+          "coinMinimalDenom": "factory/osmo10c4y9csfs8q7mtvfg4p9gd8d0acx0hpc2mte9xqzthd7rd3348tsfhaesm/sICP-native-ICP",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/internetcomputer/images/icp.png"
+        },
+        {
+          "coinDenom": "BADKID",
+          "coinMinimalDenom": "factory/osmo10n8rv8npx870l69248hnp6djy6pll2yuzzn9x8/BADKID",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/badkid.png"
+        },
+        {
+          "coinDenom": "LAB",
+          "coinMinimalDenom": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/LAB.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "factory/osmo1em6xs47hd82806f5cxgyufguxrrc7l0aqx7nzzptjuqgswczk8csavdxek/alloyed/allUSDT",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "milkTIA",
+          "coinMinimalDenom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
+          "coinDecimals": 6,
+          "coinGeckoId": "milkyway-staked-tia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/milktia.png"
+        },
+        {
+          "coinDenom": "sqOSMO",
+          "coinMinimalDenom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqosmo.svg"
+        },
+        {
+          "coinDenom": "ETH",
+          "coinMinimalDenom": "factory/osmo1k6c8jln7ejuqwtqmay3yvzrg3kueaczl96pk067ldg8u835w0yhsw27twm/alloyed/allETH",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
+        },
+        {
+          "coinDenom": "LVN",
+          "coinMinimalDenom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
+          "coinDecimals": 6,
+          "coinGeckoId": "levana-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.png"
+        },
+        {
+          "coinDenom": "SOL",
+          "coinMinimalDenom": "factory/osmo1n3n75av8awcnw4jl62n3l48e6e4sxqmaf97w5ua6ddu4s475q5qq9udvx4/alloyed/allSOL",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol_circle.png"
+        },
+        {
+          "coinDenom": "CAC",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/cac",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CAC.png"
+        },
+        {
+          "coinDenom": "PBB",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/pbb",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/PBB.png"
+        },
+        {
+          "coinDenom": "SHITMOS",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/shitmos",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png"
+        },
+        {
+          "coinDenom": "bOSMO",
+          "coinMinimalDenom": "factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bOSMO.png"
+        },
+        {
+          "coinDenom": "CDT",
+          "coinMinimalDenom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
+          "coinDecimals": 6,
+          "coinGeckoId": "collateralized-debt-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CDT.svg"
+        },
+        {
+          "coinDenom": "MBRN",
+          "coinMinimalDenom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
+          "coinDecimals": 6,
+          "coinGeckoId": "membrane",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/MBRN.svg"
+        },
+        {
+          "coinDenom": "stIBCX",
+          "coinMinimalDenom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.png"
+        },
+        {
+          "coinDenom": "WBTC",
+          "coinMinimalDenom": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
+          "coinDecimals": 8,
+          "coinGeckoId": "wrapped-bitcoin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png"
+        },
+        {
+          "coinDenom": "BTC",
+          "coinMinimalDenom": "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoin/images/btc.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
+          "coinDecimals": 6,
+          "coinGeckoId": "tether",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "SAGA",
+          "coinMinimalDenom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
+          "coinDecimals": 6,
+          "coinGeckoId": "saga-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga_white.png"
+        },
+        {
+          "coinDenom": "SCRT",
+          "coinMinimalDenom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+          "coinDecimals": 6,
+          "coinGeckoId": "secret",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png"
+        },
+        {
+          "coinDenom": "DAI",
+          "coinMinimalDenom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+          "coinDecimals": 18,
+          "coinGeckoId": "dai",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/dai.svg"
+        },
+        {
+          "coinDenom": "LUNC",
+          "coinMinimalDenom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+          "coinDecimals": 6,
+          "coinGeckoId": "terra-luna",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png"
+        },
+        {
+          "coinDenom": "UM",
+          "coinMinimalDenom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/penumbra/images/um.png"
+        },
+        {
+          "coinDenom": "ARB",
+          "coinMinimalDenom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
+          "coinDecimals": 18,
+          "coinGeckoId": "arbitrum",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.png"
+        },
+        {
+          "coinDenom": "NTRN",
+          "coinMinimalDenom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
+          "coinDecimals": 6,
+          "coinGeckoId": "neutron-3",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.png"
+        },
+        {
+          "coinDenom": "AKT",
+          "coinMinimalDenom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+          "coinDecimals": 6,
+          "coinGeckoId": "akash-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png"
+        },
+        {
+          "coinDenom": "ORAI",
+          "coinMinimalDenom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+          "coinDecimals": 6,
+          "coinGeckoId": "oraichain-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-token.png"
+        },
+        {
+          "coinDenom": "OM",
+          "coinMinimalDenom": "ibc/164807F6226F91990F358C6467EEE8B162E437BDCD3DADEC3F0CE20693720795",
+          "coinDecimals": 6,
+          "coinGeckoId": "mantra-dao",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.png"
+        },
+        {
+          "coinDenom": "SCR",
+          "coinMinimalDenom": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.png"
+        },
+        {
+          "coinDenom": "LAVA",
+          "coinMinimalDenom": "ibc/1AEF145C549D4F9847C79E49710B198C294C7F4A107F4610DEE8E725FFC4B378",
+          "coinDecimals": 6,
+          "coinGeckoId": "lava-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lava/images/lava.png"
+        },
+        {
+          "coinDenom": "QSR.legacy",
+          "coinMinimalDenom": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quasar/images/quasar.png"
+        },
+        {
+          "coinDenom": "NGM",
+          "coinMinimalDenom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+          "coinDecimals": 6,
+          "coinGeckoId": "e-money",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png"
+        },
+        {
+          "coinDenom": "REGEN",
+          "coinMinimalDenom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+          "coinDecimals": 6,
+          "coinGeckoId": "regen",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
+        },
+        {
+          "coinDenom": "TGD",
+          "coinMinimalDenom": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png"
+        },
+        {
+          "coinDenom": "SOL",
+          "coinMinimalDenom": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
+          "coinDecimals": 8,
+          "coinGeckoId": "wrapped-solana",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol_circle.png"
+        },
+        {
+          "coinDenom": "USDY",
+          "coinMinimalDenom": "ibc/23104D411A6EB6031FA92FB75F227422B84989969E91DCAD56A535DD7FF0A373",
+          "coinDecimals": 18,
+          "coinGeckoId": "ondo-us-dollar-yield",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/usdy.png"
+        },
+        {
+          "coinDenom": "PAGE",
+          "coinMinimalDenom": "ibc/23A62409E4AD8133116C249B1FA38EED30E500A115D7B153109462CD82C1CD99",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/page.png"
+        },
+        {
+          "coinDenom": "ARCH",
+          "coinMinimalDenom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
+          "coinDecimals": 18,
+          "coinGeckoId": "archway",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/arch.png"
+        },
+        {
+          "coinDenom": "CMST",
+          "coinMinimalDenom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+          "coinDecimals": 6,
+          "coinGeckoId": "composite",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png"
+        },
+        {
+          "coinDenom": "ATOM",
+          "coinMinimalDenom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          "coinDecimals": 6,
+          "coinGeckoId": "cosmos",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png"
+        },
+        {
+          "coinDenom": "NETA",
+          "coinMinimalDenom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+          "coinDecimals": 6,
+          "coinGeckoId": "neta",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
+        },
+        {
+          "coinDenom": "FX",
+          "coinMinimalDenom": "ibc/2B30802A0B03F91E4E16D6175C9B70F2911377C1CAE9E50FF011C821465463F9",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fxcore/images/fx.png"
+        },
+        {
+          "coinDenom": "BLD",
+          "coinMinimalDenom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+          "coinDecimals": 6,
+          "coinGeckoId": "agoric",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
+        },
+        {
+          "coinDenom": "XION",
+          "coinMinimalDenom": "ibc/2E3784772E70F7B3A638BA88F65C8BE125D3CDB6E28C6AABC51098C94F5E16A5",
+          "coinDecimals": 6,
+          "coinGeckoId": "xion-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
+        },
+        {
+          "coinDenom": "WYND",
+          "coinMinimalDenom": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.png"
+        },
+        {
+          "coinDenom": "DIG",
+          "coinMinimalDenom": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
+        },
+        {
+          "coinDenom": "DARC",
+          "coinMinimalDenom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png"
+        },
+        {
+          "coinDenom": "NYM",
+          "coinMinimalDenom": "ibc/37CB3078432510EE57B9AFA8DBE028B33AE3280A144826FEAC5F2334CF2C5539",
+          "coinDecimals": 6,
+          "coinGeckoId": "nym",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nym_token_light.png"
+        },
+        {
+          "coinDenom": "DGN",
+          "coinMinimalDenom": "ibc/3B95D63B520C283BCA86F8CD426D57584039463FD684A5CBA31D2780B86A1995",
+          "coinDecimals": 6,
+          "coinGeckoId": "dragon-coin-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dungeon/images/DGN.png"
+        },
+        {
+          "coinDenom": "MED",
+          "coinMinimalDenom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+          "coinDecimals": 6,
+          "coinGeckoId": "medibloc",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
+        },
+        {
+          "coinDenom": "DOT",
+          "coinMinimalDenom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+          "coinDecimals": 10,
+          "coinGeckoId": "polkadot",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png"
+        },
+        {
+          "coinDenom": "NIBI",
+          "coinMinimalDenom": "ibc/4017C65CEA338196ECCEC3FE3FE8258F23D1DE88F1D95750CC912C7A1C1016FF",
+          "coinDecimals": 6,
+          "coinGeckoId": "nibiru",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.png"
+        },
+        {
+          "coinDenom": "CRBRUS",
+          "coinMinimalDenom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
+        },
+        {
+          "coinDenom": "qOSMO",
+          "coinMinimalDenom": "ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC",
+          "coinDecimals": 6,
+          "coinGeckoId": "osmosis",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.png"
+        },
+        {
+          "coinDenom": "JUNO",
+          "coinMinimalDenom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+          "coinDecimals": 6,
+          "coinGeckoId": "juno-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          "coinDecimals": 6,
+          "coinGeckoId": "usd-coin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
+          "coinDecimals": 6,
+          "coinGeckoId": "tether",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "BTSG",
+          "coinMinimalDenom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+          "coinDecimals": 6,
+          "coinGeckoId": "bitsong",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png"
+        },
+        {
+          "coinDenom": "HYDROGEN",
+          "coinMinimalDenom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
+          "coinDecimals": 0,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/hydrogen.png"
+        },
+        {
+          "coinDenom": "MNTA",
+          "coinMinimalDenom": "ibc/51D893F870B7675E507E91DA8DB0B22EA66333207E4F5C0708757F08EE059B0B",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.png"
+        },
+        {
+          "coinDenom": "IOV",
+          "coinMinimalDenom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png"
+        },
+        {
+          "coinDenom": "GLTO",
+          "coinMinimalDenom": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/glto.png"
+        },
+        {
+          "coinDenom": "PICA",
+          "coinMinimalDenom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/pica.svg"
+        },
+        {
+          "coinDenom": "MARS.old",
+          "coinMinimalDenom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png"
+        },
+        {
+          "coinDenom": "KAVA",
+          "coinMinimalDenom": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+          "coinDecimals": 6,
+          "coinGeckoId": "kava",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
+        },
+        {
+          "coinDenom": "EEUR",
+          "coinMinimalDenom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png"
+        },
+        {
+          "coinDenom": "FET",
+          "coinMinimalDenom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+          "coinDecimals": 18,
+          "coinGeckoId": "fetch-ai",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png"
+        },
+        {
+          "coinDenom": "WFTM",
+          "coinMinimalDenom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+          "coinDecimals": 18,
+          "coinGeckoId": "fantom",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png"
+        },
+        {
+          "coinDenom": "KYVE",
+          "coinMinimalDenom": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
+          "coinDecimals": 6,
+          "coinGeckoId": "kyve-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.png"
+        },
+        {
+          "coinDenom": "C4E",
+          "coinMinimalDenom": "ibc/62118FB4D5FEDD5D2B18DC93648A745CD5E5B01D420E9B7A5FED5381CB13A7E8",
+          "coinDecimals": 6,
+          "coinGeckoId": "chain4energy",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
+        },
+        {
+          "coinDenom": "BUSD",
+          "coinMinimalDenom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+          "coinDecimals": 18,
+          "coinGeckoId": "binance-usd",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
+        },
+        {
+          "coinDenom": "QCK",
+          "coinMinimalDenom": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
+        },
+        {
+          "coinDenom": "XRP",
+          "coinMinimalDenom": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
+          "coinDecimals": 6,
+          "coinGeckoId": "ripple",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png"
+        },
+        {
+          "coinDenom": "INJ",
+          "coinMinimalDenom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+          "coinDecimals": 18,
+          "coinGeckoId": "injective-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png"
+        },
+        {
+          "coinDenom": "WETH",
+          "coinMinimalDenom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+          "coinDecimals": 18,
+          "coinGeckoId": "weth",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/weth.svg"
+        },
+        {
+          "coinDenom": "DORA",
+          "coinMinimalDenom": "ibc/672406ADE4EDFD8C5EA7A0D0DD0C37E431DA7BD8393A15CD2CFDE3364917EB2A",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/doravota/images/dora.svg"
+        },
+        {
+          "coinDenom": "KSM",
+          "coinMinimalDenom": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
+          "coinDecimals": 12,
+          "coinGeckoId": "kusama",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/kusama/images/ksm.svg"
+        },
+        {
+          "coinDenom": "UMEE",
+          "coinMinimalDenom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
+        },
+        {
+          "coinDenom": "ISLM",
+          "coinMinimalDenom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
+          "coinDecimals": 18,
+          "coinGeckoId": "islamic-coin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/haqq/images/islm.png"
+        },
+        {
+          "coinDenom": "EVMOS",
+          "coinMinimalDenom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+          "coinDecimals": 18,
+          "coinGeckoId": "evmos",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png"
+        },
+        {
+          "coinDenom": "DOT",
+          "coinMinimalDenom": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
+          "coinDecimals": 10,
+          "coinGeckoId": "polkadot",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png"
+        },
+        {
+          "coinDenom": "WAVAX",
+          "coinMinimalDenom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+          "coinDecimals": 18,
+          "coinGeckoId": "wrapped-avax",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+          "coinDecimals": 6,
+          "coinGeckoId": "tether",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "SEI",
+          "coinMinimalDenom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
+          "coinDecimals": 6,
+          "coinGeckoId": "sei-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.png"
+        },
+        {
+          "coinDenom": "nBTC",
+          "coinMinimalDenom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
+          "coinDecimals": 14,
+          "coinGeckoId": "bitcoin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nbtc.png"
+        },
+        {
+          "coinDenom": "LUNA",
+          "coinMinimalDenom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+          "coinDecimals": 6,
+          "coinGeckoId": "terra-luna-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
+        },
+        {
+          "coinDenom": "CHEQ",
+          "coinMinimalDenom": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+          "coinDecimals": 9,
+          "coinGeckoId": "cheqd-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png"
+        },
+        {
+          "coinDenom": "IRIS",
+          "coinMinimalDenom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+          "coinDecimals": 6,
+          "coinGeckoId": "iris-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png"
+        },
+        {
+          "coinDenom": "GKEY",
+          "coinMinimalDenom": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png"
+        },
+        {
+          "coinDenom": "CTK",
+          "coinMinimalDenom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+          "coinDecimals": 6,
+          "coinGeckoId": "certik",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
+        },
+        {
+          "coinDenom": "PSTAKE",
+          "coinMinimalDenom": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+          "coinDecimals": 18,
+          "coinGeckoId": "pstake-finance",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png"
+        },
+        {
+          "coinDenom": "LAMB",
+          "coinMinimalDenom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+          "coinDecimals": 6,
+          "coinGeckoId": "axelar-usdt",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "ROWAN",
+          "coinMinimalDenom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png"
+        },
+        {
+          "coinDenom": "DYDX",
+          "coinMinimalDenom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
+          "coinDecimals": 18,
+          "coinGeckoId": "dydx-chain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx-circle.svg"
+        },
+        {
+          "coinDenom": "HAVA",
+          "coinMinimalDenom": "ibc/884EBC228DFCE8F1304D917A712AA9611427A6C1ECC3179B2E91D7468FB091A2",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/hava.png"
+        },
+        {
+          "coinDenom": "LUM",
+          "coinMinimalDenom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+          "coinDecimals": 6,
+          "coinGeckoId": "lum-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
+        },
+        {
+          "coinDenom": "JKL",
+          "coinMinimalDenom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+          "coinDecimals": 6,
+          "coinGeckoId": "jackal-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png"
+        },
+        {
+          "coinDenom": "SWTH",
+          "coinMinimalDenom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+          "coinDecimals": 8,
+          "coinGeckoId": "switcheo",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png"
+        },
+        {
+          "coinDenom": "AXL",
+          "coinMinimalDenom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+          "coinDecimals": 6,
+          "coinGeckoId": "axelar",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png"
+        },
+        {
+          "coinDenom": "EURe",
+          "coinMinimalDenom": "ibc/92AE2F53284505223A1BB80D132F859A00E190C6A738772F0B3EF65E20BA484F",
+          "coinDecimals": 6,
+          "coinGeckoId": "monerium-eur-money",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eure.png"
+        },
+        {
+          "coinDenom": "IST",
+          "coinMinimalDenom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+          "coinDecimals": 6,
+          "coinGeckoId": "inter-stable-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
+        },
+        {
+          "coinDenom": "SNEAKY",
+          "coinMinimalDenom": "ibc/94ED1F172BC633DFC56D7E26551D8B101ADCCC69052AC44FED89F97FF658138F",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/sneaky.png"
+        },
+        {
+          "coinDenom": "XPLA",
+          "coinMinimalDenom": "ibc/95C9B5870F95E21A242E6AF9ADCB1F212EE4A8855087226C36FBE43FC41A77B8",
+          "coinDecimals": 18,
+          "coinGeckoId": "xpla",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.png"
+        },
+        {
+          "coinDenom": "P2P",
+          "coinMinimalDenom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+          "coinDecimals": 6,
+          "coinGeckoId": "sentinel",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
+        },
+        {
+          "coinDenom": "stDYDX",
+          "coinMinimalDenom": "ibc/980E82A9F8E7CA8CD480F4577E73682A6D3855A267D1831485D7EBEF0E7A6C2C",
+          "coinDecimals": 18,
+          "coinGeckoId": "dydx-chain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdydx.png"
+        },
+        {
+          "coinDenom": "STARS",
+          "coinMinimalDenom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+          "coinDecimals": 6,
+          "coinGeckoId": "stargaze",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
+        },
+        {
+          "coinDenom": "LIKE",
+          "coinMinimalDenom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png"
+        },
+        {
+          "coinDenom": "DYM",
+          "coinMinimalDenom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
+          "coinDecimals": 18,
+          "coinGeckoId": "dymension",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.png"
+        },
+        {
+          "coinDenom": "GEO",
+          "coinMinimalDenom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png"
+        },
+        {
+          "coinDenom": "SOMM",
+          "coinMinimalDenom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+          "coinDecimals": 6,
+          "coinGeckoId": "sommelier",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png"
+        },
+        {
+          "coinDenom": "DEC",
+          "coinMinimalDenom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+          "coinDecimals": 6,
+          "coinGeckoId": "usd-coin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png"
+        },
+        {
+          "coinDenom": "XPRT",
+          "coinMinimalDenom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+          "coinDecimals": 6,
+          "coinGeckoId": "persistence",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png"
+        },
+        {
+          "coinDenom": "SGE",
+          "coinMinimalDenom": "ibc/A1830DECC0B742F0B2044FF74BE727B5CF92C9A28A9235C3BACE4D24A23504FA",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sge/images/sge.png"
+        },
+        {
+          "coinDenom": "REBUS",
+          "coinMinimalDenom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png"
+        },
+        {
+          "coinDenom": "NCT",
+          "coinMinimalDenom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
+          "coinDecimals": 6,
+          "coinGeckoId": "toucan-protocol-nature-carbon-tonne",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.png"
+        },
+        {
+          "coinDenom": "STRD",
+          "coinMinimalDenom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+          "coinDecimals": 6,
+          "coinGeckoId": "stride",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png"
+        },
+        {
+          "coinDenom": "WMATIC",
+          "coinMinimalDenom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+          "coinDecimals": 18,
+          "coinGeckoId": "wmatic",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.png"
+        },
+        {
+          "coinDenom": "LORE",
+          "coinMinimalDenom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
+          "coinDecimals": 6,
+          "coinGeckoId": "gitopia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/lore.png"
+        },
+        {
+          "coinDenom": "PLQ",
+          "coinMinimalDenom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+          "coinDecimals": 18,
+          "coinGeckoId": "planq",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.png"
+        },
+        {
+          "coinDenom": "XKI",
+          "coinMinimalDenom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png"
+        },
+        {
+          "coinDenom": "ASTRO",
+          "coinMinimalDenom": "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B",
+          "coinDecimals": 6,
+          "coinGeckoId": "astroport-fi",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png"
+        },
+        {
+          "coinDenom": "NOM",
+          "coinMinimalDenom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png"
+        },
+        {
+          "coinDenom": "HUAHUA",
+          "coinMinimalDenom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+          "coinDecimals": 6,
+          "coinGeckoId": "chihuahua-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png"
+        },
+        {
+          "coinDenom": "KUJI",
+          "coinMinimalDenom": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
+        },
+        {
+          "coinDenom": "ACRE",
+          "coinMinimalDenom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.png"
+        },
+        {
+          "coinDenom": "USTC",
+          "coinMinimalDenom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+          "coinDecimals": 6,
+          "coinGeckoId": "terrausd",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
+        },
+        {
+          "coinDenom": "NEWT",
+          "coinMinimalDenom": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/newt.png"
+        },
+        {
+          "coinDenom": "ODIN",
+          "coinMinimalDenom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png"
+        },
+        {
+          "coinDenom": "SOLAR",
+          "coinMinimalDenom": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
+        },
+        {
+          "coinDenom": "BZE",
+          "coinMinimalDenom": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+          "coinDecimals": 6,
+          "coinGeckoId": "bzedge",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.png"
+        },
+        {
+          "coinDenom": "MNTL",
+          "coinMinimalDenom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
+        },
+        {
+          "coinDenom": "HASH",
+          "coinMinimalDenom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+          "coinDecimals": 9,
+          "coinGeckoId": "hash-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png"
+        },
+        {
+          "coinDenom": "FLIX",
+          "coinMinimalDenom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.png"
+        },
+        {
+          "coinDenom": "WBTC",
+          "coinMinimalDenom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+          "coinDecimals": 8,
+          "coinGeckoId": "axlwbtc",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png"
+        },
+        {
+          "coinDenom": "stOSMO",
+          "coinMinimalDenom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+          "coinDecimals": 6,
+          "coinGeckoId": "stride-staked-osmo",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+          "coinDecimals": 6,
+          "coinGeckoId": "axlusdc",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png"
+        },
+        {
+          "coinDenom": "LINK",
+          "coinMinimalDenom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+          "coinDecimals": 18,
+          "coinGeckoId": "chainlink",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.png"
+        },
+        {
+          "coinDenom": "TIA",
+          "coinMinimalDenom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
+          "coinDecimals": 6,
+          "coinGeckoId": "celestia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png"
+        },
+        {
+          "coinDenom": "BCNA",
+          "coinMinimalDenom": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png"
+        },
+        {
+          "coinDenom": "MPWR",
+          "coinMinimalDenom": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/empowerchain/images/mpwr.svg"
+        },
+        {
+          "coinDenom": "FCT",
+          "coinMinimalDenom": "ibc/E43ABCC7E80E99E4E6E1226AE5695DDE0F83CB5C257CD04D47C36B8B90C1C839",
+          "coinDecimals": 6,
+          "coinGeckoId": "firmachain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/firmachain/images/fct.png"
+        },
+        {
+          "coinDenom": "PEPE",
+          "coinMinimalDenom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
+          "coinDecimals": 18,
+          "coinGeckoId": "pepe",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.png"
+        },
+        {
+          "coinDenom": "CRO",
+          "coinMinimalDenom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+          "coinDecimals": 8,
+          "coinGeckoId": "crypto-com-chain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cro.svg"
+        },
+        {
+          "coinDenom": "NRIDE",
+          "coinMinimalDenom": "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.png"
+        },
+        {
+          "coinDenom": "SOURCE",
+          "coinMinimalDenom": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/source/images/source.png"
+        },
+        {
+          "coinDenom": "VDL",
+          "coinMinimalDenom": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/vdl.png"
+        },
+        {
+          "coinDenom": "GRAV",
+          "coinMinimalDenom": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+          "coinDecimals": 6,
+          "coinGeckoId": "graviton",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png"
+        },
+        {
+          "coinDenom": "WETH",
+          "coinMinimalDenom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+          "coinDecimals": 18,
+          "coinGeckoId": "axlweth",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
+        },
+        {
+          "coinDenom": "CMDX",
+          "coinMinimalDenom": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+          "coinDecimals": 6,
+          "coinGeckoId": "comdex",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
+        },
+        {
+          "coinDenom": "DSM",
+          "coinMinimalDenom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+          "coinDecimals": 6,
+          "coinGeckoId": "desmos",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png"
+        },
+        {
+          "coinDenom": "TORI",
+          "coinMinimalDenom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png"
+        },
+        {
+          "coinDenom": "WHALE",
+          "coinMinimalDenom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png"
+        },
+        {
+          "coinDenom": "L1",
+          "coinMinimalDenom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png"
+        },
+        {
+          "coinDenom": "TX",
+          "coinMinimalDenom": "ibc/F3166F4D31D6BA1EC6C9F5536F5DDDD4CC93DBA430F7419E7CDC41C497944A65",
+          "coinDecimals": 6,
+          "coinGeckoId": "tx",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/tx.png"
+        },
+        {
+          "coinDenom": "IXO",
+          "coinMinimalDenom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+          "coinDecimals": 6,
+          "coinGeckoId": "ixo",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
+        },
+        {
+          "coinDenom": "WBNB",
+          "coinMinimalDenom": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+          "coinDecimals": 18,
+          "coinGeckoId": "wbnb",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
+        },
+        {
+          "coinDenom": "BAND",
+          "coinMinimalDenom": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+          "coinDecimals": 6,
+          "coinGeckoId": "band-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png"
+        },
+        {
+          "coinDenom": "BOOT",
+          "coinMinimalDenom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+          "coinDecimals": 0,
+          "coinGeckoId": "bostrom",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
+        },
+        {
+          "coinDenom": "ION",
+          "coinMinimalDenom": "uion",
+          "coinDecimals": 6,
+          "coinGeckoId": "ion",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png"
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "OSMO",
+          "coinMinimalDenom": "uosmo",
+          "coinDecimals": 6,
+          "coinGeckoId": "osmosis",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png"
+        },
+        {
+          "coinDenom": "ICP",
+          "coinMinimalDenom": "factory/osmo10c4y9csfs8q7mtvfg4p9gd8d0acx0hpc2mte9xqzthd7rd3348tsfhaesm/sICP-native-ICP",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/internetcomputer/images/icp.png"
+        },
+        {
+          "coinDenom": "BADKID",
+          "coinMinimalDenom": "factory/osmo10n8rv8npx870l69248hnp6djy6pll2yuzzn9x8/BADKID",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/badkid.png"
+        },
+        {
+          "coinDenom": "LAB",
+          "coinMinimalDenom": "factory/osmo17fel472lgzs87ekt9dvk0zqyh5gl80sqp4sk4n/LAB",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/LAB.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "factory/osmo1em6xs47hd82806f5cxgyufguxrrc7l0aqx7nzzptjuqgswczk8csavdxek/alloyed/allUSDT",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "milkTIA",
+          "coinMinimalDenom": "factory/osmo1f5vfcph2dvfeqcqkhetwv75fda69z7e5c2dldm3kvgj23crkv6wqcn47a0/umilkTIA",
+          "coinDecimals": 6,
+          "coinGeckoId": "milkyway-staked-tia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/milktia.png"
+        },
+        {
+          "coinDenom": "sqOSMO",
+          "coinMinimalDenom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqosmo.svg"
+        },
+        {
+          "coinDenom": "ETH",
+          "coinMinimalDenom": "factory/osmo1k6c8jln7ejuqwtqmay3yvzrg3kueaczl96pk067ldg8u835w0yhsw27twm/alloyed/allETH",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
+        },
+        {
+          "coinDenom": "LVN",
+          "coinMinimalDenom": "factory/osmo1mlng7pz4pnyxtpq0akfwall37czyk9lukaucsrn30ameplhhshtqdvfm5c/ulvn",
+          "coinDecimals": 6,
+          "coinGeckoId": "levana-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/levana.png"
+        },
+        {
+          "coinDenom": "SOL",
+          "coinMinimalDenom": "factory/osmo1n3n75av8awcnw4jl62n3l48e6e4sxqmaf97w5ua6ddu4s475q5qq9udvx4/alloyed/allSOL",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol_circle.png"
+        },
+        {
+          "coinDenom": "CAC",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/cac",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CAC.png"
+        },
+        {
+          "coinDenom": "PBB",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/pbb",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/PBB.png"
+        },
+        {
+          "coinDenom": "SHITMOS",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/shitmos",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/shitmos.png"
+        },
+        {
+          "coinDenom": "bOSMO",
+          "coinMinimalDenom": "factory/osmo1s3l0lcqc7tu0vpj6wdjz9wqpxv8nk6eraevje4fuwkyjnwuy82qsx3lduv/boneOsmo",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bOSMO.png"
+        },
+        {
+          "coinDenom": "CDT",
+          "coinMinimalDenom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/ucdt",
+          "coinDecimals": 6,
+          "coinGeckoId": "collateralized-debt-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CDT.svg"
+        },
+        {
+          "coinDenom": "MBRN",
+          "coinMinimalDenom": "factory/osmo1s794h9rxggytja3a4pmwul53u98k06zy2qtrdvjnfuxruh7s8yjs6cyxgd/umbrn",
+          "coinDecimals": 6,
+          "coinGeckoId": "membrane",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/MBRN.svg"
+        },
+        {
+          "coinDenom": "stIBCX",
+          "coinMinimalDenom": "factory/osmo1xqw2sl9zk8a6pch0csaw78n4swg5ws8t62wc5qta4gnjxfqg6v2qcs243k/stuibcx",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/stibcx.png"
+        },
+        {
+          "coinDenom": "WBTC",
+          "coinMinimalDenom": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
+          "coinDecimals": 8,
+          "coinGeckoId": "wrapped-bitcoin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png"
+        },
+        {
+          "coinDenom": "BTC",
+          "coinMinimalDenom": "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoin/images/btc.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
+          "coinDecimals": 6,
+          "coinGeckoId": "tether",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "SAGA",
+          "coinMinimalDenom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
+          "coinDecimals": 6,
+          "coinGeckoId": "saga-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/saga/images/saga_white.png"
+        },
+        {
+          "coinDenom": "SCRT",
+          "coinMinimalDenom": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+          "coinDecimals": 6,
+          "coinGeckoId": "secret",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.png"
+        },
+        {
+          "coinDenom": "DAI",
+          "coinMinimalDenom": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+          "coinDecimals": 18,
+          "coinGeckoId": "dai",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/dai.svg"
+        },
+        {
+          "coinDenom": "LUNC",
+          "coinMinimalDenom": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+          "coinDecimals": 6,
+          "coinGeckoId": "terra-luna",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png"
+        },
+        {
+          "coinDenom": "UM",
+          "coinMinimalDenom": "ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/penumbra/images/um.png"
+        },
+        {
+          "coinDenom": "ARB",
+          "coinMinimalDenom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
+          "coinDecimals": 18,
+          "coinGeckoId": "arbitrum",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.png"
+        },
+        {
+          "coinDenom": "NTRN",
+          "coinMinimalDenom": "ibc/126DA09104B71B164883842B769C0E9EC1486C0887D27A9999E395C2C8FB5682",
+          "coinDecimals": 6,
+          "coinGeckoId": "neutron-3",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.png"
+        },
+        {
+          "coinDenom": "AKT",
+          "coinMinimalDenom": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+          "coinDecimals": 6,
+          "coinGeckoId": "akash-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.png"
+        },
+        {
+          "coinDenom": "ORAI",
+          "coinMinimalDenom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+          "coinDecimals": 6,
+          "coinGeckoId": "oraichain-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-token.png"
+        },
+        {
+          "coinDenom": "OM",
+          "coinMinimalDenom": "ibc/164807F6226F91990F358C6467EEE8B162E437BDCD3DADEC3F0CE20693720795",
+          "coinDecimals": 6,
+          "coinGeckoId": "mantra-dao",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.png"
+        },
+        {
+          "coinDenom": "SCR",
+          "coinMinimalDenom": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/scorum/images/scr.png"
+        },
+        {
+          "coinDenom": "LAVA",
+          "coinMinimalDenom": "ibc/1AEF145C549D4F9847C79E49710B198C294C7F4A107F4610DEE8E725FFC4B378",
+          "coinDecimals": 6,
+          "coinGeckoId": "lava-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lava/images/lava.png"
+        },
+        {
+          "coinDenom": "QSR.legacy",
+          "coinMinimalDenom": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quasar/images/quasar.png"
+        },
+        {
+          "coinDenom": "NGM",
+          "coinMinimalDenom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+          "coinDecimals": 6,
+          "coinGeckoId": "e-money",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.png"
+        },
+        {
+          "coinDenom": "REGEN",
+          "coinMinimalDenom": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+          "coinDecimals": 6,
+          "coinGeckoId": "regen",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
+        },
+        {
+          "coinDenom": "TGD",
+          "coinMinimalDenom": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.png"
+        },
+        {
+          "coinDenom": "SOL",
+          "coinMinimalDenom": "ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA",
+          "coinDecimals": 8,
+          "coinGeckoId": "wrapped-solana",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol_circle.png"
+        },
+        {
+          "coinDenom": "USDY",
+          "coinMinimalDenom": "ibc/23104D411A6EB6031FA92FB75F227422B84989969E91DCAD56A535DD7FF0A373",
+          "coinDecimals": 18,
+          "coinGeckoId": "ondo-us-dollar-yield",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/noble/images/usdy.png"
+        },
+        {
+          "coinDenom": "PAGE",
+          "coinMinimalDenom": "ibc/23A62409E4AD8133116C249B1FA38EED30E500A115D7B153109462CD82C1CD99",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/page.png"
+        },
+        {
+          "coinDenom": "ARCH",
+          "coinMinimalDenom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
+          "coinDecimals": 18,
+          "coinGeckoId": "archway",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/archway/images/arch.png"
+        },
+        {
+          "coinDenom": "CMST",
+          "coinMinimalDenom": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+          "coinDecimals": 6,
+          "coinGeckoId": "composite",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png"
+        },
+        {
+          "coinDenom": "ATOM",
+          "coinMinimalDenom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          "coinDecimals": 6,
+          "coinGeckoId": "cosmos",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.png"
+        },
+        {
+          "coinDenom": "NETA",
+          "coinMinimalDenom": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+          "coinDecimals": 6,
+          "coinGeckoId": "neta",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
+        },
+        {
+          "coinDenom": "FX",
+          "coinMinimalDenom": "ibc/2B30802A0B03F91E4E16D6175C9B70F2911377C1CAE9E50FF011C821465463F9",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fxcore/images/fx.png"
+        },
+        {
+          "coinDenom": "BLD",
+          "coinMinimalDenom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+          "coinDecimals": 6,
+          "coinGeckoId": "agoric",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
+        },
+        {
+          "coinDenom": "XION",
+          "coinMinimalDenom": "ibc/2E3784772E70F7B3A638BA88F65C8BE125D3CDB6E28C6AABC51098C94F5E16A5",
+          "coinDecimals": 6,
+          "coinGeckoId": "xion-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
+        },
+        {
+          "coinDenom": "WYND",
+          "coinMinimalDenom": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.png"
+        },
+        {
+          "coinDenom": "DIG",
+          "coinMinimalDenom": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
+        },
+        {
+          "coinDenom": "DARC",
+          "coinMinimalDenom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.png"
+        },
+        {
+          "coinDenom": "NYM",
+          "coinMinimalDenom": "ibc/37CB3078432510EE57B9AFA8DBE028B33AE3280A144826FEAC5F2334CF2C5539",
+          "coinDecimals": 6,
+          "coinGeckoId": "nym",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nyx/images/nym_token_light.png"
+        },
+        {
+          "coinDenom": "DGN",
+          "coinMinimalDenom": "ibc/3B95D63B520C283BCA86F8CD426D57584039463FD684A5CBA31D2780B86A1995",
+          "coinDecimals": 6,
+          "coinGeckoId": "dragon-coin-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dungeon/images/DGN.png"
+        },
+        {
+          "coinDenom": "MED",
+          "coinMinimalDenom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+          "coinDecimals": 6,
+          "coinGeckoId": "medibloc",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
+        },
+        {
+          "coinDenom": "DOT",
+          "coinMinimalDenom": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+          "coinDecimals": 10,
+          "coinGeckoId": "polkadot",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png"
+        },
+        {
+          "coinDenom": "NIBI",
+          "coinMinimalDenom": "ibc/4017C65CEA338196ECCEC3FE3FE8258F23D1DE88F1D95750CC912C7A1C1016FF",
+          "coinDecimals": 6,
+          "coinGeckoId": "nibiru",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nibiru/images/nibiru.png"
+        },
+        {
+          "coinDenom": "CRBRUS",
+          "coinMinimalDenom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
+        },
+        {
+          "coinDenom": "qOSMO",
+          "coinMinimalDenom": "ibc/42D24879D4569CE6477B7E88206ADBFE47C222C6CAD51A54083E4A72594269FC",
+          "coinDecimals": 6,
+          "coinGeckoId": "osmosis",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qosmo.png"
+        },
+        {
+          "coinDenom": "JUNO",
+          "coinMinimalDenom": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+          "coinDecimals": 6,
+          "coinGeckoId": "juno-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          "coinDecimals": 6,
+          "coinGeckoId": "usd-coin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
+          "coinDecimals": 6,
+          "coinGeckoId": "tether",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "BTSG",
+          "coinMinimalDenom": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+          "coinDecimals": 6,
+          "coinGeckoId": "bitsong",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.png"
+        },
+        {
+          "coinDenom": "HYDROGEN",
+          "coinMinimalDenom": "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
+          "coinDecimals": 0,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/hydrogen.png"
+        },
+        {
+          "coinDenom": "MNTA",
+          "coinMinimalDenom": "ibc/51D893F870B7675E507E91DA8DB0B22EA66333207E4F5C0708757F08EE059B0B",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/mnta.png"
+        },
+        {
+          "coinDenom": "IOV",
+          "coinMinimalDenom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.png"
+        },
+        {
+          "coinDenom": "GLTO",
+          "coinMinimalDenom": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/glto.png"
+        },
+        {
+          "coinDenom": "PICA",
+          "coinMinimalDenom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/composable/images/pica.svg"
+        },
+        {
+          "coinDenom": "MARS.old",
+          "coinMinimalDenom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token-ibc.png"
+        },
+        {
+          "coinDenom": "KAVA",
+          "coinMinimalDenom": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+          "coinDecimals": 6,
+          "coinGeckoId": "kava",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
+        },
+        {
+          "coinDenom": "EEUR",
+          "coinMinimalDenom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.png"
+        },
+        {
+          "coinDenom": "FET",
+          "coinMinimalDenom": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+          "coinDecimals": 18,
+          "coinGeckoId": "fetch-ai",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png"
+        },
+        {
+          "coinDenom": "WFTM",
+          "coinMinimalDenom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+          "coinDecimals": 18,
+          "coinGeckoId": "fantom",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png"
+        },
+        {
+          "coinDenom": "KYVE",
+          "coinMinimalDenom": "ibc/613BF0BF2F2146AE9941E923725745E931676B2C14E9768CD609FA0849B2AE13",
+          "coinDecimals": 6,
+          "coinGeckoId": "kyve-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kyve/images/kyve-token.png"
+        },
+        {
+          "coinDenom": "C4E",
+          "coinMinimalDenom": "ibc/62118FB4D5FEDD5D2B18DC93648A745CD5E5B01D420E9B7A5FED5381CB13A7E8",
+          "coinDecimals": 6,
+          "coinGeckoId": "chain4energy",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chain4energy/images/c4e.png"
+        },
+        {
+          "coinDenom": "BUSD",
+          "coinMinimalDenom": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+          "coinDecimals": 18,
+          "coinGeckoId": "binance-usd",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
+        },
+        {
+          "coinDenom": "QCK",
+          "coinMinimalDenom": "ibc/635CB83EF1DFE598B10A3E90485306FD0D47D34217A4BE5FD9977FA010A5367D",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qck.png"
+        },
+        {
+          "coinDenom": "XRP",
+          "coinMinimalDenom": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
+          "coinDecimals": 6,
+          "coinGeckoId": "ripple",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png"
+        },
+        {
+          "coinDenom": "INJ",
+          "coinMinimalDenom": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+          "coinDecimals": 18,
+          "coinGeckoId": "injective-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png"
+        },
+        {
+          "coinDenom": "WETH",
+          "coinMinimalDenom": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+          "coinDecimals": 18,
+          "coinGeckoId": "weth",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/weth.svg"
+        },
+        {
+          "coinDenom": "DORA",
+          "coinMinimalDenom": "ibc/672406ADE4EDFD8C5EA7A0D0DD0C37E431DA7BD8393A15CD2CFDE3364917EB2A",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/doravota/images/dora.svg"
+        },
+        {
+          "coinDenom": "KSM",
+          "coinMinimalDenom": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
+          "coinDecimals": 12,
+          "coinGeckoId": "kusama",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/kusama/images/ksm.svg"
+        },
+        {
+          "coinDenom": "UMEE",
+          "coinMinimalDenom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
+        },
+        {
+          "coinDenom": "ISLM",
+          "coinMinimalDenom": "ibc/69110FF673D70B39904FF056CFDFD58A90BEC3194303F45C32CB91B8B0A738EA",
+          "coinDecimals": 18,
+          "coinGeckoId": "islamic-coin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/haqq/images/islm.png"
+        },
+        {
+          "coinDenom": "EVMOS",
+          "coinMinimalDenom": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+          "coinDecimals": 18,
+          "coinGeckoId": "evmos",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.png"
+        },
+        {
+          "coinDenom": "DOT",
+          "coinMinimalDenom": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
+          "coinDecimals": 10,
+          "coinGeckoId": "polkadot",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png"
+        },
+        {
+          "coinDenom": "WAVAX",
+          "coinMinimalDenom": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+          "coinDecimals": 18,
+          "coinGeckoId": "wrapped-avax",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+          "coinDecimals": 6,
+          "coinGeckoId": "tether",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "SEI",
+          "coinMinimalDenom": "ibc/71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D",
+          "coinDecimals": 6,
+          "coinGeckoId": "sei-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sei/images/sei.png"
+        },
+        {
+          "coinDenom": "nBTC",
+          "coinMinimalDenom": "ibc/75345531D87BD90BF108BE7240BD721CB2CB0A1F16D4EBA71B09EC3C43E15C8F",
+          "coinDecimals": 14,
+          "coinGeckoId": "bitcoin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nomic/images/nbtc.png"
+        },
+        {
+          "coinDenom": "LUNA",
+          "coinMinimalDenom": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+          "coinDecimals": 6,
+          "coinGeckoId": "terra-luna-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
+        },
+        {
+          "coinDenom": "CHEQ",
+          "coinMinimalDenom": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+          "coinDecimals": 9,
+          "coinGeckoId": "cheqd-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.png"
+        },
+        {
+          "coinDenom": "IRIS",
+          "coinMinimalDenom": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+          "coinDecimals": 6,
+          "coinGeckoId": "iris-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.png"
+        },
+        {
+          "coinDenom": "GKEY",
+          "coinMinimalDenom": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png"
+        },
+        {
+          "coinDenom": "CTK",
+          "coinMinimalDenom": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+          "coinDecimals": 6,
+          "coinGeckoId": "certik",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
+        },
+        {
+          "coinDenom": "PSTAKE",
+          "coinMinimalDenom": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+          "coinDecimals": 18,
+          "coinGeckoId": "pstake-finance",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.png"
+        },
+        {
+          "coinDenom": "LAMB",
+          "coinMinimalDenom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+          "coinDecimals": 6,
+          "coinGeckoId": "axelar-usdt",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "ROWAN",
+          "coinMinimalDenom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.png"
+        },
+        {
+          "coinDenom": "DYDX",
+          "coinMinimalDenom": "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C",
+          "coinDecimals": 18,
+          "coinGeckoId": "dydx-chain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx-circle.svg"
+        },
+        {
+          "coinDenom": "HAVA",
+          "coinMinimalDenom": "ibc/884EBC228DFCE8F1304D917A712AA9611427A6C1ECC3179B2E91D7468FB091A2",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/hava.png"
+        },
+        {
+          "coinDenom": "LUM",
+          "coinMinimalDenom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+          "coinDecimals": 6,
+          "coinGeckoId": "lum-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
+        },
+        {
+          "coinDenom": "JKL",
+          "coinMinimalDenom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+          "coinDecimals": 6,
+          "coinGeckoId": "jackal-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.png"
+        },
+        {
+          "coinDenom": "SWTH",
+          "coinMinimalDenom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+          "coinDecimals": 8,
+          "coinGeckoId": "switcheo",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.png"
+        },
+        {
+          "coinDenom": "AXL",
+          "coinMinimalDenom": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+          "coinDecimals": 6,
+          "coinGeckoId": "axelar",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.png"
+        },
+        {
+          "coinDenom": "EURe",
+          "coinMinimalDenom": "ibc/92AE2F53284505223A1BB80D132F859A00E190C6A738772F0B3EF65E20BA484F",
+          "coinDecimals": 6,
+          "coinGeckoId": "monerium-eur-money",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eure.png"
+        },
+        {
+          "coinDenom": "IST",
+          "coinMinimalDenom": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+          "coinDecimals": 6,
+          "coinGeckoId": "inter-stable-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
+        },
+        {
+          "coinDenom": "SNEAKY",
+          "coinMinimalDenom": "ibc/94ED1F172BC633DFC56D7E26551D8B101ADCCC69052AC44FED89F97FF658138F",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/sneaky.png"
+        },
+        {
+          "coinDenom": "XPLA",
+          "coinMinimalDenom": "ibc/95C9B5870F95E21A242E6AF9ADCB1F212EE4A8855087226C36FBE43FC41A77B8",
+          "coinDecimals": 18,
+          "coinGeckoId": "xpla",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xpla/images/xpla.png"
+        },
+        {
+          "coinDenom": "P2P",
+          "coinMinimalDenom": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+          "coinDecimals": 6,
+          "coinGeckoId": "sentinel",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
+        },
+        {
+          "coinDenom": "stDYDX",
+          "coinMinimalDenom": "ibc/980E82A9F8E7CA8CD480F4577E73682A6D3855A267D1831485D7EBEF0E7A6C2C",
+          "coinDecimals": 18,
+          "coinGeckoId": "dydx-chain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stdydx.png"
+        },
+        {
+          "coinDenom": "STARS",
+          "coinMinimalDenom": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+          "coinDecimals": 6,
+          "coinGeckoId": "stargaze",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
+        },
+        {
+          "coinDenom": "LIKE",
+          "coinMinimalDenom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png"
+        },
+        {
+          "coinDenom": "DYM",
+          "coinMinimalDenom": "ibc/9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
+          "coinDecimals": 18,
+          "coinGeckoId": "dymension",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.png"
+        },
+        {
+          "coinDenom": "GEO",
+          "coinMinimalDenom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.png"
+        },
+        {
+          "coinDenom": "SOMM",
+          "coinMinimalDenom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+          "coinDecimals": 6,
+          "coinGeckoId": "sommelier",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.png"
+        },
+        {
+          "coinDenom": "DEC",
+          "coinMinimalDenom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+          "coinDecimals": 6,
+          "coinGeckoId": "usd-coin",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png"
+        },
+        {
+          "coinDenom": "XPRT",
+          "coinMinimalDenom": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+          "coinDecimals": 6,
+          "coinGeckoId": "persistence",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.png"
+        },
+        {
+          "coinDenom": "SGE",
+          "coinMinimalDenom": "ibc/A1830DECC0B742F0B2044FF74BE727B5CF92C9A28A9235C3BACE4D24A23504FA",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sge/images/sge.png"
+        },
+        {
+          "coinDenom": "REBUS",
+          "coinMinimalDenom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.png"
+        },
+        {
+          "coinDenom": "NCT",
+          "coinMinimalDenom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
+          "coinDecimals": 6,
+          "coinGeckoId": "toucan-protocol-nature-carbon-tonne",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/nct.png"
+        },
+        {
+          "coinDenom": "STRD",
+          "coinMinimalDenom": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+          "coinDecimals": 6,
+          "coinGeckoId": "stride",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.png"
+        },
+        {
+          "coinDenom": "WMATIC",
+          "coinMinimalDenom": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+          "coinDecimals": 18,
+          "coinGeckoId": "wmatic",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.png"
+        },
+        {
+          "coinDenom": "LORE",
+          "coinMinimalDenom": "ibc/B1C1806A540B3E165A2D42222C59946FB85BA325596FC85662D7047649F419F3",
+          "coinDecimals": 6,
+          "coinGeckoId": "gitopia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gitopia/images/lore.png"
+        },
+        {
+          "coinDenom": "PLQ",
+          "coinMinimalDenom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+          "coinDecimals": 18,
+          "coinGeckoId": "planq",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.png"
+        },
+        {
+          "coinDenom": "XKI",
+          "coinMinimalDenom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.png"
+        },
+        {
+          "coinDenom": "ASTRO",
+          "coinMinimalDenom": "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B",
+          "coinDecimals": 6,
+          "coinGeckoId": "astroport-fi",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/astro.png"
+        },
+        {
+          "coinDenom": "NOM",
+          "coinMinimalDenom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png"
+        },
+        {
+          "coinDenom": "HUAHUA",
+          "coinMinimalDenom": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+          "coinDecimals": 6,
+          "coinGeckoId": "chihuahua-token",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png"
+        },
+        {
+          "coinDenom": "KUJI",
+          "coinMinimalDenom": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
+        },
+        {
+          "coinDenom": "ACRE",
+          "coinMinimalDenom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.png"
+        },
+        {
+          "coinDenom": "USTC",
+          "coinMinimalDenom": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+          "coinDecimals": 6,
+          "coinGeckoId": "terrausd",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
+        },
+        {
+          "coinDenom": "NEWT",
+          "coinMinimalDenom": "ibc/BF685448E564B5A4AC8F6E0493A0B979D0E0BF5EC11F7E15D25A0A2160C944DD",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/newt.png"
+        },
+        {
+          "coinDenom": "ODIN",
+          "coinMinimalDenom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.png"
+        },
+        {
+          "coinDenom": "SOLAR",
+          "coinMinimalDenom": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
+        },
+        {
+          "coinDenom": "BZE",
+          "coinMinimalDenom": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+          "coinDecimals": 6,
+          "coinGeckoId": "bzedge",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.png"
+        },
+        {
+          "coinDenom": "MNTL",
+          "coinMinimalDenom": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
+        },
+        {
+          "coinDenom": "HASH",
+          "coinMinimalDenom": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+          "coinDecimals": 9,
+          "coinGeckoId": "hash-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/prov.png"
+        },
+        {
+          "coinDenom": "FLIX",
+          "coinMinimalDenom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/omniflixhub/images/flix.png"
+        },
+        {
+          "coinDenom": "WBTC",
+          "coinMinimalDenom": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+          "coinDecimals": 8,
+          "coinGeckoId": "axlwbtc",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/wbtc.png"
+        },
+        {
+          "coinDenom": "stOSMO",
+          "coinMinimalDenom": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+          "coinDecimals": 6,
+          "coinGeckoId": "stride-staked-osmo",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+          "coinDecimals": 6,
+          "coinGeckoId": "axlusdc",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.png"
+        },
+        {
+          "coinDenom": "LINK",
+          "coinMinimalDenom": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+          "coinDecimals": 18,
+          "coinGeckoId": "chainlink",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.png"
+        },
+        {
+          "coinDenom": "TIA",
+          "coinMinimalDenom": "ibc/D79E7D83AB399BFFF93433E54FAA480C191248FC556924A2A8351AE2638B3877",
+          "coinDecimals": 6,
+          "coinGeckoId": "celestia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/celestia/images/celestia.png"
+        },
+        {
+          "coinDenom": "BCNA",
+          "coinMinimalDenom": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.png"
+        },
+        {
+          "coinDenom": "MPWR",
+          "coinMinimalDenom": "ibc/DD3938D8131F41994C1F01F4EB5233DEE9A0A5B787545B9A07A321925655BF38",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/empowerchain/images/mpwr.svg"
+        },
+        {
+          "coinDenom": "FCT",
+          "coinMinimalDenom": "ibc/E43ABCC7E80E99E4E6E1226AE5695DDE0F83CB5C257CD04D47C36B8B90C1C839",
+          "coinDecimals": 6,
+          "coinGeckoId": "firmachain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/firmachain/images/fct.png"
+        },
+        {
+          "coinDenom": "PEPE",
+          "coinMinimalDenom": "ibc/E47F4E97C534C95B942729E1B25DBDE111EA791411CFF100515050BEA0AC0C6B",
+          "coinDecimals": 18,
+          "coinGeckoId": "pepe",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.png"
+        },
+        {
+          "coinDenom": "CRO",
+          "coinMinimalDenom": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+          "coinDecimals": 8,
+          "coinGeckoId": "crypto-com-chain",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cro.svg"
+        },
+        {
+          "coinDenom": "NRIDE",
+          "coinMinimalDenom": "ibc/E750D31033DC1CF4A044C3AA0A8117401316DC918FBEBC4E3D34F91B09D5F54C",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/nride.png"
+        },
+        {
+          "coinDenom": "SOURCE",
+          "coinMinimalDenom": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/source/images/source.png"
+        },
+        {
+          "coinDenom": "VDL",
+          "coinMinimalDenom": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/vdl.png"
+        },
+        {
+          "coinDenom": "GRAV",
+          "coinMinimalDenom": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+          "coinDecimals": 6,
+          "coinGeckoId": "graviton",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.png"
+        },
+        {
+          "coinDenom": "WETH",
+          "coinMinimalDenom": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+          "coinDecimals": 18,
+          "coinGeckoId": "axlweth",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png"
+        },
+        {
+          "coinDenom": "CMDX",
+          "coinMinimalDenom": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+          "coinDecimals": 6,
+          "coinGeckoId": "comdex",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
+        },
+        {
+          "coinDenom": "DSM",
+          "coinMinimalDenom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+          "coinDecimals": 6,
+          "coinGeckoId": "desmos",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.png"
+        },
+        {
+          "coinDenom": "TORI",
+          "coinMinimalDenom": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/utori.png"
+        },
+        {
+          "coinDenom": "WHALE",
+          "coinMinimalDenom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/migaloo/images/white-whale.png"
+        },
+        {
+          "coinDenom": "L1",
+          "coinMinimalDenom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.png"
+        },
+        {
+          "coinDenom": "TX",
+          "coinMinimalDenom": "ibc/F3166F4D31D6BA1EC6C9F5536F5DDDD4CC93DBA430F7419E7CDC41C497944A65",
+          "coinDecimals": 6,
+          "coinGeckoId": "tx",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/tx.png"
+        },
+        {
+          "coinDenom": "IXO",
+          "coinMinimalDenom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+          "coinDecimals": 6,
+          "coinGeckoId": "ixo",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
+        },
+        {
+          "coinDenom": "WBNB",
+          "coinMinimalDenom": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+          "coinDecimals": 18,
+          "coinGeckoId": "wbnb",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.png"
+        },
+        {
+          "coinDenom": "BAND",
+          "coinMinimalDenom": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+          "coinDecimals": 6,
+          "coinGeckoId": "band-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.png"
+        },
+        {
+          "coinDenom": "BOOT",
+          "coinMinimalDenom": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+          "coinDecimals": 0,
+          "coinGeckoId": "bostrom",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
+        },
+        {
+          "coinDenom": "ION",
+          "coinMinimalDenom": "uion",
+          "coinDecimals": 6,
+          "coinGeckoId": "ion",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png"
+        },
+        {
+          "coinDenom": "IBCX",
+          "coinMinimalDenom": "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx",
+          "coinDecimals": 6,
+          "coinGeckoId": "ibc-index",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibcx.svg"
+        },
+        {
+          "coinDenom": "ampOSMO",
+          "coinMinimalDenom": "factory/osmo1dv8wz09tckslr2wy5z86r46dxvegylhpt97r9yd6qc3kyc6tv42qa89dr9/ampOSMO",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/amposmo.png"
+        },
+        {
+          "coinDenom": "sqATOM",
+          "coinMinimalDenom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqatom",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqatom.svg"
+        },
+        {
+          "coinDenom": "sqBTC",
+          "coinMinimalDenom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqbtc",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqbtc.svg"
+        },
+        {
+          "coinDenom": "WOSMO",
+          "coinMinimalDenom": "factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/wosmo.png"
+        },
+        {
+          "coinDenom": "sqTIA",
+          "coinMinimalDenom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/sqtia",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sqtia.svg"
+        },
+        {
+          "coinDenom": "RAPTR",
+          "coinMinimalDenom": "factory/osmo1279xudevmf5cw83vkhglct7jededp86k90k2le/RAPTR",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/RAPTR.png"
+        },
+        {
+          "coinDenom": "SAIL",
+          "coinMinimalDenom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sail.png"
+        },
+        {
+          "coinDenom": "TORO",
+          "coinMinimalDenom": "factory/osmo1nr8zfakf6jauye3uqa9lrmr5xumee5n42lv92z/toro",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/toro.png"
+        },
+        {
+          "coinDenom": "IBC",
+          "coinMinimalDenom": "factory/osmo1kqdw6pvn0xww6tyfv2sqvkkencdz0qw406x54r/IBC",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ibc.png"
+        },
+        {
+          "coinDenom": "BERNESE",
+          "coinMinimalDenom": "factory/osmo1s6ht8qrm8x0eg8xag5x3ckx9mse9g4se248yss/BERNESE",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bernese.png"
+        },
+        {
+          "coinDenom": "wLIBRA",
+          "coinMinimalDenom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/0l/images/libra.png"
+        },
+        {
+          "coinDenom": "BWH",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/bwh",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BWH.png"
+        },
+        {
+          "coinDenom": "WIHA",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/wiha",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/WIHA.png"
+        },
+        {
+          "coinDenom": "CRAZYHORSE",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/crazyhorse",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CrazyHorse.png"
+        },
+        {
+          "coinDenom": "COCA",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/coca",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/COCA.png"
+        },
+        {
+          "coinDenom": "BAG",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/bag",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BAG.png"
+        },
+        {
+          "coinDenom": "TURD",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/turd",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/TURD.png"
+        },
+        {
+          "coinDenom": "TRX.rt",
+          "coinMinimalDenom": "factory/osmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9/TRX.rt",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/tron/images/trx.png"
+        },
+        {
+          "coinDenom": "USDT.eth.rt",
+          "coinMinimalDenom": "factory/osmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9/USDT.rt",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        },
+        {
+          "coinDenom": "COOK",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/COOK",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/COOK.png"
+        },
+        {
+          "coinDenom": "TRX",
+          "coinMinimalDenom": "factory/osmo14mafhhp337yjj2aujplawz0tks6jd2lel4hkwz4agyzhvvztzaqsqzjq8x/alloyed/allTRX",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/tron/images/trx.png"
+        },
+        {
+          "coinDenom": "OP",
+          "coinMinimalDenom": "factory/osmo1nufyzqlm8qhu2w7lm0l4rrax0ec8rsk69mga4tel8eare7c7ljaqpk2lyg/alloyed/allOP",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/optimism/images/op.png"
+        },
+        {
+          "coinDenom": "SHIB",
+          "coinMinimalDenom": "factory/osmo1f588gk9dazpsueevdl2w6wfkmfmhg5gdvg2uerdlzl0atkasqhsq59qc6a/alloyed/allSHIB",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg"
+        },
+        {
+          "coinDenom": "ARB",
+          "coinMinimalDenom": "factory/osmo1p7x454ex08s4f9ztmm7wfv7lvtgdkfztj2u7v7fezfcauy85q35qmqrdpk/alloyed/allARB",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/arbitrum/images/arb.png"
+        },
+        {
+          "coinDenom": "LINK",
+          "coinMinimalDenom": "factory/osmo18zdw5yvs6gfp95rp74qqwug9yduw2fyr8kplk2xgs726s9axc5usa2vpgw/alloyed/allLINK",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.png"
+        },
+        {
+          "coinDenom": "PEPE",
+          "coinMinimalDenom": "factory/osmo1nnlxegt0scm9qkzys9c874t0ntapv4epfjy2w49c0xdrp3dr0v4ssmelzx/alloyed/allPEPE",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/pepe.png"
+        },
+        {
+          "coinDenom": "DOT",
+          "coinMinimalDenom": "factory/osmo1r53fx9fvcdzncrs7zkn4gw5vfelx5gk8k5wc6wqha2jpkh992rusr5tk02/alloyed/allDOT",
+          "coinDecimals": 10,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.png"
+        },
+        {
+          "coinDenom": "COSMOUSD",
+          "coinMinimalDenom": "factory/osmo104jtrwcljnxfljhml8mxrw7qetcsdmqvy3sprw/ucosmousd",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/CosmoUSD.png"
+        },
+        {
+          "coinDenom": "XTRUMP",
+          "coinMinimalDenom": "factory/osmo1hg0zf0c9can4tvtulh5gmmxe4jpflre3yewxjl/XTRUMP",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/XTRUMP.png"
+        },
+        {
+          "coinDenom": "LEG",
+          "coinMinimalDenom": "factory/osmo1c3sjhsneuajqn4ke84kqqaf26ct5cjs8z5ale0yv7096wh6fyf6qxmgkph/leg",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/leg.png"
+        },
+        {
+          "coinDenom": "fBAD",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fBAD",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fBAD.png"
+        },
+        {
+          "coinDenom": "fMAD",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fMAD",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fMAD.png"
+        },
+        {
+          "coinDenom": "fSLOTH",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fSLOTH",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fSLOTH.png"
+        },
+        {
+          "coinDenom": "fNUT",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fNUT",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fNUT.png"
+        },
+        {
+          "coinDenom": "TON",
+          "coinMinimalDenom": "factory/osmo12lnwf54yd30p6amzaged2atln8k0l32n7ncxf04ctg7u7ymnsy7qkqgsw4/alloyed/allTON",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ton/images/ton.png"
+        },
+        {
+          "coinDenom": "BVT0",
+          "coinMinimalDenom": "factory/osmo1xu0gk9aggv79597xwazyfzaggv2pze9z7cq3p9p72tkkux9a7xaqufa792/BVT",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BVT0.png"
+        },
+        {
+          "coinDenom": "BVT1",
+          "coinMinimalDenom": "factory/osmo16nxtnrnl7lctvnhhpcxqmmpv63n93zgg0ukaveyc0jl4dtad79cs53c3an/BVT",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BVT1.png"
+        },
+        {
+          "coinDenom": "AVAIL.eth.rt",
+          "coinMinimalDenom": "factory/osmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9/AVAIL.rt",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avail/images/avail.png"
+        },
+        {
+          "coinDenom": "ckBTC",
+          "coinMinimalDenom": "factory/osmo10c4y9csfs8q7mtvfg4p9gd8d0acx0hpc2mte9xqzthd7rd3348tsfhaesm/sICP-icrc-ckBTC",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/internetcomputer/images/ckbtc.png"
+        },
+        {
+          "coinDenom": "fWIZ",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fWIZ",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fWIZ.png"
+        },
+        {
+          "coinDenom": "fWITCH",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fWITCH",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fWITCH.png"
+        },
+        {
+          "coinDenom": "fCRYPTONIUM",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fCRYPTONIUM",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fCRYPTONIUM.png"
+        },
+        {
+          "coinDenom": "fATLAS",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fATLAS",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fATLAS.png"
+        },
+        {
+          "coinDenom": "fGECK",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fGECK",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fGECK.png"
+        },
+        {
+          "coinDenom": "fBULLS",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fBULLS",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fBULLS.png"
+        },
+        {
+          "coinDenom": "UNI",
+          "coinMinimalDenom": "factory/osmo1eqjda4pc6e09jtxzxggf6jl3jye2yn453ja58we5gxwzmf5ah28qvlnaz8/alloyed/allUNI",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
+        },
+        {
+          "coinDenom": "RBTC.rt",
+          "coinMinimalDenom": "factory/osmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9/BTC.rt",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/rootstock/images/rbtc.png"
+        },
+        {
+          "coinDenom": "DOGE",
+          "coinMinimalDenom": "factory/osmo10pk4crey8fpdyqd62rsau0y02e3rk055w5u005ah6ly7k849k5tsf72x40/alloyed/allDOGE",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/dogecoin/images/doge.png"
+        },
+        {
+          "coinDenom": "LTC",
+          "coinMinimalDenom": "factory/osmo1csp8fk353hnq2tmulklecxpex43qmjvrkxjcsh4c3eqcw2vjcslq5jls9v/alloyed/allLTC",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/litecoin/images/ltc.png"
+        },
+        {
+          "coinDenom": "BCH",
+          "coinMinimalDenom": "factory/osmo1cranx3twqxfrgeqvgsu262gy54vafpc9xap6scye99v244zl970s7kw2sz/alloyed/allBCH",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoincash/images/bch.png"
+        },
+        {
+          "coinDenom": "SPICE",
+          "coinMinimalDenom": "factory/osmo1n6asrjy9754q8y9jsxqf557zmsv3s3xa5m9eg5/uspice",
+          "coinDecimals": 6,
+          "coinGeckoId": "spice-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/spice.png"
+        },
+        {
+          "coinDenom": "BOMU",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/bomu",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/bomu.png"
+        },
+        {
+          "coinDenom": "SHERPA",
+          "coinMinimalDenom": "factory/osmo1n6asrjy9754q8y9jsxqf557zmsv3s3xa5m9eg5/usherpa",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/sherpa.png"
+        },
+        {
+          "coinDenom": "XRP",
+          "coinMinimalDenom": "factory/osmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0/alloyed/allXRP",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png"
+        },
+        {
+          "coinDenom": "FIL",
+          "coinMinimalDenom": "factory/osmo1ss0n3ghv5rr4z4y54fnkprc69tegmdm3ejlkgr2z4utnyg7eljgs9pztvs/alloyed/allFIL",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/filecoin/images/fil.png"
+        },
+        {
+          "coinDenom": "ckDOGE",
+          "coinMinimalDenom": "factory/osmo10c4y9csfs8q7mtvfg4p9gd8d0acx0hpc2mte9xqzthd7rd3348tsfhaesm/dogecoin-native-DOGE",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ckDOGE.png"
+        },
+        {
+          "coinDenom": "SUI",
+          "coinMinimalDenom": "factory/osmo1nqu7rc5mj5p2cgyfp7gl3lw7kw99cltple3xtzl2cs5fyw0r2tasr7xv48/alloyed/allSUI",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/sui/images/sui.svg"
+        },
+        {
+          "coinDenom": "APT",
+          "coinMinimalDenom": "factory/osmo1zynnzvwdu72zc4mxqnnp348ksfmayldqyfs8khdud3myr7m5h8nsqwta2v/alloyed/allAPT",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/aptos/images/aptos.svg"
+        },
+        {
+          "coinDenom": "BNB",
+          "coinMinimalDenom": "factory/osmo1zetxzc5nka4jm203ljjtjf933jwjh45ge6spfeef447rnnhqxc4qrazrcz/alloyed/allBNB",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/bnb.png"
+        },
+        {
+          "coinDenom": "DYDX",
+          "coinMinimalDenom": "factory/osmo1zem8r6dv6u38f6qpg546zy30946av8h5srgug0s4gcyy6cfecf3seac083/alloyed/allDYDX",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx-circle.svg"
+        },
+        {
+          "coinDenom": "FET",
+          "coinMinimalDenom": "factory/osmo1mdvn6lmykp2z345ncpf647dztslyll8cyhwj9pltrc0lf7nva3cqvrp6qs/alloyed/allFET",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.png"
+        },
+        {
+          "coinDenom": "AIOZ",
+          "coinMinimalDenom": "factory/osmo17ceugf0nnkk228k2sulemn0s9pl3yg554462eexxs3pgq8p629us98gqae/alloyed/allAIOZ",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/aioz/images/aioz.png"
+        },
+        {
+          "coinDenom": "T7S",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/t7s",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/T7S.png"
+        },
+        {
+          "coinDenom": "DYM",
+          "coinMinimalDenom": "factory/osmo12cf6l99qrchfppmjp80gvkpnle2tuxpck2cf6fz030w74mq49u4qm3dh4d/alloyed/allDYM",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dymension/images/dymension-logo.png"
+        },
+        {
+          "coinDenom": "POL",
+          "coinMinimalDenom": "factory/osmo1fg7y3j86fkp93yxpq5q8lk8c64k8wxj3qw8us49msgpr2gsgddjqxpgr9m/alloyed/allPOL",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/matic-purple.png"
+        },
+        {
+          "coinDenom": "BABA",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/ba-ba",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BA-BA.png"
+        },
+        {
+          "coinDenom": "MOVE",
+          "coinMinimalDenom": "factory/osmo1v90ezcqkv5utjc52vg4w2gztmcpt7l4vqxzuryj6zl3qr8wy539quxeafk/alloyed/allMOVE",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/movement/images/move.png"
+        },
+        {
+          "coinDenom": "CULT",
+          "coinMinimalDenom": "factory/osmo1qdvwftqd8ml6t9w6dmj97m03ck5ghqqmd8y7cm/cult",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/cult.png"
+        },
+        {
+          "coinDenom": "fHAM",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fHAM",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fHAM.png"
+        },
+        {
+          "coinDenom": "fCEWT",
+          "coinMinimalDenom": "factory/osmo1dywfmhyc8y0wga7qpzej0x0mgwqg25fj4eccp494w8yafzdpgamsx9ryyv/fCEWT",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/fCEWT.png"
+        },
+        {
+          "coinDenom": "STLTH",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/stlth",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/STLTH.png"
+        },
+        {
+          "coinDenom": "MTC",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/mtc",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/MTC.png"
+        },
+        {
+          "coinDenom": "NAM",
+          "coinMinimalDenom": "ibc/C7110DEC66869DAE9BE9C3C60F4B5313B16A2204AE020C3B0527DD6B322386A3",
+          "coinDecimals": 6,
+          "coinGeckoId": "namada",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/namada/images/namada.svg"
+        },
+        {
+          "coinDenom": "EBABY",
+          "coinMinimalDenom": "factory/osmo12r3yc76u9lxe33yemstatnw8602culdjzrtr8lmnpycmd3z7d4jsxx60kc/FwNhFaW3zLxoLUgXCdWjqBzcvGNPaB7B2XZqm2xgrB93",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/babylon/images/eBABY.svg"
+        },
+        {
+          "coinDenom": "FOST",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/fost",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/FOST.png"
+        },
+        {
+          "coinDenom": "TRUMP",
+          "coinMinimalDenom": "factory/osmo1524q4dt7ckx25daydfd0ya0hyu6t26ch5509nvmxm4gcvuhk0fvs8qzl5q/alloyed/allTRUMP",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/trump.png"
+        },
+        {
+          "coinDenom": "PENGU",
+          "coinMinimalDenom": "factory/osmo10nu66efsxxkdgh70xs8xur9mygrg79m5ht7zcmzsrdzxkhz7hpssz9hg9k/alloyed/allPENGU",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/pengu.png"
+        },
+        {
+          "coinDenom": "ZEC",
+          "coinMinimalDenom": "factory/osmo1twk0c4kcwnhkyn6pzxe0qsk6a3nrye2w2sy309d60sljfysugagsd7e3mn/alloyed/allZEC",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/zcash/images/zec.png"
+        },
+        {
+          "coinDenom": "YMOS",
+          "coinMinimalDenom": "factory/osmo1vdvnznwg597qngrq9mnfcfk0am9jdc9y446jewhcqdreqz4r75xq5j5zvy/ymos",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ymos.png"
+        },
+        {
+          "coinDenom": "BRNZ",
+          "coinMinimalDenom": "factory/osmo13gu58hzw3e9aqpj25h67m7snwcjuccd7v4p55w/brnz",
+          "coinDecimals": 0,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/BRNZ.png"
+        },
+        {
+          "coinDenom": "ashLAB",
+          "coinMinimalDenom": "factory/osmo1svj5kd8kzj7xxtrd6ftjk0856ffpyj4egz7f9pd9dge5wr4kwansmefq07/lab.ash",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ashLAB.png"
+        },
+        {
+          "coinDenom": "earnUSDC",
+          "coinMinimalDenom": "factory/osmo1vf6e300hv2qe7r5rln8deft45ewgyytjnwfrdfcv5rgzrfy0s6cswjqf9r/mars-usdc-looped",
+          "coinDecimals": 6
+        },
+        {
+          "coinDenom": "earnCDT",
+          "coinMinimalDenom": "factory/osmo1jw6r68y0uhfmqagc7uhtdddctc7wq95pncvrqnvtd47w4hx46p7se9nju5/earn-cdt",
+          "coinDecimals": 6
+        },
+        {
+          "coinDenom": "ashION",
+          "coinMinimalDenom": "factory/osmo1svj5kd8kzj7xxtrd6ftjk0856ffpyj4egz7f9pd9dge5wr4kwansmefq07/ion.ash",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ashion.png"
+        },
+        {
+          "coinDenom": "ALLIN",
+          "coinMinimalDenom": "factory/osmo1gzcz4anh88fz3vanx0842gsa3y8jcvck3qw90e/uallin",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/allin.png"
+        },
+        {
+          "coinDenom": "allUSD",
+          "coinMinimalDenom": "factory/osmo1t82ql2w69m9g3un7c6sk5wss578ewst2uscr7zdkn6k8rmzc3e8qz9n4q2/alloyed/allUSD",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/usd.svg"
+        },
+        {
+          "coinDenom": "LABS",
+          "coinMinimalDenom": "factory/osmo1are7fpe5l6jzm9sjn7u4qkq6q77wwrrsxzlyw8lcegmmaxdukvuq4h46dx/LABS",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/LABS.png"
+        },
+        {
+          "coinDenom": "QUARK",
+          "coinMinimalDenom": "factory/osmo1x7s7a2erqspkm6e79n7yh7fw3yh7xx4lt54mxg/uquark",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/quark.png"
+        },
+        {
+          "coinDenom": "NINEDOLLERS",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/ninedollers",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/NINEDOLLERS.png"
+        },
+        {
+          "coinDenom": "SLAYER",
+          "coinMinimalDenom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/slayer",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/SLAYER.png"
+        },
+        {
+          "coinDenom": "EPIX",
+          "coinMinimalDenom": "factory/osmo130tfawc7katf7jwzt2rjdranhqju929rjra3xwsrfsd85hedh3tsssy9j7/alloyed/allEPIX",
+          "coinDecimals": 12,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/epix/images/epix.svg"
+        },
+        {
+          "coinDenom": "GSI",
+          "coinMinimalDenom": "factory/osmo187hj0cr8csrhzm8ukzsp53vc0cfp338ftacy7j/gsi",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/gsi.png"
+        }
+      ],
+      "description": "Osmosis (OSMO) is the premier DEX and cross-chain DeFi hub within the Cosmos ecosystem, a network of over 50 sovereign, interoperable blockchains seamlessly connected through the Inter-Blockchain Communication Protocol (IBC). Pioneering in its approach, Osmosis offers a dynamic trading and liquidity provision experience, integrating non-IBC assets from other ecosystems, including Ethereum, Solana, Avalanche, and Polkadot. Initially adopting Balancer-style pools, Osmosis now also features a concentrated liquidity model that is orders of magnitude more capital efficient, meaning that significantly less liquidity is required to handle the same amount of trading volume with minimal slippage.\n\nAs a true appchain, Osmosis has greater control over the full blockchain stack than traditional smart contract DEXs, which must follow the code of the parent chain that it is built on. This fine-grained control has enabled, for example, the development of Superfluid Staking, an extension of Proof of Stake that allows assets at the application layer to be staked to secure the chain. The customizability of appchains also allows implementing features like the Protocol Revenue module, which enables Osmosis to conduct on-chain arbitrage on behalf of OSMO stakers, balancing prices across pools while generating real yield revenue from this volume. Additionally, as a sovereign appchain, Osmosis governance can vote on upgrades to the protocol. One example of this was the introduction of a Taker Fee, which switched on the collection of exchange fees to generate diverse yield from Osmosis volume and distribute it to OSMO stakers.\n\nOsmosis is bringing the full centralized exchange experience to the decentralized world by building a cross-chain native DEX and trading suite that connects all chains over IBC, including Ethereum and Bitcoin. To reach this goal, Osmosis hosts an ever-expanding suite of DeFi applications aimed at providing a one-stop experience that includes lending, credit, margin, DeFi strategy vaults, power perps, fiat on-ramps, NFTs, stablecoins, and more — all of the functionalities that centralized exchange offer and more, in the trust-minimized environment of decentralized finance.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.osmosis.zone/"
+          },
+          {
+            "address": "https://rpc.lavenderfive.com:443/osmosis"
+          },
+          {
+            "address": "https://rpc-osmosis.ecostake.com"
+          },
+          {
+            "address": "https://osmosis-rpc.polkachu.com"
+          },
+          {
+            "address": "https://osmosis.rpc.stakin-nodes.com"
+          },
+          {
+            "address": "https://osmosis-rpc.publicnode.com:443"
+          },
+          {
+            "address": "https://community.nuxian-node.ch:6797/osmosis/trpc"
+          },
+          {
+            "address": "http://rpc-osmosis.freshstaking.com:31657"
+          },
+          {
+            "address": "https://osmosis-rpc.stake-town.com"
+          },
+          {
+            "address": "https://rpc.osmosis.validatus.com"
+          },
+          {
+            "address": "https://public.stakewolle.com/cosmos/osmosis/rpc"
+          },
+          {
+            "address": "https://rpc.cros-nest.com/osmosis"
+          },
+          {
+            "address": "https://rpc.osmosis.goldenratiostaking.net"
+          },
+          {
+            "address": "https://osmosis-rpc.noders.services"
+          },
+          {
+            "address": "https://osmosis-rpc.highstakes.ch"
+          },
+          {
+            "address": "https://rpc.osmosis.citizenweb3.com/"
+          },
+          {
+            "address": "https://osmosis.api.pocket.network"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://lcd.osmosis.zone/"
+          },
+          {
+            "address": "https://rest.osmosis.goldenratiostaking.net"
+          },
+          {
+            "address": "https://rest.lavenderfive.com:443/osmosis"
+          },
+          {
+            "address": "https://rest-osmosis.ecostake.com"
+          },
+          {
+            "address": "https://osmosis-api.polkachu.com"
+          },
+          {
+            "address": "https://osmosis.rest.stakin-nodes.com"
+          },
+          {
+            "address": "https://osmosis-rest.publicnode.com"
+          },
+          {
+            "address": "https://community.nuxian-node.ch:6797/osmosis/crpc"
+          },
+          {
+            "address": "https://osmosis-api.stake-town.com"
+          },
+          {
+            "address": "https://api.osmosis.validatus.com:443"
+          },
+          {
+            "address": "https://public.stakewolle.com/cosmos/osmosis/rest"
+          },
+          {
+            "address": "https://rest.cros-nest.com/osmosis"
+          },
+          {
+            "address": "https://osmosis-api.noders.services"
+          },
+          {
+            "address": "https://osmosis-api.highstakes.ch"
+          },
+          {
+            "address": "https://api.osmosis.citizenweb3.com/"
+          },
+          {
+            "address": "https://osmosis.api.pocket.network"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://ezstaking.app/osmosis/txs/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "junotestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Juno Testnet",
+      "chain_id": "uni-7",
+      "bech32Prefix": "juno",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "juno",
+        "bech32PrefixAccPub": "junopub",
+        "bech32PrefixValAddr": "junovaloper",
+        "bech32PrefixValPub": "junovaloperpub",
+        "bech32PrefixConsAddr": "junovalcons",
+        "bech32PrefixConsPub": "junovalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "JUNOX",
+        "coinMinimalDenom": "ujunox",
+        "coinDecimals": 6,
+        "coinGeckoId": "juno-network",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "JUNOX",
+          "coinMinimalDenom": "ujunox",
+          "coinDecimals": 6,
+          "coinGeckoId": "juno-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png",
+          "gasPriceStep": {
+            "low": 0.003,
+            "average": 0.0045,
+            "high": 0.006
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "JUNOX",
+          "coinMinimalDenom": "ujunox",
+          "coinDecimals": 6,
+          "coinGeckoId": "juno-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.png"
+        },
+        {
+          "coinDenom": "NEXX",
+          "coinMinimalDenom": "factory/juno12klaltyqvg2j6v034jwdxrk5n4242ttse4sdpt/NEXX",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/junotestnet/images/nexx.png"
+        },
+        {
+          "coinDenom": "ARENA",
+          "coinMinimalDenom": "factory/juno12dgadj3wwv5jn0ec7tw5cgvq526nn4gnt2tujlmd57p2ra6k87esl36r9k/ARENA",
+          "coinDecimals": 6
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://juno-testnet-rpc.polkachu.com"
+          },
+          {
+            "address": "https://rpc-uni.junonetwork.io"
+          },
+          {
+            "address": "https://junotestnet-rpc.kleomedes.network"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://juno-testnet-api.polkachu.com"
+          },
+          {
+            "address": "https://lcd-uni.junonetwork.io"
+          },
+          {
+            "address": "https://junotestnet-api.kleomedes.network"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer.stavr.tech/Juno-Testnet/txs/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "agoricdevnet",
@@ -2498,39 +5450,386 @@
     },
     {
       "chain_name": "babylontestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Babylon Testnet",
+      "chain_id": "bbn-test-5",
+      "bech32Prefix": "bbn",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "bbn",
+        "bech32PrefixAccPub": "bbnpub",
+        "bech32PrefixValAddr": "bbnvaloper",
+        "bech32PrefixValPub": "bbnvaloperpub",
+        "bech32PrefixConsAddr": "bbnvalcons",
+        "bech32PrefixConsPub": "bbnvalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "BABY",
+        "coinMinimalDenom": "ubbn",
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "BABY",
+          "coinMinimalDenom": "ubbn",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg",
+          "gasPriceStep": {
+            "low": 0.007,
+            "average": 0.007,
+            "high": 0.01
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "BABY",
+          "coinMinimalDenom": "ubbn",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "eBABY",
+          "coinMinimalDenom": "cw20:bbn1cnx34p82zngq0uuaendsne0x4s5gsm7gpwk2es8zk8rz8tnj938qqyq8f9",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/eBABY.svg"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://babylon-testnet-rpc.nodes.guru"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://babylon-testnet-api.nodes.guru"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://babylon-testnet.l2scan.co/tx/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "celestiatestnet3",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Mocha Testnet",
+      "chain_id": "mocha-4",
+      "bech32Prefix": "celestia",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "celestia",
+        "bech32PrefixAccPub": "celestiapub",
+        "bech32PrefixValAddr": "celestiavaloper",
+        "bech32PrefixValPub": "celestiavaloperpub",
+        "bech32PrefixConsAddr": "celestiavalcons",
+        "bech32PrefixConsPub": "celestiavalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/celestiatestnet3/images/celestia.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/celestiatestnet3/images/celestia.svg"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "TIA",
+          "coinMinimalDenom": "utia",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/celestiatestnet3/images/celestia.png",
+          "gasPriceStep": {
+            "low": 0.01,
+            "average": 0.02,
+            "high": 0.1
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "TIA",
+          "coinMinimalDenom": "utia",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/celestiatestnet3/images/celestia.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc-mocha.pops.one"
+          },
+          {
+            "address": "https://celestia-testnet-rpc.publicnode.com:443"
+          },
+          {
+            "address": "https://rpc-mocha-full.avril14th.org"
+          },
+          {
+            "address": "https://celestia-testnet-rpc.itrocket.net"
+          },
+          {
+            "address": "https://rpc-celestia-testnet.cryptech.com.ua"
+          },
+          {
+            "address": "https://rpc.celestia.testnet.dteam.tech:443"
+          },
+          {
+            "address": "https://celestia-testnet-rpc.stakeandrelax.net"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api-mocha.pops.one"
+          },
+          {
+            "address": "https://celestia-testnet-rest.publicnode.com"
+          },
+          {
+            "address": "https://api-mocha-full.avril14th.org"
+          },
+          {
+            "address": "https://celestia-testnet-api.itrocket.net"
+          },
+          {
+            "address": "https://api-celestia-testnet.cryptech.com.ua"
+          },
+          {
+            "address": "https://api.celestia.testnet.dteam.tech:443"
+          },
+          {
+            "address": "https://celestia-testnet-api.stakeandrelax.net"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://mintscan.io/celestia-testnet/txs/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "coreumtestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "TX",
+      "chain_id": "coreum-testnet-1",
+      "bech32Prefix": "testcore",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "testcore",
+        "bech32PrefixAccPub": "testcorepub",
+        "bech32PrefixValAddr": "testcorevaloper",
+        "bech32PrefixValPub": "testcorevaloperpub",
+        "bech32PrefixConsAddr": "testcorevalcons",
+        "bech32PrefixConsPub": "testcorevalconspub"
+      },
+      "slip44": 990,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/tx.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "TESTTX",
+        "coinMinimalDenom": "utestcore",
+        "coinDecimals": 6,
+        "coinGeckoId": "tx",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/tx.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "TESTTX",
+          "coinMinimalDenom": "utestcore",
+          "coinDecimals": 6,
+          "coinGeckoId": "tx",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/tx.png",
+          "gasPriceStep": {
+            "low": 0.0625,
+            "average": 0.0625,
+            "high": 62.5
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "TESTTX",
+          "coinMinimalDenom": "utestcore",
+          "coinDecimals": 6,
+          "coinGeckoId": "tx",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/coreum/images/tx.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.testnet-1.tx.org:443"
+          },
+          {
+            "address": "https://rpc-01.testnet-1.tx.org:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://rest.testnet-1.tx.org:443"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer.testnet-1.tx.org/tx/transactions/${txHash}"
+        }
+      ],
+      "features": [
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "doravotatestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Dora Vota Testnet",
+      "chain_id": "vota-testnet",
+      "bech32Prefix": "dora",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "dora",
+        "bech32PrefixAccPub": "dorapub",
+        "bech32PrefixValAddr": "doravaloper",
+        "bech32PrefixValPub": "doravaloperpub",
+        "bech32PrefixConsAddr": "doravalcons",
+        "bech32PrefixConsPub": "doravalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/doravotatestnet/images/doravota.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "DORA",
+        "coinMinimalDenom": "peaka",
+        "coinDecimals": 18,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/doravotatestnet/images/doravota.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "DORA",
+          "coinMinimalDenom": "peaka",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/doravotatestnet/images/doravota.png"
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "DORA",
+          "coinMinimalDenom": "peaka",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/doravotatestnet/images/doravota.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://vota-testnet-rpc.dorafactory.org/"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://vota-testnet-rest.dorafactory.org"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://maci-explorer-test.dorafactory.org/dora/tx/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "empowertestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Empower Testnet",
+      "chain_id": "circulus-1",
+      "bech32Prefix": "empower",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "empower",
+        "bech32PrefixAccPub": "empowerpub",
+        "bech32PrefixValAddr": "empowervaloper",
+        "bech32PrefixValPub": "empowervaloperpub",
+        "bech32PrefixConsAddr": "empowervalcons",
+        "bech32PrefixConsPub": "empowervalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/empowertestnet/images/mpwr.png"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "MPWR",
+          "coinMinimalDenom": "umpwr",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/empowertestnet/images/mpwr.png"
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "MPWR",
+          "coinMinimalDenom": "umpwr",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/empowertestnet/images/mpwr.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://empower-testnet-rpc.polkachu.com:443"
+          },
+          {
+            "address": "https://empower.rpc.cumulo.com.es:443"
+          },
+          {
+            "address": "https://rpc-t.empower.nodestake.top:443"
+          },
+          {
+            "address": "https://rpc-empower.nodeist.net:443"
+          },
+          {
+            "address": "https://empower-testnet.nodejumper.io:443"
+          },
+          {
+            "address": "https://rpc.circulus-1.empower.aviaone.com:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://empower-testnet-api.polkachu.com:443"
+          },
+          {
+            "address": "https://empower.api.cumulo.com.es:443"
+          },
+          {
+            "address": "https://empw.api.t.stavr.tech"
+          },
+          {
+            "address": "https://api-t.empower.nodestake.top:443"
+          },
+          {
+            "address": "https://api-empower.nodeist.net:443"
+          },
+          {
+            "address": "https://empower-testnet.nodejumper.io:1317"
+          },
+          {
+            "address": "https://api.circulus-1.empower.aviaone.com"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://empowerchain.exploreme.pro/transaction/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "entrypointtestnet",
@@ -2549,33 +5848,422 @@
     },
     {
       "chain_name": "injectivetestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Injective",
+      "chain_id": "injective-888",
+      "bech32Prefix": "inj",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "inj",
+        "bech32PrefixAccPub": "injpub",
+        "bech32PrefixValAddr": "injvaloper",
+        "bech32PrefixValPub": "injvaloperpub",
+        "bech32PrefixConsAddr": "injvalcons",
+        "bech32PrefixConsPub": "injvalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "INJ",
+        "coinMinimalDenom": "inj",
+        "coinDecimals": 18,
+        "coinGeckoId": "injective-protocol",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "INJ",
+          "coinMinimalDenom": "inj",
+          "coinDecimals": 18,
+          "coinGeckoId": "injective-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png",
+          "gasPriceStep": {
+            "low": 500000000,
+            "average": 700000000,
+            "high": 900000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "INJ",
+          "coinMinimalDenom": "inj",
+          "coinDecimals": 18,
+          "coinGeckoId": "injective-protocol",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.png"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "factory/inj17vytdwqczqz72j65saukplrktd4gyfme5agf6c/usdc",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png"
+        },
+        {
+          "coinDenom": "USDT",
+          "coinMinimalDenom": "peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdt.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://injective-testnet-rpc.polkachu.com"
+          },
+          {
+            "address": "https://testnet.sentry.tm.injective.network:443"
+          },
+          {
+            "address": "https://testnet.tm.injective.network"
+          },
+          {
+            "address": "https://injective-testnet-rpc.publicnode.com:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://injective-testnet-api.polkachu.com"
+          },
+          {
+            "address": "https://testnet.sentry.lcd.injective.network:443"
+          },
+          {
+            "address": "https://testnet.lcd.injective.network"
+          },
+          {
+            "address": "https://injective-testnet-rest.publicnode.com"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://testnet.explorer.injective.network/transaction/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "int3facetestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Int3face Testnet",
+      "chain_id": "int3-test-2",
+      "bech32Prefix": "int3",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "int3",
+        "bech32PrefixAccPub": "int3pub",
+        "bech32PrefixValAddr": "int3valoper",
+        "bech32PrefixValPub": "int3valoperpub",
+        "bech32PrefixConsAddr": "int3valcons",
+        "bech32PrefixConsPub": "int3valconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/int3face-chain-logo.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "INT3",
+        "coinMinimalDenom": "uint3",
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/int3.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "INT3",
+          "coinMinimalDenom": "uint3",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/int3.png",
+          "gasPriceStep": {
+            "low": 0.01,
+            "average": 0.025,
+            "high": 0.04
+          }
+        },
+        {
+          "coinDenom": "BTC",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/bitcoin-btc",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/btc.int3.png",
+          "gasPriceStep": {
+            "low": 1e-7,
+            "average": 0.0000025,
+            "high": 0.000004
+          }
+        },
+        {
+          "coinDenom": "BCH",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/bitcoin-cash-bch",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/bch.int3.png",
+          "gasPriceStep": {
+            "low": 0.000001,
+            "average": 0.000025,
+            "high": 0.00004
+          }
+        },
+        {
+          "coinDenom": "LTC",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/litecoin-ltc",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/ltc.int3.png",
+          "gasPriceStep": {
+            "low": 0.000001,
+            "average": 0.000025,
+            "high": 0.00004
+          }
+        },
+        {
+          "coinDenom": "DOGE",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/dogecoin-doge",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/doge.int3.png",
+          "gasPriceStep": {
+            "low": 0.001,
+            "average": 0.0025,
+            "high": 0.004
+          }
+        },
+        {
+          "coinDenom": "TON",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/ton-ton",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/ton.int3.png",
+          "gasPriceStep": {
+            "low": 0.0001,
+            "average": 0.00025,
+            "high": 0.0004
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "INT3",
+          "coinMinimalDenom": "uint3",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/int3.png"
+        },
+        {
+          "coinDenom": "BTC",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/bitcoin-btc",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/btc.int3.png"
+        },
+        {
+          "coinDenom": "BCH",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/bitcoin-cash-bch",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/bch.int3.png"
+        },
+        {
+          "coinDenom": "LTC",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/litecoin-ltc",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/ltc.int3.png"
+        },
+        {
+          "coinDenom": "DOGE",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/dogecoin-doge",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/doge.int3.png"
+        },
+        {
+          "coinDenom": "TON",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/ton-ton",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/ton.int3.png"
+        },
+        {
+          "coinDenom": "SOL",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/solana-sol",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/sol.int3.png"
+        },
+        {
+          "coinDenom": "XRP",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/xrpl-xrp",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/xrp.int3.png"
+        },
+        {
+          "coinDenom": "ZEC",
+          "coinMinimalDenom": "factory/int31zlefkpe3g0vvm9a4h0jf9000lmqutlh99h7fsd/zcash-zec",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/zec.int3.png"
+        }
+      ],
+      "description": "Int3face is a cross-chain bridge that connects the Cosmos ecosystem with other blockchains.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.testnet.int3face.zone"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.testnet.int3face.zone"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://testnet.explorer.int3face.zone/int3face-1/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "lavatestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Lava Testnet",
+      "chain_id": "lava-testnet-2",
+      "bech32Prefix": "lava@",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "lava@",
+        "bech32PrefixAccPub": "lava@pub",
+        "bech32PrefixValAddr": "lava@valoper",
+        "bech32PrefixValPub": "lava@valoperpub",
+        "bech32PrefixConsAddr": "lava@valcons",
+        "bech32PrefixConsPub": "lava@valconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/lavatestnet/images/lava-icon.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "LAVA",
+        "coinMinimalDenom": "ulava",
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/lavatestnet/images/lava-icon.svg"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "LAVA",
+          "coinMinimalDenom": "ulava",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/lavatestnet/images/lava-icon.svg",
+          "gasPriceStep": {
+            "low": 0.000001,
+            "average": 0.025,
+            "high": 0.04
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "LAVA",
+          "coinMinimalDenom": "ulava",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/lavatestnet/images/lava-icon.svg"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://lav1.tendermintrpc.lava.build:443"
+          },
+          {
+            "address": "http://lava.rpc.t.stavr.tech:198"
+          },
+          {
+            "address": "https://lava-testnet-rpc.itrocket.net:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://lav1.lava.build/"
+          },
+          {
+            "address": "https://lava.api.t.stavr.tech"
+          },
+          {
+            "address": "https://lava-testnet-api.itrocket.net"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://lava.explorers.guru//transaction/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "likecointestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "LikeCoin Testnet",
+      "chain_id": "likecoin-public-testnet-5",
+      "bech32Prefix": "like",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "like",
+        "bech32PrefixAccPub": "likepub",
+        "bech32PrefixValAddr": "likevaloper",
+        "bech32PrefixValPub": "likevaloperpub",
+        "bech32PrefixConsAddr": "likevalcons",
+        "bech32PrefixConsPub": "likevalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "EKIL",
+        "coinMinimalDenom": "nanoekil",
+        "coinDecimals": 9,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "EKIL",
+          "coinMinimalDenom": "nanoekil",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png",
+          "gasPriceStep": {
+            "low": 1000,
+            "average": 10000,
+            "high": 1000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "EKIL",
+          "coinMinimalDenom": "nanoekil",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://node.testnet.like.co/rpc/"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://node.testnet.like.co/"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://testnet.bigdipper.live/likecoin/transactions/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "mantrachaintestnet",
@@ -2587,27 +6275,276 @@
     },
     {
       "chain_name": "mantrachaintestnet2",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "MANTRA Dukong Testnet",
+      "chain_id": "mantra-dukong-1",
+      "bech32Prefix": "mantra",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "mantra",
+        "bech32PrefixAccPub": "mantrapub",
+        "bech32PrefixValAddr": "mantravaloper",
+        "bech32PrefixValPub": "mantravaloperpub",
+        "bech32PrefixConsAddr": "mantravalcons",
+        "bech32PrefixConsPub": "mantravalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "MANTRA",
+        "coinMinimalDenom": "amantra",
+        "coinDecimals": 18,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "MANTRA",
+          "coinMinimalDenom": "amantra",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.png",
+          "gasPriceStep": {
+            "low": 40000000000,
+            "average": 80000000000,
+            "high": 120000000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "MANTRA",
+          "coinMinimalDenom": "amantra",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mantrachain/images/OM-Prim-Col.png"
+        },
+        {
+          "coinDenom": "TREATS",
+          "coinMinimalDenom": "factory/mantra1uvn4qgh96lc83dzu8mpf3u93lk605ls0vg0nf2/TREATS",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/mantrachaintestnet2/images/treats.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.dukong.mantrachain.io"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.dukong.mantrachain.io"
+          },
+          {
+            "address": "https://lcd-office.cosmostation.io/mantra-testnet/"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://mintscan.io/mantra-testnet/txs/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "neutrontestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Neutron Testnet",
+      "chain_id": "pion-1",
+      "bech32Prefix": "neutron",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "neutron",
+        "bech32PrefixAccPub": "neutronpub",
+        "bech32PrefixValAddr": "neutronvaloper",
+        "bech32PrefixValPub": "neutronvaloperpub",
+        "bech32PrefixConsAddr": "neutronvalcons",
+        "bech32PrefixConsPub": "neutronvalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/neutron-raw.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/neutron-raw.svg"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "NTRN",
+          "coinMinimalDenom": "untrn",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.png",
+          "gasPriceStep": {
+            "low": 0.0053,
+            "average": 0.0053,
+            "high": 0.0053
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "NTRN",
+          "coinMinimalDenom": "untrn",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/ntrn.png"
+        },
+        {
+          "coinDenom": "amATOM",
+          "coinMinimalDenom": "factory/neutron15lku24mqhvy4v4gryrqs4662n9v9q4ux9tayn89cmdzldjcgawushxvm76/amatom",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/amATOM.svg"
+        },
+        {
+          "coinDenom": "ARENA",
+          "coinMinimalDenom": "factory/neutron1r3slyjlf7g76mz3na6gh7c8ek62rhssrzf60uh0emyw3x94rppyqfcs0pk/uarena",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/arena_dao.png"
+        },
+        {
+          "coinDenom": "TEST1",
+          "coinMinimalDenom": "factory/neutron1aphhmsv5lglvvycldlveckjq8zcgwvg34cn0cs/test-token-1",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "TEST2",
+          "coinMinimalDenom": "factory/neutron1aphhmsv5lglvvycldlveckjq8zcgwvg34cn0cs/test-token-2",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "TEST3",
+          "coinMinimalDenom": "factory/neutron1aphhmsv5lglvvycldlveckjq8zcgwvg34cn0cs/test-token-3",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "TEST4",
+          "coinMinimalDenom": "factory/neutron1aphhmsv5lglvvycldlveckjq8zcgwvg34cn0cs/test-token-4",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "TEST5",
+          "coinMinimalDenom": "factory/neutron1aphhmsv5lglvvycldlveckjq8zcgwvg34cn0cs/test-token-5",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "TEST6",
+          "coinMinimalDenom": "factory/neutron1aphhmsv5lglvvycldlveckjq8zcgwvg34cn0cs/test-token-6",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/babylontestnet/images/logo.svg"
+        },
+        {
+          "coinDenom": "dTIA",
+          "coinMinimalDenom": "factory/neutron1qex378awvwhsxealmrtuunn70f242u49dagqus6ug423paxyevyqvw9s3t/uTIA",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/neutron/images/dTIA.svg"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc-falcron.pion-1.ntrn.tech"
+          },
+          {
+            "address": "https://neutron-testnet-rpc.polkachu.com/"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://rest-falcron.pion-1.ntrn.tech"
+          },
+          {
+            "address": "https://api.pion.remedy.tm.p2p.org"
+          },
+          {
+            "address": "https://rest.baryon-sentry-01.rs-testnet.polypore.xyz"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer.rs-testnet.polypore.xyz/pion-1/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "nolustestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Nolus Testnet",
+      "chain_id": "rila-3",
+      "bech32Prefix": "nolus",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "nolus",
+        "bech32PrefixAccPub": "noluspub",
+        "bech32PrefixValAddr": "nolusvaloper",
+        "bech32PrefixValPub": "nolusvaloperpub",
+        "bech32PrefixConsAddr": "nolusvalcons",
+        "bech32PrefixConsPub": "nolusvalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "NLS",
+        "coinMinimalDenom": "unls",
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "NLS",
+          "coinMinimalDenom": "unls",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png",
+          "gasPriceStep": {
+            "low": 0.01,
+            "average": 0.025,
+            "high": 0.05
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "NLS",
+          "coinMinimalDenom": "unls",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nolus/images/nolus.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rila-rpc.nolus.network"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://rila-lcd.nolus.network"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://testnet.ping.pub/nolus/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "nolustestnet1",
@@ -2619,65 +6556,685 @@
     },
     {
       "chain_name": "sgetestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "SGE Testnet",
+      "chain_id": "sge-network-3",
+      "bech32Prefix": "sge",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "sge",
+        "bech32PrefixAccPub": "sgepub",
+        "bech32PrefixValAddr": "sgevaloper",
+        "bech32PrefixValPub": "sgevaloperpub",
+        "bech32PrefixConsAddr": "sgevalcons",
+        "bech32PrefixConsPub": "sgevalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sge/images/sge.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sge/images/sge.svg"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "SGE",
+          "coinMinimalDenom": "usge",
+          "coinDecimals": 6
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "SGE",
+          "coinMinimalDenom": "usge",
+          "coinDecimals": 6
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.testnet.sgenetwork.io"
+          },
+          {
+            "address": "https://testnet-saage-rpc.lavenderfive.com/ "
+          },
+          {
+            "address": "https://saage-testnet-rpc.polkachu.com/"
+          },
+          {
+            "address": "https://rpc-t.sge.nodestake.top/"
+          },
+          {
+            "address": "https://sge.rpc.t.stavr.tech:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.testnet.sgenetwork.io"
+          },
+          {
+            "address": "https://api-t.sge.nodestake.top/"
+          },
+          {
+            "address": "https://saage-testnet-api.polkachu.com/"
+          },
+          {
+            "address": "https://sge.api.t.stavr.tech"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://blockexplorer.testnet.sgenetwork.io/sge-network/tx/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "stargazetestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Stargaze Testnet",
+      "chain_id": "elgafar-1",
+      "bech32Prefix": "stars",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "stars",
+        "bech32PrefixAccPub": "starspub",
+        "bech32PrefixValAddr": "starsvaloper",
+        "bech32PrefixValPub": "starsvaloperpub",
+        "bech32PrefixConsAddr": "starsvalcons",
+        "bech32PrefixConsPub": "starsvalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.svg"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "STARS",
+          "coinMinimalDenom": "ustars",
+          "coinDecimals": 6,
+          "coinGeckoId": "stargaze",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+          "gasPriceStep": {
+            "low": 0.03,
+            "average": 0.04,
+            "high": 0.05
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "STARS",
+          "coinMinimalDenom": "ustars",
+          "coinDecimals": 6,
+          "coinGeckoId": "stargaze",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.elgafar-1.stargaze-apis.com"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://rest.elgafar-1.stargaze-apis.com"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://testnet-explorer.publicawesome.dev/stargaze/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "swisstroniktestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Swisstronik Testnet",
+      "chain_id": "swisstronik_1291-1",
+      "bech32Prefix": "swtr",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "swtr",
+        "bech32PrefixAccPub": "swtrpub",
+        "bech32PrefixValAddr": "swtrvaloper",
+        "bech32PrefixValPub": "swtrvaloperpub",
+        "bech32PrefixConsAddr": "swtrvalcons",
+        "bech32PrefixConsPub": "swtrvalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/swisstroniktestnet/images/swisstronik.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "SWTR",
+        "coinMinimalDenom": "aswtr",
+        "coinDecimals": 18,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/swisstroniktestnet/images/swisstronik.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "SWTR",
+          "coinMinimalDenom": "aswtr",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/swisstroniktestnet/images/swisstronik.png"
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "SWTR",
+          "coinMinimalDenom": "aswtr",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/swisstroniktestnet/images/swisstronik.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.testnet.swisstronik.com"
+          },
+          {
+            "address": "https://testnet-swisstronik-rpc.genznodes.dev"
+          },
+          {
+            "address": "https://rpc.swisstronik.comunitynode.my.id"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.testnet.swisstronik.com"
+          },
+          {
+            "address": "https://testnet-swisstronik-api.genznodes.dev"
+          },
+          {
+            "address": "https://rest.swisstronik.comunitynode.my.id/"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer-cosmos.testnet.swisstronik.com/swisstronik/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go"
+      ]
     },
     {
       "chain_name": "synternettestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Amber Public Testnet",
+      "chain_id": "amber-2",
+      "bech32Prefix": "amber",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "amber",
+        "bech32PrefixAccPub": "amberpub",
+        "bech32PrefixValAddr": "ambervaloper",
+        "bech32PrefixValPub": "ambervaloperpub",
+        "bech32PrefixConsAddr": "ambervalcons",
+        "bech32PrefixConsPub": "ambervalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/synternet/images/synt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/synternet/images/synt.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "AMBER",
+        "coinMinimalDenom": "uamber",
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/synternet/images/synt.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "AMBER",
+          "coinMinimalDenom": "uamber",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/synternet/images/synt.png",
+          "gasPriceStep": {
+            "low": 0.01,
+            "average": 0.025,
+            "high": 0.03
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "AMBER",
+          "coinMinimalDenom": "uamber",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/synternet/images/synt.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc-testnet.synternet.com/"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api-testnet.synternet.com/"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer-testnet.synternet.com/transactions/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "titannettestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Titan Network Testnet",
+      "chain_id": "titan-test-4",
+      "bech32Prefix": "titan",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "titan",
+        "bech32PrefixAccPub": "titanpub",
+        "bech32PrefixValAddr": "titanvaloper",
+        "bech32PrefixValPub": "titanvaloperpub",
+        "bech32PrefixConsAddr": "titanvalcons",
+        "bech32PrefixConsPub": "titanvalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titannettestnet/images/ttnt.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titannettestnet/images/ttnt.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "TTNT",
+        "coinMinimalDenom": "uttnt",
+        "coinDecimals": 6,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titannettestnet/images/ttnt.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "TTNT",
+          "coinMinimalDenom": "uttnt",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titannettestnet/images/ttnt.png",
+          "gasPriceStep": {
+            "low": 0.01,
+            "average": 0.025,
+            "high": 0.03
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "TTNT",
+          "coinMinimalDenom": "uttnt",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titannettestnet/images/ttnt.png"
+        },
+        {
+          "coinDenom": "TNT4",
+          "coinMinimalDenom": "utnt4",
+          "coinDecimals": 2,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titannettestnet/images/tnt4.png"
+        }
+      ],
+      "description": "Titan Chain aims to solve the resource utilization challenges in the Web3 ecosystem by creating an efficient, transparent, and decentralized infrastructure marketplace. Built on Cosmos SDK, it enables seamless trading of computing, storage, and bandwidth resources while ensuring fair compensation for resource providers.\n\nThe project focuses on making decentralized infrastructure services more accessible and efficient through its modular blockchain design. Using the Inter-blockchain Communication (IBC) protocol, Titan Chain can connect with other blockchain networks, facilitating broader resource sharing and integration across the ecosystem.\n\nThe network uses TTNT tokens for governance and securing the network through a Delegated Proof-of-Stake consensus mechanism, where token holders can participate in network decisions and earn rewards for contributing to network stability.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.titannet.io:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://lcd.titannet.io:443"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://testnet.titan.explorers.guru/transaction/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "titantestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Titan Testnet",
+      "chain_id": "titan_18889-1",
+      "bech32Prefix": "titan",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "titan",
+        "bech32PrefixAccPub": "titanpub",
+        "bech32PrefixValAddr": "titanvaloper",
+        "bech32PrefixValPub": "titanvaloperpub",
+        "bech32PrefixConsAddr": "titanvalcons",
+        "bech32PrefixConsPub": "titanvalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titantestnet/images/chain.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titantestnet/images/chain.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "TKX",
+        "coinMinimalDenom": "atkx",
+        "coinDecimals": 18,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titantestnet/images/tkx.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "TKX",
+          "coinMinimalDenom": "atkx",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titantestnet/images/tkx.png",
+          "gasPriceStep": {
+            "low": 100000000000,
+            "average": 110000000000,
+            "high": 200000000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "TKX",
+          "coinMinimalDenom": "atkx",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/titantestnet/images/tkx.png"
+        },
+        {
+          "coinDenom": "BTC",
+          "coinMinimalDenom": "factory/titan14jwu2vsu4xuefce0xjyk2t58awth4v42lvwxslqe6vszac66y4tqe4sjm5/w-btc",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoin/images/btc.png"
+        },
+        {
+          "coinDenom": "ETH",
+          "coinMinimalDenom": "factory/titan16gyvmp43st00s220zypex4lgvwqc3ve8l4657rhxj8myeadswmkq75slkc/eth",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth.svg"
+        },
+        {
+          "coinDenom": "USDC",
+          "coinMinimalDenom": "factory/titan16gyvmp43st00s220zypex4lgvwqc3ve8l4657rhxj8myeadswmkq75slkc/usdc",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png"
+        },
+        {
+          "coinDenom": "SOL",
+          "coinMinimalDenom": "factory/titan16gyvmp43st00s220zypex4lgvwqc3ve8l4657rhxj8myeadswmkq75slkc/sol",
+          "coinDecimals": 9,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/sol_circle.png"
+        },
+        {
+          "coinDenom": "MEOW",
+          "coinMinimalDenom": "factory/titan16gyvmp43st00s220zypex4lgvwqc3ve8l4657rhxj8myeadswmkq75slkc/meow",
+          "coinDecimals": 8,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/solana/images/meow.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://titan-testnet-rpc.titanlab.io:443"
+          },
+          {
+            "address": "https://titan-testnet-rpc-1.titanlab.io:443"
+          },
+          {
+            "address": "https://titan-testnet-rpc-2.titanlab.io:443"
+          },
+          {
+            "address": "https://titan-testnet-rpc-3.titanlab.io:443"
+          },
+          {
+            "address": "https://titan-testnet-rpc-4.titanlab.io:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://titan-testnet-lcd.titanlab.io:443"
+          },
+          {
+            "address": "https://titan-testnet-lcd-1.titanlab.io:443"
+          },
+          {
+            "address": "https://titan-testnet-lcd-2.titanlab.io:443"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://titan-testnet-explorer-light.titanlab.io/Titan%20Testnet/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "xiontestnet2",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "Xion Testnet",
+      "chain_id": "xion-testnet-2",
+      "bech32Prefix": "xion",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "xion",
+        "bech32PrefixAccPub": "xionpub",
+        "bech32PrefixValAddr": "xionvaloper",
+        "bech32PrefixValPub": "xionvaloperpub",
+        "bech32PrefixConsAddr": "xionvalcons",
+        "bech32PrefixConsPub": "xionvalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "XION",
+        "coinMinimalDenom": "uxion",
+        "coinDecimals": 6,
+        "coinGeckoId": "xion-2",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "XION",
+          "coinMinimalDenom": "uxion",
+          "coinDecimals": 6,
+          "coinGeckoId": "xion-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png",
+          "gasPriceStep": {
+            "low": 0.001,
+            "average": 0.001,
+            "high": 0.01
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "XION",
+          "coinMinimalDenom": "uxion",
+          "coinDecimals": 6,
+          "coinGeckoId": "xion-2",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
+        }
+      ],
+      "description": "XION is the first walletless L1 blockchain purpose built for consumer adoption through chain abstraction.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.xion-testnet-2.burnt.com:443"
+          },
+          {
+            "address": "https://testnet-2-rpc.xion-api.com:443"
+          },
+          {
+            "address": "https://xion-testnet-rpc.polkachu.com:443"
+          },
+          {
+            "address": "https://burnt-testnet-rpc.itrocket.net:443"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.xion-testnet-2.burnt.com"
+          },
+          {
+            "address": "https://testnet-2-api.xion-api.com"
+          },
+          {
+            "address": "https://xion-testnet-api.polkachu.com"
+          },
+          {
+            "address": "https://burnt-testnet-api.itrocket.net"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://www.mintscan.io/xion-testnet/transactions/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go",
+        "cosmwasm"
+      ]
     },
     {
       "chain_name": "xrplevmtestnet",
+      "status": "live",
+      "networkType": "testnet",
       "prettyName": "XRPL EVM Testnet",
+      "chain_id": "xrplevm_1449000-1",
+      "bech32Prefix": "ethm",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "ethm",
+        "bech32PrefixAccPub": "ethmpub",
+        "bech32PrefixValAddr": "ethmvaloper",
+        "bech32PrefixValPub": "ethmvaloperpub",
+        "bech32PrefixConsAddr": "ethmvalcons",
+        "bech32PrefixConsPub": "ethmvalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/xrplevmtestnet/images/xrplevm.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/xrplevmtestnet/images/xrplevm.svg"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "XRP",
+          "coinMinimalDenom": "axrp",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png",
+          "gasPriceStep": {
+            "low": 200000000000,
+            "average": 250000000000,
+            "high": 400000000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "XRP",
+          "coinMinimalDenom": "axrp",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/xrpl/images/xrp.png"
+        }
+      ],
+      "description": "The XRPL Ethereum Virtual Machine (EVM) is an innovative extension of the XRP Ledger developed by Peersyst in collaboration with Ripple that integrates Ethereum's smart contract capabilities via a dedicated sidechain. Built on the Cosmos SDK with a fork of evmOS, this sidechain utilizes a Proof-of-Authority (PoA) consensus model, ensuring high performance and low latency while maintaining the fundamental attributes of the XRP Ledger. It connects to the XRP Ledger through the Axelar network, employing XRP—bridged from the XRPL—as its native currency. This allows for seamless asset transfers and communication between the XRPL and the EVM sidechain. Moreover, the XRPL EVM supports Inter-Blockchain Communication (IBC), promoting interoperability with other blockchains in the Cosmos ecosystem.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.testnet.xrplevm.org"
+          },
+          {
+            "address": "https://xrpl-evm-testnet.rpc.grove.city/v1/0caa84c4"
+          },
+          {
+            "address": "https://xrpevm.kintsugi-nodes.com"
+          },
+          {
+            "address": "https://xrp-testnet-rpc.polkachu.com/"
+          },
+          {
+            "address": "https://rpc.xrpl.cumulo.com.es"
+          },
+          {
+            "address": "https://xrpl-rpc.embervalidator.top/"
+          },
+          {
+            "address": "https://xrp-rpc.enigma-validator.com/"
+          },
+          {
+            "address": "https://xrplevm-testnet-rpc.itrocket.net"
+          },
+          {
+            "address": "http://xrpl-testnet-rpc.luckystar.asia/"
+          },
+          {
+            "address": "https://exrpd-testnet-rpc.mekonglabs.tech/"
+          },
+          {
+            "address": "https://xrpl-testnet-rpc.mictonode.com"
+          },
+          {
+            "address": "https://rpc-t.xrp.nodestake.org"
+          },
+          {
+            "address": "https://xrpl-testnet-rpc.cosmonautstakes.com"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.xrpl.cumulo.com.es"
+          },
+          {
+            "address": "http://cosmos.testnet.xrplevm.org:1317"
+          },
+          {
+            "address": "https://api-xrp.kintsugi-nodes.com"
+          },
+          {
+            "address": "https://xrp-testnet-api.polkachu.com/"
+          },
+          {
+            "address": "https://xrplevm-testnet-api.itrocket.net"
+          },
+          {
+            "address": "https://xrpl-testnet-api.luckystar.asia/"
+          },
+          {
+            "address": "https://exrpd-testnet-api.mekonglabs.tech/"
+          },
+          {
+            "address": "https://xrpl-testnet-api.mictonode.com"
+          },
+          {
+            "address": "https://api-t.xrp.nodestake.org"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer.testnet.xrplevm.org/tx/${txHash}"
+        }
+      ],
+      "features": [
+        "ibc-go"
+      ]
     }
   ]
 }

--- a/osmosis-1/generated/frontend/chainlist.json
+++ b/osmosis-1/generated/frontend/chainlist.json
@@ -30969,19 +30969,135 @@
     },
     {
       "chain_name": "nim",
+      "status": "live",
+      "networkType": "mainnet",
       "prettyName": "Nim Network",
+      "chain_id": "nim_1122-1",
+      "bech32Prefix": "nim",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "nim",
+        "bech32PrefixAccPub": "nimpub",
+        "bech32PrefixValAddr": "nimvaloper",
+        "bech32PrefixValPub": "nimvaloperpub",
+        "bech32PrefixConsAddr": "nimvalcons",
+        "bech32PrefixConsPub": "nimvalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nim/images/nim.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nim/images/nim.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "NIM",
+        "coinMinimalDenom": "anim",
+        "coinDecimals": 18,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nim/images/nim.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "NIM",
+          "coinMinimalDenom": "anim",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nim/images/nim.png",
+          "gasPriceStep": {
+            "low": 20000000000,
+            "average": 20000000000,
+            "high": 20000000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "NIM",
+          "coinMinimalDenom": "anim",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/nim/images/nim.png"
+        }
+      ],
+      "description": "Nim Network is a highly-adoptable AI Gaming chain that will provide the ultimate ecosystem for exploration and development of games at the intersection of Web3 and AI.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.mainnet.nimnet.tech"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://rest.mainnet.nimnet.tech"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer.nim.network/tx/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "mande",
+      "status": "live",
+      "networkType": "mainnet",
       "prettyName": "Mande Network",
+      "chain_id": "mande_18071918-1",
+      "bech32Prefix": "mande",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "mande",
+        "bech32PrefixAccPub": "mandepub",
+        "bech32PrefixValAddr": "mandevaloper",
+        "bech32PrefixValPub": "mandevaloperpub",
+        "bech32PrefixConsAddr": "mandevalcons",
+        "bech32PrefixConsPub": "mandevalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.png",
         "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.svg"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "MAND",
+        "coinMinimalDenom": "amand",
+        "coinDecimals": 18,
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "MAND",
+          "coinMinimalDenom": "amand",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.png",
+          "gasPriceStep": {
+            "low": 20000000000,
+            "average": 20000000000,
+            "high": 20000000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "MAND",
+          "coinMinimalDenom": "amand",
+          "coinDecimals": 18,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mande/images/mande.png"
+        }
+      ],
+      "description": "Credibility Hub for Web3",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://mande-mainnet-tendermint.public.blastapi.io"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://mande-mainnet-rest.public.blastapi.io"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://dym.fyi/r/mande/tx/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "penumbra",
@@ -31035,24 +31151,208 @@
     },
     {
       "chain_name": "moo",
+      "status": "live",
+      "networkType": "mainnet",
       "prettyName": "MilkyWay",
+      "chain_id": "moo-1",
+      "bech32Prefix": "init",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "init",
+        "bech32PrefixAccPub": "initpub",
+        "bech32PrefixValAddr": "initvaloper",
+        "bech32PrefixValPub": "initvaloperpub",
+        "bech32PrefixConsAddr": "initvalcons",
+        "bech32PrefixConsPub": "initvalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/moo/images/milkyway.png"
-      }
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "INIT",
+          "coinMinimalDenom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+          "coinDecimals": 6,
+          "coinGeckoId": "initia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/initia/images/INIT.png"
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "INIT",
+          "coinMinimalDenom": "ibc/37A3FB4FED4CA04ED6D9E5DA36C6D27248645F0E22F585576A1488B8A89C5A50",
+          "coinDecimals": 6,
+          "coinGeckoId": "initia",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/initia/images/INIT.png"
+        },
+        {
+          "coinDenom": "milkINIT",
+          "coinMinimalDenom": "factory/init17p9rzwnnfxcjp32un9ug7yhhzgtkhvl9jfksztgw5uh69wac2pgsj6uxxj/umilkINIT",
+          "coinDecimals": 6,
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/moo/images/milkINIT.png"
+        }
+      ],
+      "description": "MilkyWay's moo-1 is an Initia L2 minitia focused on liquid staking solutions.",
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc-moo-1.anvil.asia-southeast.initia.xyz"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://rest-moo-1.anvil.asia-southeast.initia.xyz"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://scan.initia.xyz/moo-1/txs/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "paxi",
+      "status": "live",
+      "networkType": "mainnet",
       "prettyName": "Paxi",
+      "chain_id": "paxi-mainnet",
+      "bech32Prefix": "paxi",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "paxi",
+        "bech32PrefixAccPub": "paxipub",
+        "bech32PrefixValAddr": "paxivaloper",
+        "bech32PrefixValPub": "paxivaloperpub",
+        "bech32PrefixConsAddr": "paxivalcons",
+        "bech32PrefixConsPub": "paxivalconspub"
+      },
+      "slip44": 118,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/paxi/images/paxi.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "PAXI",
+        "coinMinimalDenom": "upaxi",
+        "coinDecimals": 6,
+        "coinGeckoId": "paxi-network",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/paxi/images/paxi.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "PAXI",
+          "coinMinimalDenom": "upaxi",
+          "coinDecimals": 6,
+          "coinGeckoId": "paxi-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/paxi/images/paxi.png",
+          "gasPriceStep": {
+            "low": 0.05,
+            "average": 0.1,
+            "high": 0.25
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "PAXI",
+          "coinMinimalDenom": "upaxi",
+          "coinDecimals": 6,
+          "coinGeckoId": "paxi-network",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/paxi/images/paxi.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://mainnet-rpc.paxinet.io"
+          },
+          {
+            "address": "https://rpc.paxi.indonode.net"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://mainnet-lcd.paxinet.io"
+          },
+          {
+            "address": "https://api.paxi.indonode.net"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://explorer.paxinet.io/tx/${txHash}"
+        }
+      ]
     },
     {
       "chain_name": "qie",
+      "status": "live",
+      "networkType": "mainnet",
       "prettyName": "QIE",
+      "chain_id": "qie_1990-1",
+      "bech32Prefix": "qie",
+      "bech32Config": {
+        "bech32PrefixAccAddr": "qie",
+        "bech32PrefixAccPub": "qiepub",
+        "bech32PrefixValAddr": "qievaloper",
+        "bech32PrefixValPub": "qievaloperpub",
+        "bech32PrefixConsAddr": "qievalcons",
+        "bech32PrefixConsPub": "qievalconspub"
+      },
+      "slip44": 60,
       "logo_URIs": {
         "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qie/images/qie.png"
-      }
+      },
+      "stakeCurrency": {
+        "coinDenom": "QIE",
+        "coinMinimalDenom": "aqie",
+        "coinDecimals": 18,
+        "coinGeckoId": "qie",
+        "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qie/images/qie.png"
+      },
+      "feeCurrencies": [
+        {
+          "coinDenom": "QIE",
+          "coinMinimalDenom": "aqie",
+          "coinDecimals": 18,
+          "coinGeckoId": "qie",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qie/images/qie.png",
+          "gasPriceStep": {
+            "low": 20000000000,
+            "average": 25000000000,
+            "high": 40000000000
+          }
+        }
+      ],
+      "currencies": [
+        {
+          "coinDenom": "QIE",
+          "coinMinimalDenom": "aqie",
+          "coinDecimals": 18,
+          "coinGeckoId": "qie",
+          "coinImageUrl": "https://raw.githubusercontent.com/cosmos/chain-registry/master/qie/images/qie.png"
+        }
+      ],
+      "apis": {
+        "rpc": [
+          {
+            "address": "https://rpc.qie.digital"
+          },
+          {
+            "address": "https://tendermint.qie.digital"
+          }
+        ],
+        "rest": [
+          {
+            "address": "https://api.qie.digital"
+          }
+        ]
+      },
+      "explorers": [
+        {
+          "txPage": "https://mainnet.qie.digital/tx/${txHash}"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Update generator to prefer chain-registry explorer entries that provide a tx_page containing the {txHash} template (falling back to the first tx_page available) and respect existing zone override properties. This aligns explorer URL selection with the chain registry's snake_case tx_page field and the zone schema's required pattern. Regenerated frontend chainlist JSON for osmo-test-5 and osmosis-1 to include the updated Osmosis entry and related metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity logic change, but it alters how explorer URLs are selected and regenerates a large `chainlist.json`, which could impact downstream consumers if fields/values change unexpectedly.
> 
> **Overview**
> Updates `generate_chainlist.mjs` to select explorer transaction URLs from chain-registry `explorers[].tx_page` (snake_case), **preferring entries that include the `{txHash}` template** and falling back to the first available `tx_page`, while still honoring `zoneChain` override URLs.
> 
> Regenerates `osmo-test-5/generated/frontend/chainlist.json`, substantially expanding chain entries (e.g., Osmosis and multiple testnets) with additional metadata such as `status`, `networkType`, full currency/fee/staking configs, API endpoints, and updated explorer `txPage` values driven by the new selection logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a2774f870beb08be7804496be6778e9e197c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->