### PR TITLE
feat: graceful shutdown lifecycle for asset listings

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -49,6 +49,16 @@ jobs:
           echo "IBC_NEWLY_CLEARED=$(grep -oP 'IBC_NEWLY_CLEARED=\K[0-9]+' ../../../ibc-check.log || echo 0)" >> $GITHUB_ENV
           echo "IBC_ERRORS=$(grep -oP 'IBC_ERRORS=\K[0-9]+' ../../../ibc-check.log || echo 0)" >> $GITHUB_ENV
 
+      - name: Check Market Health (independent unstable track)
+        working-directory: ./.github/workflows/utility
+        run: |
+          node check_market_health.mjs osmosis-1 2>&1 | tee ../../../market-health.log || true
+
+      - name: Check Extended Halts (60d + planned shutdown)
+        working-directory: ./.github/workflows/utility
+        run: |
+          node check_extended_halts.mjs osmosis-1 2>&1 | tee ../../../extended-halts.log || true
+
       - name: Add Chain Stubs
         working-directory: ./.github/workflows/utility
         run: node add_chain_stubs.mjs osmosis-1
@@ -254,6 +264,40 @@ jobs:
             grep -A 100 'IBC CLIENT HEALTH SUMMARY' ibc-check.log | head -60 >> workflow-summary.md || true
             echo '```' >> workflow-summary.md
             echo "</details>" >> workflow-summary.md
+          fi
+
+          echo "" >> workflow-summary.md
+          echo "---" >> workflow-summary.md
+          echo "" >> workflow-summary.md
+
+          # Manual halts currently in effect (visibility for drift detection)
+          echo "## Manual halts currently in effect" >> workflow-summary.md
+          echo "" >> workflow-summary.md
+
+          MANUAL_HALTS=$(jq -r '
+            .assets
+            | map(select(
+                (.osmosis_deposit_halt_reason == "manual")
+                or (.osmosis_withdrawal_halt_reason == "manual")
+              ))
+          ' osmosis-1/osmosis.zone_assets.json)
+          MANUAL_HALT_COUNT=$(echo "$MANUAL_HALTS" | jq 'length')
+
+          if [ "$MANUAL_HALT_COUNT" -eq 0 ]; then
+            echo "_None._" >> workflow-summary.md
+          else
+            echo "| Chain | Base denom | Direction | Tooltip |" >> workflow-summary.md
+            echo "|-------|-----------|-----------|---------|" >> workflow-summary.md
+            echo "$MANUAL_HALTS" | jq -r '
+              .[] | (
+                (if .osmosis_deposit_halt_reason == "manual" then
+                   "| \(.chain_name) | \(.base_denom) | deposit | \(.tooltip_message // "") |"
+                 else "" end),
+                (if .osmosis_withdrawal_halt_reason == "manual" then
+                   "| \(.chain_name) | \(.base_denom) | withdrawal | \(.tooltip_message // "") |"
+                 else "" end)
+              ) | select(. != "")
+            ' >> workflow-summary.md
           fi
 
           echo "" >> workflow-summary.md

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -52,12 +52,12 @@ jobs:
       - name: Check Market Health (independent unstable track)
         working-directory: ./.github/workflows/utility
         run: |
-          node check_market_health.mjs osmosis-1 2>&1 | tee ../../../market-health.log || true
+          node check_market_health.mjs osmosis-1 2>&1 | tee ../../../market-health.log
 
       - name: Check Extended Halts (60d + planned shutdown)
         working-directory: ./.github/workflows/utility
         run: |
-          node check_extended_halts.mjs osmosis-1 2>&1 | tee ../../../extended-halts.log || true
+          node check_extended_halts.mjs osmosis-1 2>&1 | tee ../../../extended-halts.log
 
       - name: Add Chain Stubs
         working-directory: ./.github/workflows/utility
@@ -261,7 +261,7 @@ jobs:
             echo "<details><summary>IBC check details</summary>" >> workflow-summary.md
             echo "" >> workflow-summary.md
             echo '```' >> workflow-summary.md
-            grep -A 100 'IBC CLIENT HEALTH SUMMARY' ibc-check.log | head -60 >> workflow-summary.md || true
+            grep -A 100 'BRIDGE-STATE CHECK SUMMARY' ibc-check.log | head -60 >> workflow-summary.md || true
             echo '```' >> workflow-summary.md
             echo "</details>" >> workflow-summary.md
           fi

--- a/.github/workflows/propose_unverify.yml
+++ b/.github/workflows/propose_unverify.yml
@@ -1,12 +1,13 @@
-# Weekly: open/update a PR proposing osmosis_verified=false for assets that
+# Bi-weekly: open/update a PR proposing osmosis_verified=false for assets that
 # have been continuously unstable for 90+ days, subject to a 30-day per-asset
 # cooldown via state.lastUnverifyProposedAt.
 #
-# Runs every Monday at 16:00 UTC, after the daily generate_all_files cron.
+# Runs on the 1st and 15th of each month at 16:00 UTC, after the daily
+# generate_all_files cron. This gives ~14-day cadence without weekly noise.
 
 on:
   schedule:
-    - cron: "0 16 * * 1" # Mondays at 16:00 UTC
+    - cron: "0 16 1,15 * *" # 1st and 15th of each month at 16:00 UTC
   workflow_dispatch:
 
 name: Propose Unverify Candidates

--- a/.github/workflows/propose_unverify.yml
+++ b/.github/workflows/propose_unverify.yml
@@ -1,0 +1,62 @@
+# Weekly: open/update a PR proposing osmosis_verified=false for assets that
+# have been continuously unstable for 90+ days, subject to a 30-day per-asset
+# cooldown via state.lastUnverifyProposedAt.
+#
+# Runs every Monday at 16:00 UTC, after the daily generate_all_files cron.
+
+on:
+  schedule:
+    - cron: "0 16 * * 1" # Mondays at 16:00 UTC
+  workflow_dispatch:
+
+name: Propose Unverify Candidates
+jobs:
+  propose_unverify:
+    name: Propose unverify candidates
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unverify-candidate check (propose mode)
+        working-directory: ./.github/workflows/utility
+        run: node check_unverify_candidates.mjs osmosis-1 --propose
+
+      - name: Capture PR body
+        id: prbody
+        run: |
+          if [ -f osmosis-1/generated/reports/unverify_candidates_pr_body.md ]; then
+            echo "has_body=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_body=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or update PR
+        if: steps.prbody.outputs.has_body == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(unverify): weekly unverify candidate sweep"
+          branch: auto-unverify/weekly-candidates
+          title: "chore(unverify): assets exceeded 90-day unstable threshold"
+          body-path: osmosis-1/generated/reports/unverify_candidates_pr_body.md
+          labels: |
+            auto-unverify
+            needs-review
+          delete-branch: false

--- a/.github/workflows/propose_unverify.yml
+++ b/.github/workflows/propose_unverify.yml
@@ -53,7 +53,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(unverify): weekly unverify candidate sweep"
+          commit-message: "chore(unverify): unverify candidate sweep"
           branch: auto-unverify/weekly-candidates
           title: "chore(unverify): assets exceeded 90-day unstable threshold"
           body-path: osmosis-1/generated/reports/unverify_candidates_pr_body.md

--- a/.github/workflows/utility/asset_status_report.mjs
+++ b/.github/workflows/utility/asset_status_report.mjs
@@ -14,6 +14,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { calculateIbcHash } from './assetlist_functions.mjs';
 
 const LOW_LIQUIDITY_USD = 1000;
 const LOW_VOLUME_24H_USD = 100;
@@ -35,8 +36,11 @@ const reportsDir = path.join(zonePath, 'generated', 'reports');
 const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
 
 async function fetchNumia() {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(NUMIA_TOKENS_URL);
+    const res = await fetch(NUMIA_TOKENS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
     if (!res.ok) return new Map();
     const data = await res.json();
     const byDenom = new Map();
@@ -50,6 +54,7 @@ async function fetchNumia() {
     }
     return byDenom;
   } catch {
+    clearTimeout(timeoutId);
     return new Map();
   }
 }
@@ -73,12 +78,13 @@ async function main() {
   const state = loadJSON(statePath, { assets: [] });
   const numia = await fetchNumia();
 
-  const zoneByOrigin = new Map();
-  for (const a of zoneData.assets) {
-    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
-  }
   const stateByDenom = new Map();
   for (const a of state.assets ?? []) stateByDenom.set(a.base_denom, a);
+
+  const frontendByDenom = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
+  }
 
   const nowIso = new Date().toISOString();
   const nowMs = new Date(nowIso).getTime();
@@ -90,18 +96,22 @@ async function main() {
   const pending = [];
   const inconsistencies = [];
 
-  for (const asset of frontendData.assets ?? []) {
-    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
-    const za = zoneByOrigin.get(zoneKey);
-    if (!za) continue;
-    const sa = stateByDenom.get(asset.coinMinimalDenom);
-    const m = numia.get(asset.coinMinimalDenom);
+  // Iterate zone_assets directly so we cover killed-chain assets whose
+  // generator output disappeared. Compute coinMinimalDenom via the same IBC
+  // hash the generator uses.
+  for (const za of zoneData.assets) {
+    if (!za.path) continue; // non-IBC entries skipped
+    const coinMinimalDenom = await calculateIbcHash(za.path);
+    const sa = stateByDenom.get(coinMinimalDenom);
+    const m = numia.get(coinMinimalDenom);
+    const feAsset = frontendByDenom.get(coinMinimalDenom);
+    const symbol = feAsset?.symbol ?? za._comment ?? za.base_denom;
 
     if (za.osmosis_unstable === true) {
       if (!sa?.lastDowntimeDate) {
         inconsistencies.push({
           chain: za.chain_name,
-          symbol: asset.symbol,
+          symbol,
           issue: 'osmosis_unstable=true but no state.lastDowntimeDate',
         });
       }
@@ -110,8 +120,8 @@ async function main() {
       const daysUntilUnverify = days != null ? Math.max(0, 90 - days) : null;
       unstable.push({
         chain: za.chain_name,
-        symbol: asset.symbol,
-        baseDenom: asset.coinMinimalDenom,
+        symbol,
+        baseDenom: coinMinimalDenom,
         verified: za.osmosis_verified === true,
         reason: za.osmosis_unstable_reason ?? '?',
         lastDowntime: sa?.lastDowntimeDate ?? '-',
@@ -129,13 +139,13 @@ async function main() {
       if (!za.osmosis_deposit_halt_reason) {
         inconsistencies.push({
           chain: za.chain_name,
-          symbol: asset.symbol,
+          symbol,
           issue: 'osmosis_halt_deposits=true with no reason',
         });
       }
       halts.push({
         chain: za.chain_name,
-        symbol: asset.symbol,
+        symbol,
         direction: 'deposit',
         reason: za.osmosis_deposit_halt_reason ?? '?',
         tooltip: za.tooltip_message ?? '',
@@ -145,7 +155,7 @@ async function main() {
     if (za.osmosis_halt_withdrawals === true) {
       halts.push({
         chain: za.chain_name,
-        symbol: asset.symbol,
+        symbol,
         direction: 'withdrawal',
         reason: za.osmosis_withdrawal_halt_reason ?? '?',
         tooltip: za.tooltip_message ?? '',
@@ -156,8 +166,8 @@ async function main() {
     if (za.osmosis_disabled === true) {
       disabled.push({
         chain: za.chain_name,
-        symbol: asset.symbol,
-        baseDenom: asset.coinMinimalDenom,
+        symbol,
+        baseDenom: coinMinimalDenom,
         verified: za.osmosis_verified === true,
         liquidity: m?.liquidity ?? '?',
         volume24h: m?.volume24h ?? '?',
@@ -176,7 +186,7 @@ async function main() {
     ) {
       borderline.push({
         chain: za.chain_name,
-        symbol: asset.symbol,
+        symbol,
         liquidity: m.liquidity,
         volume24h: m.volume24h,
       });
@@ -195,7 +205,7 @@ async function main() {
       if (days >= 90 && cooldownLeft > 0) {
         pending.push({
           chain: za.chain_name,
-          symbol: asset.symbol,
+          symbol,
           daysUnstable: days,
           lastProposed: sa.lastUnverifyProposedAt,
           daysUntilRepropose: Math.ceil(cooldownLeft / (24 * 60 * 60 * 1000)),

--- a/.github/workflows/utility/asset_status_report.mjs
+++ b/.github/workflows/utility/asset_status_report.mjs
@@ -1,0 +1,293 @@
+// Purpose:
+//   workflow_dispatch utility: emit a markdown status report covering
+//     1. Unstable assets (with reason, dates, halt status, days until 60d/90d milestones)
+//     2. Halt status (every asset with halt_deposits or halt_withdrawals)
+//     3. Disabled assets (osmosis_disabled === true)
+//     4. Verification-borderline assets (verified but failing market thresholds)
+//     5. Pending unverify (in cooldown), assets that crossed 90d but had a PR opened recently
+//     6. Inconsistencies (invariants violated; e.g. osmosis_unstable=true with no state.lastDowntimeDate)
+//
+//   Read-only. No mutations.
+//
+// Usage:
+//   node asset_status_report.mjs [<zone_name>]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const LOW_LIQUIDITY_USD = 1000;
+const LOW_VOLUME_24H_USD = 100;
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+
+const args = process.argv.slice(2);
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
+
+async function fetchNumia() {
+  try {
+    const res = await fetch(NUMIA_TOKENS_URL);
+    if (!res.ok) return new Map();
+    const data = await res.json();
+    const byDenom = new Map();
+    for (const t of data) {
+      if (!t.denom) continue;
+      byDenom.set(t.denom, {
+        liquidity: Number(t.liquidity ?? 0),
+        volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+        mcap: Number(t.market_cap ?? 0),
+      });
+    }
+    return byDenom;
+  } catch {
+    return new Map();
+  }
+}
+
+function loadJSON(p, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT' && fallback !== undefined) return fallback;
+    throw err;
+  }
+}
+
+function daysBetween(nowMs, isoStart) {
+  return Math.floor((nowMs - new Date(isoStart).getTime()) / (24 * 60 * 60 * 1000));
+}
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+  const numia = await fetchNumia();
+
+  const zoneByOrigin = new Map();
+  for (const a of zoneData.assets) {
+    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
+  }
+  const stateByDenom = new Map();
+  for (const a of state.assets ?? []) stateByDenom.set(a.base_denom, a);
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+
+  const unstable = [];
+  const halts = [];
+  const disabled = [];
+  const borderline = [];
+  const pending = [];
+  const inconsistencies = [];
+
+  for (const asset of frontendData.assets ?? []) {
+    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
+    const za = zoneByOrigin.get(zoneKey);
+    if (!za) continue;
+    const sa = stateByDenom.get(asset.coinMinimalDenom);
+    const m = numia.get(asset.coinMinimalDenom);
+
+    if (za.osmosis_unstable === true) {
+      if (!sa?.lastDowntimeDate) {
+        inconsistencies.push({
+          chain: za.chain_name,
+          symbol: asset.symbol,
+          issue: 'osmosis_unstable=true but no state.lastDowntimeDate',
+        });
+      }
+      const days = sa?.lastDowntimeDate ? daysBetween(nowMs, sa.lastDowntimeDate) : null;
+      const daysUntilHalt = days != null ? Math.max(0, 60 - days) : null;
+      const daysUntilUnverify = days != null ? Math.max(0, 90 - days) : null;
+      unstable.push({
+        chain: za.chain_name,
+        symbol: asset.symbol,
+        baseDenom: asset.coinMinimalDenom,
+        verified: za.osmosis_verified === true,
+        reason: za.osmosis_unstable_reason ?? '?',
+        lastDowntime: sa?.lastDowntimeDate ?? '-',
+        lastRecovery: sa?.lastRecoveryDate ?? '-',
+        days,
+        daysUntilHalt,
+        daysUntilUnverify,
+        liquidity: m?.liquidity ?? '?',
+        volume24h: m?.volume24h ?? '?',
+        mcap: m?.mcap ?? '?',
+      });
+    }
+
+    if (za.osmosis_halt_deposits === true) {
+      if (!za.osmosis_deposit_halt_reason) {
+        inconsistencies.push({
+          chain: za.chain_name,
+          symbol: asset.symbol,
+          issue: 'osmosis_halt_deposits=true with no reason',
+        });
+      }
+      halts.push({
+        chain: za.chain_name,
+        symbol: asset.symbol,
+        direction: 'deposit',
+        reason: za.osmosis_deposit_halt_reason ?? '?',
+        tooltip: za.tooltip_message ?? '',
+        manual: za.osmosis_deposit_halt_reason === 'manual',
+      });
+    }
+    if (za.osmosis_halt_withdrawals === true) {
+      halts.push({
+        chain: za.chain_name,
+        symbol: asset.symbol,
+        direction: 'withdrawal',
+        reason: za.osmosis_withdrawal_halt_reason ?? '?',
+        tooltip: za.tooltip_message ?? '',
+        manual: za.osmosis_withdrawal_halt_reason === 'manual',
+      });
+    }
+
+    if (za.osmosis_disabled === true) {
+      disabled.push({
+        chain: za.chain_name,
+        symbol: asset.symbol,
+        baseDenom: asset.coinMinimalDenom,
+        verified: za.osmosis_verified === true,
+        liquidity: m?.liquidity ?? '?',
+        volume24h: m?.volume24h ?? '?',
+        mcap: m?.mcap ?? '?',
+        comment: za._comment ?? '',
+      });
+    }
+
+    // Verification-borderline: verified, no unstable flag, but market check fails
+    if (
+      za.osmosis_verified === true &&
+      za.osmosis_unstable !== true &&
+      m &&
+      m.liquidity < LOW_LIQUIDITY_USD &&
+      m.volume24h < LOW_VOLUME_24H_USD
+    ) {
+      borderline.push({
+        chain: za.chain_name,
+        symbol: asset.symbol,
+        liquidity: m.liquidity,
+        volume24h: m.volume24h,
+      });
+    }
+
+    // Pending unverify (in cooldown)
+    if (
+      za.osmosis_verified === true &&
+      za.osmosis_unstable === true &&
+      sa?.lastDowntimeDate &&
+      sa?.lastUnverifyProposedAt
+    ) {
+      const days = daysBetween(nowMs, sa.lastDowntimeDate);
+      const cooldownLeft =
+        COOLDOWN_MS - (nowMs - new Date(sa.lastUnverifyProposedAt).getTime());
+      if (days >= 90 && cooldownLeft > 0) {
+        pending.push({
+          chain: za.chain_name,
+          symbol: asset.symbol,
+          daysUnstable: days,
+          lastProposed: sa.lastUnverifyProposedAt,
+          daysUntilRepropose: Math.ceil(cooldownLeft / (24 * 60 * 60 * 1000)),
+        });
+      }
+    }
+  }
+
+  // ── Compose markdown ────────────────────────────────────────────────────────
+  const lines = [];
+  lines.push(`# Asset status report, ${nowIso}`);
+  lines.push('');
+
+  lines.push(`## 1. Unstable assets (${unstable.length})`);
+  lines.push('');
+  lines.push(`| Chain | Symbol | Base denom | Verified | Reason | Last downtime | Last recovery | Days | Days→halt | Days→unverify | Liquidity | Vol 24h | MCap |`);
+  lines.push(`|-------|--------|-----------|----------|--------|---------------|---------------|------|----------|---------------|-----------|---------|------|`);
+  for (const u of unstable) {
+    lines.push(
+      `| ${u.chain} | ${u.symbol} | \`${u.baseDenom}\` | ${u.verified ? '✓' : ''} | ${u.reason} | ${u.lastDowntime} | ${u.lastRecovery} | ${u.days ?? '-'} | ${u.daysUntilHalt ?? '-'} | ${u.daysUntilUnverify ?? '-'} | ${u.liquidity} | ${u.volume24h} | ${u.mcap} |`
+    );
+  }
+  lines.push('');
+
+  lines.push(`## 2. Halt status (${halts.length})`);
+  lines.push('');
+  lines.push(`| Chain | Symbol | Direction | Reason | Manual? | Tooltip |`);
+  lines.push(`|-------|--------|-----------|--------|---------|---------|`);
+  for (const h of halts) {
+    lines.push(`| ${h.chain} | ${h.symbol} | ${h.direction} | ${h.reason} | ${h.manual ? '✓' : ''} | ${h.tooltip} |`);
+  }
+  lines.push('');
+
+  lines.push(`## 3. Disabled assets (${disabled.length})`);
+  lines.push('');
+  lines.push(`| Chain | Symbol | Base denom | Verified | Liquidity | Vol 24h | MCap | Comment |`);
+  lines.push(`|-------|--------|-----------|----------|-----------|---------|------|---------|`);
+  for (const d of disabled) {
+    lines.push(
+      `| ${d.chain} | ${d.symbol} | \`${d.baseDenom}\` | ${d.verified ? '✓' : ''} | ${d.liquidity} | ${d.volume24h} | ${d.mcap} | ${d.comment} |`
+    );
+  }
+  lines.push('');
+
+  lines.push(`## 4. Verification-borderline assets (${borderline.length})`);
+  lines.push('');
+  lines.push('Verified, not currently unstable, but market check is failing today. ' +
+    'Watch list for assets that may enter the unstable lifecycle soon.');
+  lines.push('');
+  lines.push(`| Chain | Symbol | Liquidity | Vol 24h |`);
+  lines.push(`|-------|--------|-----------|---------|`);
+  for (const b of borderline) {
+    lines.push(`| ${b.chain} | ${b.symbol} | ${b.liquidity} | ${b.volume24h} |`);
+  }
+  lines.push('');
+
+  lines.push(`## 5. Pending unverify (in cooldown) (${pending.length})`);
+  lines.push('');
+  lines.push('Assets that crossed 90 days unstable and had a PR proposed within the ' +
+    'last 30 days. They\'re hidden from the candidate pool until cooldown ends.');
+  lines.push('');
+  lines.push(`| Chain | Symbol | Days unstable | Last proposed | Days until re-propose |`);
+  lines.push(`|-------|--------|--------------|---------------|----------------------|`);
+  for (const p of pending) {
+    lines.push(`| ${p.chain} | ${p.symbol} | ${p.daysUnstable} | ${p.lastProposed} | ${p.daysUntilRepropose} |`);
+  }
+  lines.push('');
+
+  lines.push(`## 6. Inconsistencies (${inconsistencies.length})`);
+  lines.push('');
+  if (inconsistencies.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push(`| Chain | Symbol | Issue |`);
+    lines.push(`|-------|--------|-------|`);
+    for (const i of inconsistencies) {
+      lines.push(`| ${i.chain} | ${i.symbol} | ${i.issue} |`);
+    }
+  }
+  lines.push('');
+
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const reportPath = path.join(
+    reportsDir,
+    `asset_status_${nowIso.slice(0, 10)}.md`
+  );
+  fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+  console.log(`\n📝 Status report: ${reportPath}`);
+  console.log(`Unstable: ${unstable.length} | Halts: ${halts.length} | Disabled: ${disabled.length} | Borderline: ${borderline.length} | Pending: ${pending.length} | Inconsistencies: ${inconsistencies.length}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -97,10 +97,14 @@ async function main() {
     );
 
     // ── Trigger A: extended unstable + failing market ───────────────────────
+    // Curator lock: any non-empty tooltip_message blocks automation. Same
+    // contract as the clearing path below and check_ibc_clients's
+    // canModifyHalt().
     if (
       zoneAsset.osmosis_unstable === true &&
       stateAsset?.lastDowntimeDate &&
-      zoneAsset.osmosis_halt_deposits !== true
+      zoneAsset.osmosis_halt_deposits !== true &&
+      !zoneAsset.tooltip_message
     ) {
       const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
       if (downtimeMs >= SIXTY_DAYS_MS) {
@@ -145,10 +149,13 @@ async function main() {
     }
 
     // ── Trigger B: planned shutdown approaching ─────────────────────────────
+    // Curator lock honoured: non-empty tooltip_message blocks the set path,
+    // matching the contract used elsewhere.
     const plannedDate = zoneAsset.planned_shutdown_date;
     if (
       plannedDate &&
-      zoneAsset.osmosis_halt_deposits !== true
+      zoneAsset.osmosis_halt_deposits !== true &&
+      !zoneAsset.tooltip_message
     ) {
       const untilMs = new Date(plannedDate).getTime() - nowMs;
       if (untilMs >= 0 && untilMs <= SHUTDOWN_WINDOW_MS) {

--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -24,6 +24,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { calculateIbcHash } from './assetlist_functions.mjs';
 
 const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
 const SHUTDOWN_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
@@ -47,20 +48,34 @@ const reportsDir = path.join(zonePath, 'generated', 'reports');
 const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
 
 async function fetchNumia() {
-  const res = await fetch(NUMIA_TOKENS_URL);
-  if (!res.ok) {
-    throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+  const controller = new AbortController();
+  const timeoutMs = 10000; // 10 second timeout
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  
+  try {
+    const res = await fetch(NUMIA_TOKENS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    
+    if (!res.ok) {
+      throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+    }
+    const data = await res.json();
+    const byDenom = new Map();
+    for (const t of data) {
+      if (!t.denom) continue;
+      byDenom.set(t.denom, {
+        liquidity: Number(t.liquidity ?? 0),
+        volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+      });
+    }
+    return byDenom;
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if (err.name === 'AbortError') {
+      throw new Error(`Request to ${NUMIA_TOKENS_URL} timed out after 10s (hard-fail policy)`);
+    }
+    throw new Error(`Failed to fetch from ${NUMIA_TOKENS_URL}: ${err.message}`);
   }
-  const data = await res.json();
-  const byDenom = new Map();
-  for (const t of data) {
-    if (!t.denom) continue;
-    byDenom.set(t.denom, {
-      liquidity: Number(t.liquidity ?? 0),
-      volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
-    });
-  }
-  return byDenom;
 }
 
 function loadJSON(p, fallback) {
@@ -83,17 +98,37 @@ async function main() {
     zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
   }
 
+  // Build the evaluation list. For every zone_asset that's IBC (has a path),
+  // compute its coinMinimalDenom via the same IBC hash the generator uses.
+  // This lets us iterate the canonical key even when an asset is missing
+  // from the frontend (killed-chain case).
+  const frontendBySymbol = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendBySymbol.set(asset.coinMinimalDenom, asset);
+  }
+
+  const evaluations = [];
+  for (const za of zoneData.assets) {
+    if (!za.path) continue; // skip non-IBC entries; they aren't bridged
+    const coinMinimalDenom = await calculateIbcHash(za.path);
+    const feAsset = frontendBySymbol.get(coinMinimalDenom);
+    evaluations.push({
+      coinMinimalDenom,
+      chainName: za.chain_name,
+      symbol: feAsset?.symbol ?? za._comment ?? za.base_denom,
+      zoneAsset: za,
+    });
+  }
+
   const nowIso = new Date().toISOString();
   const nowMs = new Date(nowIso).getTime();
   const mutations = [];
 
-  for (const asset of frontendData.assets ?? []) {
-    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
-    const zoneAsset = zoneByOrigin.get(zoneKey);
-    if (!zoneAsset) continue;
+  for (const ev of evaluations) {
+    const { coinMinimalDenom, chainName, symbol, zoneAsset } = ev;
 
     const stateAsset = state.assets?.find(
-      (a) => a.base_denom === asset.coinMinimalDenom
+      (a) => a.base_denom === coinMinimalDenom
     );
 
     // ── Trigger A: extended unstable + failing market ───────────────────────
@@ -108,7 +143,7 @@ async function main() {
     ) {
       const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
       if (downtimeMs >= SIXTY_DAYS_MS) {
-        const market = numia.get(asset.coinMinimalDenom);
+        const market = numia.get(coinMinimalDenom);
         const failing =
           !!market &&
           market.liquidity < LOW_LIQUIDITY_USD &&
@@ -118,8 +153,8 @@ async function main() {
           zoneAsset.osmosis_deposit_halt_reason = 'extended_unstable_market';
           mutations.push({
             kind: 'extended_halt_set',
-            asset: asset.symbol,
-            chain: asset.chainName,
+            asset: symbol,
+            chain: chainName,
             days: Math.floor(downtimeMs / (24 * 60 * 60 * 1000)),
           });
         }
@@ -132,7 +167,7 @@ async function main() {
       zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
       !zoneAsset.tooltip_message
     ) {
-      const market = numia.get(asset.coinMinimalDenom);
+      const market = numia.get(coinMinimalDenom);
       const passing =
         !!market &&
         (market.liquidity >= LOW_LIQUIDITY_USD ||
@@ -142,8 +177,8 @@ async function main() {
         delete zoneAsset.osmosis_deposit_halt_reason;
         mutations.push({
           kind: 'extended_halt_cleared',
-          asset: asset.symbol,
-          chain: asset.chainName,
+          asset: symbol,
+          chain: chainName,
         });
       }
     }
@@ -163,8 +198,8 @@ async function main() {
         zoneAsset.osmosis_deposit_halt_reason = 'planned_shutdown';
         mutations.push({
           kind: 'planned_shutdown_set',
-          asset: asset.symbol,
-          chain: asset.chainName,
+          asset: symbol,
+          chain: chainName,
           shutdown: plannedDate,
         });
       }
@@ -184,8 +219,8 @@ async function main() {
         delete zoneAsset.osmosis_deposit_halt_reason;
         mutations.push({
           kind: 'planned_shutdown_cleared',
-          asset: asset.symbol,
-          chain: asset.chainName,
+          asset: symbol,
+          chain: chainName,
         });
       }
     }

--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -1,0 +1,241 @@
+// Purpose:
+//   60-day extended deposit halt + planned-shutdown halt. Daily cron, runs
+//   after check_ibc_clients and check_market_health. Two independent triggers,
+//   both write osmosis_halt_deposits=true:
+//
+//     • 60 days since state.lastDowntimeDate AND osmosis_unstable=true AND
+//       market check still failing → halt_deposits with reason
+//       "extended_unstable_market".
+//
+//     • planned_shutdown_date within 14 days → halt_deposits with reason
+//       "planned_shutdown".
+//
+//   Reason-vocabulary contract: this script owns reasons
+//   {extended_unstable_market, planned_shutdown}. Clearing rules:
+//     • extended_unstable_market: cleared on a single passing market run.
+//       (Note: check_market_health also implements this clearing path for
+//       the market-recovery flow; both are safe because they're guarded by
+//       the same reason check.)
+//     • planned_shutdown: cleared when planned_shutdown_date is absent or
+//       > 14 days in the future.
+//
+// Usage:
+//   node check_extended_halts.mjs [<zone_name>] [--dry-run] [--force]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const SHUTDOWN_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+const LOW_LIQUIDITY_USD = 1000;
+const LOW_VOLUME_24H_USD = 100;
+const MAX_CHAINS_PER_RUN = 10;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
+
+async function fetchNumia() {
+  const res = await fetch(NUMIA_TOKENS_URL);
+  if (!res.ok) {
+    throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+  }
+  const data = await res.json();
+  const byDenom = new Map();
+  for (const t of data) {
+    if (!t.denom) continue;
+    byDenom.set(t.denom, {
+      liquidity: Number(t.liquidity ?? 0),
+      volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+    });
+  }
+  return byDenom;
+}
+
+function loadJSON(p, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT' && fallback !== undefined) return fallback;
+    throw err;
+  }
+}
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+  const numia = await fetchNumia();
+
+  const zoneByOrigin = new Map();
+  for (const a of zoneData.assets) {
+    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
+  }
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+  const mutations = [];
+
+  for (const asset of frontendData.assets ?? []) {
+    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
+    const zoneAsset = zoneByOrigin.get(zoneKey);
+    if (!zoneAsset) continue;
+
+    const stateAsset = state.assets?.find(
+      (a) => a.base_denom === asset.coinMinimalDenom
+    );
+
+    // ── Trigger A: extended unstable + failing market ───────────────────────
+    if (
+      zoneAsset.osmosis_unstable === true &&
+      stateAsset?.lastDowntimeDate &&
+      zoneAsset.osmosis_halt_deposits !== true
+    ) {
+      const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
+      if (downtimeMs >= SIXTY_DAYS_MS) {
+        const market = numia.get(asset.coinMinimalDenom);
+        const failing =
+          !!market &&
+          market.liquidity < LOW_LIQUIDITY_USD &&
+          market.volume24h < LOW_VOLUME_24H_USD;
+        if (failing) {
+          zoneAsset.osmosis_halt_deposits = true;
+          zoneAsset.osmosis_deposit_halt_reason = 'extended_unstable_market';
+          mutations.push({
+            kind: 'extended_halt_set',
+            asset: asset.symbol,
+            chain: asset.chainName,
+            days: Math.floor(downtimeMs / (24 * 60 * 60 * 1000)),
+          });
+        }
+      }
+    }
+
+    // ── Trigger A clearing: market recovered (single passing run) ──────────
+    if (
+      zoneAsset.osmosis_halt_deposits === true &&
+      zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
+      !zoneAsset.tooltip_message
+    ) {
+      const market = numia.get(asset.coinMinimalDenom);
+      const passing =
+        !!market &&
+        (market.liquidity >= LOW_LIQUIDITY_USD ||
+          market.volume24h >= LOW_VOLUME_24H_USD);
+      if (passing) {
+        delete zoneAsset.osmosis_halt_deposits;
+        delete zoneAsset.osmosis_deposit_halt_reason;
+        mutations.push({
+          kind: 'extended_halt_cleared',
+          asset: asset.symbol,
+          chain: asset.chainName,
+        });
+      }
+    }
+
+    // ── Trigger B: planned shutdown approaching ─────────────────────────────
+    const plannedDate = zoneAsset.planned_shutdown_date;
+    if (
+      plannedDate &&
+      zoneAsset.osmosis_halt_deposits !== true
+    ) {
+      const untilMs = new Date(plannedDate).getTime() - nowMs;
+      if (untilMs >= 0 && untilMs <= SHUTDOWN_WINDOW_MS) {
+        zoneAsset.osmosis_halt_deposits = true;
+        zoneAsset.osmosis_deposit_halt_reason = 'planned_shutdown';
+        mutations.push({
+          kind: 'planned_shutdown_set',
+          asset: asset.symbol,
+          chain: asset.chainName,
+          shutdown: plannedDate,
+        });
+      }
+    }
+
+    // ── Trigger B clearing ──────────────────────────────────────────────────
+    if (
+      zoneAsset.osmosis_halt_deposits === true &&
+      zoneAsset.osmosis_deposit_halt_reason === 'planned_shutdown' &&
+      !zoneAsset.tooltip_message
+    ) {
+      const untilMs = plannedDate
+        ? new Date(plannedDate).getTime() - nowMs
+        : Infinity;
+      if (!plannedDate || untilMs > SHUTDOWN_WINDOW_MS) {
+        delete zoneAsset.osmosis_halt_deposits;
+        delete zoneAsset.osmosis_deposit_halt_reason;
+        mutations.push({
+          kind: 'planned_shutdown_cleared',
+          asset: asset.symbol,
+          chain: asset.chainName,
+        });
+      }
+    }
+  }
+
+  const affectedChains = new Set(
+    mutations.filter((m) => m.chain).map((m) => m.chain)
+  );
+  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
+    console.error(
+      `\n⛔ Mutation cap exceeded: ${affectedChains.size} chains > ${MAX_CHAINS_PER_RUN}.`
+    );
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `extended_halts_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Extended halts dry-run, ${nowIso}`,
+      ``,
+      `Mutations: ${mutations.length}`,
+      ``,
+      `| Kind | Asset | Chain | Days / Shutdown |`,
+      `|------|-------|-------|-----------------|`,
+    ];
+    for (const m of mutations) {
+      lines.push(
+        `| ${m.kind} | ${m.asset ?? '-'} | ${m.chain ?? '-'} | ${m.days ?? m.shutdown ?? '-'} |`
+      );
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    return;
+  }
+
+  if (mutations.length > 0) {
+    fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+  } else {
+    console.log('No changes needed.');
+  }
+
+  const byKind = {};
+  for (const m of mutations) byKind[m.kind] = (byKind[m.kind] || 0) + 1;
+  console.log('\n' + '='.repeat(70));
+  console.log('  EXTENDED HALTS SUMMARY');
+  console.log('='.repeat(70));
+  for (const [k, v] of Object.entries(byKind)) {
+    console.log(`  ${k.padEnd(28)}: ${v}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -102,16 +102,16 @@ async function main() {
   // compute its coinMinimalDenom via the same IBC hash the generator uses.
   // This lets us iterate the canonical key even when an asset is missing
   // from the frontend (killed-chain case).
-  const frontendBySymbol = new Map();
+  const frontendByDenom = new Map();
   for (const asset of frontendData.assets ?? []) {
-    frontendBySymbol.set(asset.coinMinimalDenom, asset);
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
   }
 
   const evaluations = [];
   for (const za of zoneData.assets) {
     if (!za.path) continue; // skip non-IBC entries; they aren't bridged
     const coinMinimalDenom = await calculateIbcHash(za.path);
-    const feAsset = frontendBySymbol.get(coinMinimalDenom);
+    const feAsset = frontendByDenom.get(coinMinimalDenom);
     evaluations.push({
       coinMinimalDenom,
       chainName: za.chain_name,

--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -27,6 +27,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { calculateIbcHash } from './assetlist_functions.mjs';
 
 const LCD = "https://lcd.osmosis.zone";
 const CONCURRENCY = 5;
@@ -550,29 +551,32 @@ async function main() {
   // their transferMethods during generation, never appear in the channel walk.
   // For these, apply the manual-flip safety net so curators get a populated
   // lastDowntimeDate (anchoring the 90-day clock) even without channel data.
-  const visitedDenoms = new Set();
+  //
+  // State entries are keyed by coinMinimalDenom (matching update_assetlist_state.mjs
+  // and every other lifecycle script). For IBC assets we compute that hash from
+  // the path, since the frontend assetlist has no entry for these.
+  const visitedPaths = new Set();
   for (const cm of channelMap.values()) {
-    for (const fa of cm.assets) visitedDenoms.add(fa.coinMinimalDenom);
+    for (const fa of cm.assets) visitedPaths.add(fa.ibcPath);
   }
   for (const za of zoneData.assets) {
     if (za.osmosis_unstable !== true) continue;
-    // Build the same coinMinimalDenom the frontend uses. For IBC assets the
-    // path encodes it via an IBC hash, but we'd need the generator's
-    // computation. As a pragmatic shortcut, skip if the frontend already
-    // produced an entry for this zone_asset (visited above).
-    const fePath = za.path;
-    const fa = fePath ? [...channelMap.values()]
-      .flatMap((cm) => cm.assets)
-      .find((a) => a.ibcPath === fePath) : null;
-    if (fa) continue; // already visited
-    // No frontend match. Populate state.lastDowntimeDate by base_denom, which
-    // matches the state-indexing convention.
-    const stateAsset = getOrCreateStateAsset(state, za.base_denom);
+    if (!za.path) continue; // non-IBC entries are not handled here
+    if (visitedPaths.has(za.path)) continue;
+
+    const coinMinimalDenom = await calculateIbcHash(za.path);
+    const stateAsset = getOrCreateStateAsset(state, coinMinimalDenom);
     if (!stateAsset.lastDowntimeDate) {
       stateAsset.lastDowntimeDate = nowIso;
       mutations.push({
         kind: 'safety_net',
-        fa: { chainName: za.chain_name, symbol: za._comment ?? za.base_denom, ibcPath: za.path ?? '?', sourceDenom: za.base_denom },
+        fa: {
+          chainName: za.chain_name,
+          symbol: za._comment ?? za.base_denom,
+          ibcPath: za.path,
+          sourceDenom: za.base_denom,
+          coinMinimalDenom,
+        },
       });
     }
   }

--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -1,16 +1,29 @@
 // Purpose:
-//   Check IBC client health for all IBC assets in the generated frontend
-//   assetlist. Automatically sets/clears osmosis_unstable in zone_assets.json,
-//   adding new minimal entries for assets not yet present and removing them
-//   when they recover.
+//   Unified bridge-state check. For every IBC asset in the generated frontend
+//   assetlist:
+//     • Detect "bridge-down" condition (IBC client Expired/Frozen on either
+//       side, OR source chain marked status="killed" in the chain registry).
+//     • Detect "bridge-up" condition (IBC client Active on both sides AND
+//       source chain status="live").
+//     • Set/clear osmosis_unstable + osmosis_halt_deposits +
+//       osmosis_halt_withdrawals in zone_assets.json, with reasons.
+//     • Maintain state.json's lastDowntimeDate / lastRecoveryDate fields
+//       (flap-vs-fresh-incident rule).
 //
-//   When clearing a flag, both the Osmosis-side client AND the counterparty-side
-//   client are verified as Active before clearing, since withdrawals from Osmosis
-//   require the counterparty's client of Osmosis to be healthy.
+//   Reason-vocabulary contract: this script owns reasons {ibc_client,
+//   source_chain_killed} for both unstable and halts, and {bridge_down,
+//   source_chain_killed} for halts. Halts with any other reason (notably
+//   "manual" or one owned by check_extended_halts.mjs) are NEVER touched
+//   by this script. A non-empty tooltip on a halt also locks the halt
+//   (curator has taken ownership).
 //
 // Usage:
-//   node check_ibc_clients.mjs <zone_name>
+//   node check_ibc_clients.mjs [<zone_name>] [--dry-run] [--force]
 //   Example: node check_ibc_clients.mjs osmosis-1
+//   Example: node check_ibc_clients.mjs osmosis-1 --dry-run
+//
+//   --dry-run : no writes; emits markdown report; exit 0.
+//   --force   : bypass the mutation cap (>10 distinct source chains touched).
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -23,21 +36,62 @@ const COUNTERPARTY_TIMEOUT_MS = 5000;
 const COUNTERPARTY_MAX_ENDPOINTS = 5;
 const CHAIN_REGISTRY_PATH = path.join('..', '..', '..', 'chain-registry');
 
-const zoneBasePath = process.argv[2] || 'osmosis-1';
+// Mutation safeguard: if a single run would touch assets across more than
+// MAX_CHAINS_PER_RUN distinct source chains, the script exits without
+// committing. Counts the unique `chain_name` field on each affected
+// zone_asset entry. Intended to catch mass-flips from chain-registry
+// submodule bumps or upstream regressions. Per-chain (not per-asset) so a
+// single big chain producing many asset rows passes through normally.
+const MAX_CHAINS_PER_RUN = 10;
+
+// 30-day flap threshold: if an asset recovered <= 30d ago and goes
+// unstable again, treat as a continuation of the original incident
+// (preserve lastDowntimeDate). Beyond 30d → fresh incident.
+const FLAP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// CLI args
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
 const zonePath = path.join('..', '..', '..', zoneBasePath);
 const filePrefix = zoneBasePath.split('-')[0];
 const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
-const frontendPath  = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
 const chainlistPath = path.join(zonePath, 'generated', 'frontend', 'chainlist.json');
 const zoneChainsPath = path.join(zonePath, `${filePrefix}.zone_chains.json`);
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
 
-// Fields that constitute a "thin" auto-added entry (safe to remove entirely
-// when the client recovers, since there's nothing else of value in the entry)
-const THIN_FIELDS = new Set(['chain_name', 'base_denom', 'path', 'osmosis_unstable', '_comment']);
+// Auto-managed fields. A "thin entry" is one where everything was auto-set
+// by this script (no curator content), so it can be removed entirely on
+// recovery rather than just having its flags cleared. Note that
+// tooltip_message is intentionally NOT in this set: any curator-set tooltip
+// counts as content that must be preserved.
+const AUTO_MANAGED_FIELDS = new Set([
+  'chain_name',
+  'base_denom',
+  'path',
+  '_comment',
+  'osmosis_unstable',
+  'osmosis_unstable_reason',
+  'osmosis_halt_deposits',
+  'osmosis_deposit_halt_reason',
+  'osmosis_halt_withdrawals',
+  'osmosis_withdrawal_halt_reason',
+]);
 
 function isThinEntry(asset) {
-  return Object.keys(asset).every(k => THIN_FIELDS.has(k));
+  return Object.keys(asset).every((k) => AUTO_MANAGED_FIELDS.has(k));
 }
+
+// Reasons this script is allowed to clear. Anything else (extended_unstable_market,
+// planned_shutdown, manual) is owned by another script or the curator and is
+// left alone.
+const OWNED_HALT_REASONS = new Set(['bridge_down', 'source_chain_killed']);
+const OWNED_UNSTABLE_REASONS = new Set(['ibc_client', 'source_chain_killed']);
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
@@ -87,6 +141,18 @@ async function processInBatches(items, batchSize, fn) {
   return results;
 }
 
+// ── Chain registry: source chain status ──────────────────────────────────────
+
+function getSourceChainStatus(chainName) {
+  try {
+    const chainFile = path.join(CHAIN_REGISTRY_PATH, chainName, 'chain.json');
+    const chainData = JSON.parse(fs.readFileSync(chainFile, 'utf8'));
+    return chainData.status ?? 'unknown'; // typically 'live', 'killed', 'upcoming'
+  } catch {
+    return 'unknown';
+  }
+}
+
 // ── IBC client lookup (Osmosis side) ─────────────────────────────────────────
 
 async function getClientStatusForChannel(channelId) {
@@ -110,11 +176,6 @@ async function getClientStatusForChannel(channelId) {
 
 // ── IBC client lookup (counterparty side) ────────────────────────────────────
 
-// Returns REST endpoints for a counterparty chain in priority order:
-//   1. zone_chains.json  — single manually curated endpoint (highest quality)
-//   2. chainlist.json    — validated and ordered endpoints from endpoint validation
-//   3. chain registry    — raw unvalidated fallback
-// Returns null if the chain is marked "killed" in the chain registry (skip queries).
 function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName) {
   const seen = new Set();
   const endpoints = [];
@@ -128,38 +189,31 @@ function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByNa
     }
   }
 
-  // 1. zone_chains.json — single curated REST endpoint
   const zoneChain = zoneChainsByName.get(chainName);
   if (zoneChain?.rest) add(zoneChain.rest);
 
-  // 2. Generated chainlist — validated endpoints in order
   const chainlistChain = chainlistByName.get(chainName);
   for (const e of chainlistChain?.apis?.rest ?? []) add(e.address);
 
-  // 3. Chain registry — raw fallback; also check for killed status
   try {
     const chainFile = path.join(CHAIN_REGISTRY_PATH, chainName, 'chain.json');
     const chainData = JSON.parse(fs.readFileSync(chainFile, 'utf8'));
-    if (chainData.status === 'killed') return null; // chain is permanently dead
+    if (chainData.status === 'killed') return null;
     for (const e of chainData.apis?.rest ?? []) add(e.address);
   } catch { /* chain not in registry */ }
 
   return endpoints;
 }
 
-// Returns 'Active', 'Expired', 'Frozen', or 'unknown' (if unreachable/missing).
-// 'unknown' is treated as a reason NOT to clear — preserves the flag.
-// deadEndpoints: Set<string> shared across calls — endpoints that have already
-// failed are skipped immediately, preventing repeated timeouts for dead chains.
 async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByName, chainlistByName, deadEndpoints) {
   if (!chainName || !channelId) return 'unknown';
 
   const endpoints = getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName);
-  if (endpoints === null) return 'killed'; // chain registry marks this chain as dead
+  if (endpoints === null) return 'killed';
   if (endpoints.length === 0) return 'unknown';
 
   for (const endpoint of endpoints.slice(0, COUNTERPARTY_MAX_ENDPOINTS)) {
-    if (deadEndpoints.has(endpoint)) continue; // skip known-dead endpoints immediately
+    if (deadEndpoints.has(endpoint)) continue;
 
     try {
       const channelData = await fetchJSONWithTimeout(
@@ -177,9 +231,9 @@ async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByNam
       const statusData = await fetchJSONWithTimeout(
         `${endpoint}/ibc/core/client/v1/client_status/${clientId}`
       );
-      return statusData.status; // 'Active', 'Expired', 'Frozen'
+      return statusData.status;
     } catch {
-      deadEndpoints.add(endpoint); // mark endpoint dead for all subsequent channels
+      deadEndpoints.add(endpoint);
       continue;
     }
   }
@@ -187,7 +241,73 @@ async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByNam
   return 'unknown';
 }
 
-// ── Main ──────────────────────────────────────────────────────────────────────
+// ── State helpers ───────────────────────────────────────────────────────────
+
+function loadState() {
+  try {
+    return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') return { assets: [] };
+    throw err;
+  }
+}
+
+function getOrCreateStateAsset(state, baseDenom) {
+  if (!state.assets) state.assets = [];
+  let s = state.assets.find((a) => a.base_denom === baseDenom);
+  if (!s) {
+    s = { base_denom: baseDenom };
+    state.assets.push(s);
+  }
+  return s;
+}
+
+/**
+ * Apply the flap-vs-fresh-incident rule to lastDowntimeDate / lastRecoveryDate.
+ * Mutates stateAsset in place.
+ */
+function applyDowntimeDateRule(stateAsset, nowIso) {
+  const now = new Date(nowIso).getTime();
+  if (!stateAsset.lastDowntimeDate) {
+    stateAsset.lastDowntimeDate = nowIso;
+    return;
+  }
+  if (!stateAsset.lastRecoveryDate) {
+    // continuously unstable; clock keeps running
+    return;
+  }
+  const recoveredAt = new Date(stateAsset.lastRecoveryDate).getTime();
+  if (now - recoveredAt <= FLAP_WINDOW_MS) {
+    // short flap, preserve original downtime, clear recovery
+    delete stateAsset.lastRecoveryDate;
+  } else {
+    // fresh incident
+    stateAsset.lastDowntimeDate = nowIso;
+    delete stateAsset.lastRecoveryDate;
+  }
+}
+
+// ── Halt mutation helpers ────────────────────────────────────────────────────
+
+/** Returns true if this script may safely modify the halt flag based on its
+ *  current reason and the shared tooltip_message field. A non-empty
+ *  tooltip_message is treated as a curator-owned override that locks all
+ *  halt/unstable automation for this asset. */
+function canModifyHalt(zoneAsset, reasonField) {
+  const currentReason = zoneAsset[reasonField];
+  if (currentReason && !OWNED_HALT_REASONS.has(currentReason)) return false;
+  if (zoneAsset.tooltip_message) return false;
+  return true;
+}
+
+function canModifyUnstable(zoneAsset) {
+  const currentReason = zoneAsset.osmosis_unstable_reason;
+  if (currentReason && !OWNED_UNSTABLE_REASONS.has(currentReason)) return false;
+  if (zoneAsset.tooltip_message) return false;
+  return true;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
   // Load zone_assets.json
@@ -199,7 +319,6 @@ async function main() {
     process.exit(1);
   }
 
-  // Load generated frontend assetlist as the source of truth for IBC assets
   let frontendData;
   try {
     frontendData = JSON.parse(fs.readFileSync(frontendPath, 'utf8'));
@@ -208,7 +327,8 @@ async function main() {
     process.exit(1);
   }
 
-  // Build counterparty endpoint lookups (zone_chains → chainlist → registry)
+  const state = loadState();
+
   const zoneChainsByName = new Map();
   try {
     const zc = JSON.parse(fs.readFileSync(zoneChainsPath, 'utf8'));
@@ -221,18 +341,15 @@ async function main() {
     for (const chain of cl.chains ?? []) chainlistByName.set(chain.chain_name, chain);
   } catch { /* optional */ }
 
-  // Build a lookup of zone_assets entries by path for fast matching
   const zoneByPath = new Map();
   for (const asset of zoneData.assets) {
     if (asset.path) zoneByPath.set(asset.path, asset);
   }
 
-  // Collect IBC assets from the frontend assetlist, grouped by channel.
-  // Store counterparty info at the channel level (all assets on a channel
-  // share the same counterparty chain and channel ID).
-  const channelMap = new Map(); // channelId -> { assets, counterpartyChainName, counterpartyChannelId }
+  // Group frontend IBC assets by channel.
+  const channelMap = new Map();
   for (const asset of frontendData.assets ?? []) {
-    const ibcMethod = asset.transferMethods?.find(m => m.type === 'ibc');
+    const ibcMethod = asset.transferMethods?.find((m) => m.type === 'ibc');
     if (!ibcMethod?.chain?.channelId || !ibcMethod?.chain?.path) continue;
 
     const channelId = ibcMethod.chain.channelId;
@@ -244,20 +361,21 @@ async function main() {
       });
     }
     channelMap.get(channelId).assets.push({
-      chainName:   asset.chainName,
+      chainName: asset.chainName,
       sourceDenom: asset.sourceDenom,
-      symbol:      asset.symbol,
+      coinMinimalDenom: asset.coinMinimalDenom,
+      symbol: asset.symbol,
       channelId,
-      ibcPath:     ibcMethod.chain.path,
+      ibcPath: ibcMethod.chain.path,
     });
   }
 
   const uniqueChannels = [...channelMap.keys()];
   const totalAssets = [...channelMap.values()].reduce((n, c) => n + c.assets.length, 0);
-  console.log(`Checking IBC client status for ${uniqueChannels.length} unique channels (${totalAssets} IBC assets in frontend)...\n`);
+  console.log(`Checking IBC client + chain status for ${uniqueChannels.length} channels (${totalAssets} IBC assets)...\n`);
 
-  // Query Osmosis LCD in batches
-  const results = await processInBatches(
+  // Phase 1: Osmosis-side IBC client status
+  const ibcResults = await processInBatches(
     uniqueChannels,
     CONCURRENCY,
     async (channelId) => {
@@ -270,189 +388,269 @@ async function main() {
     }
   );
 
-  const stats = {
-    active: 0, flagged: 0, cleared: 0, removed: 0,
-    alreadyFlagged: 0, counterpartySkipped: 0, errors: 0,
-  };
-  const newlyFlagged         = [];
-  const newlyCleared         = [];
-  const newlyRemoved         = [];
-  const counterpartySkipped  = [];
-  const errorChannels        = [];
-
-  // ── Phase 1: identify channels needing a counterparty check ─────────────────
-  // Only Osmosis-Active channels with currently unstable-flagged assets need it.
-  const cpCheckNeeded = new Map(); // osmosisChannelId -> { counterpartyChainName, counterpartyChannelId }
-  for (const result of results) {
-    if (result.error || result.status !== 'Active') continue;
-    const { assets: channelAssets, counterpartyChainName, counterpartyChannelId } = channelMap.get(result.channelId);
-    const hasUnstableAssets = channelAssets.some(fa => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true);
-    if (hasUnstableAssets && counterpartyChainName && counterpartyChannelId) {
-      cpCheckNeeded.set(result.channelId, { counterpartyChainName, counterpartyChannelId });
+  // Phase 2: counterparty checks for channels we might clear
+  const cpCheckNeeded = new Map();
+  for (const r of ibcResults) {
+    if (r.error || r.status !== 'Active') continue;
+    const cm = channelMap.get(r.channelId);
+    const hasUnstableAssets = cm.assets.some(
+      (fa) => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true
+    );
+    if (hasUnstableAssets && cm.counterpartyChainName && cm.counterpartyChannelId) {
+      cpCheckNeeded.set(r.channelId, cm);
     }
   }
 
-  // ── Phase 2: run counterparty checks in concurrent batches ──────────────────
-  // deadEndpoints is shared across all calls so a failed endpoint is never
-  // retried for a different channel on the same dead chain.
-  const cpStatuses = new Map(); // osmosisChannelId -> status string
+  const cpStatuses = new Map();
   if (cpCheckNeeded.size > 0) {
-    console.log(`Checking counterparty client status for ${cpCheckNeeded.size} channel(s)...\n`);
+    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} channel(s)...\n`);
     const deadEndpoints = new Set();
-    const cpEntries = [...cpCheckNeeded.entries()];
-    const cpBatchResults = await processInBatches(
-      cpEntries,
+    const cpResults = await processInBatches(
+      [...cpCheckNeeded.entries()],
       CONCURRENCY,
-      async ([channelId, { counterpartyChainName, counterpartyChannelId }]) => {
+      async ([channelId, cm]) => {
         const status = await getCounterpartyClientStatus(
-          counterpartyChainName, counterpartyChannelId,
-          zoneChainsByName, chainlistByName, deadEndpoints
+          cm.counterpartyChainName,
+          cm.counterpartyChannelId,
+          zoneChainsByName,
+          chainlistByName,
+          deadEndpoints
         );
         return [channelId, status];
       }
     );
-    for (const [channelId, status] of cpBatchResults) {
-      cpStatuses.set(channelId, status);
-    }
+    for (const [channelId, status] of cpResults) cpStatuses.set(channelId, status);
   }
 
-  // ── Phase 3: apply flags using pre-computed results ──────────────────────────
-  for (const result of results) {
-    const { assets: channelAssets, counterpartyChainName, counterpartyChannelId } = channelMap.get(result.channelId);
+  // Phase 3: apply mutations (collected first, written later so dry-run can short-circuit)
+  const mutations = [];
+  const nowIso = new Date().toISOString();
 
-    if (result.error) {
-      stats.errors++;
-      errorChannels.push({ channelId: result.channelId, error: result.error });
-      continue; // leave flags unchanged on error
+  for (const r of ibcResults) {
+    const cm = channelMap.get(r.channelId);
+
+    if (r.error) {
+      mutations.push({ kind: 'ibc_error', channelId: r.channelId, error: r.error });
+      continue;
     }
 
-    const isProblematic = result.status !== 'Active';
+    const osmosisDown = r.status !== 'Active';
+    const cpStatus = cpStatuses.get(r.channelId); // undefined if no unstable assets
 
-    if (!isProblematic) {
-      // Osmosis-side client is Active. Check pre-computed counterparty status
-      // before clearing any flags (covers the withdrawal direction).
-      const cpStatus = cpStatuses.get(result.channelId); // undefined = no unstable assets, skip check
-      if (cpStatus !== undefined && cpStatus !== 'Active') {
-        // Counterparty side unconfirmed or broken — skip clearing for all assets on this channel
-        for (const fa of channelAssets) {
-          if (zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true) {
-            stats.counterpartySkipped++;
-            counterpartySkipped.push({ ...fa, cpStatus, counterpartyChainName, counterpartyChannelId });
-          }
-        }
-        continue;
-      }
-    }
+    for (const fa of cm.assets) {
+      // Per-asset evaluation, since source chain status is per-chain.
+      const sourceStatus = getSourceChainStatus(fa.chainName);
+      const chainKilled = sourceStatus === 'killed';
+      const chainLive = sourceStatus === 'live';
 
-    for (const fa of channelAssets) {
-      const zoneAsset = zoneByPath.get(fa.ibcPath);
+      const bridgeDown = osmosisDown || chainKilled;
+      const bridgeUp = !osmosisDown && chainLive && (cpStatus === undefined || cpStatus === 'Active');
 
-      if (isProblematic) {
-        if (zoneAsset) {
-          if (zoneAsset.osmosis_unstable === true) {
-            stats.alreadyFlagged++;
-          } else {
-            zoneAsset.osmosis_unstable = true;
-            stats.flagged++;
-            newlyFlagged.push({ ...fa, status: result.status, clientId: result.clientId });
-          }
-        } else {
-          // Asset not in zone_assets yet — add a minimal entry
-          const newEntry = {
+      const reasonOnDown = chainKilled ? 'source_chain_killed' : 'ibc_client';
+      const haltReasonOnDown = chainKilled ? 'source_chain_killed' : 'bridge_down';
+
+      let zoneAsset = zoneByPath.get(fa.ibcPath);
+      const stateAsset = getOrCreateStateAsset(state, fa.coinMinimalDenom);
+
+      if (bridgeDown) {
+        // ── Bridge-down ────────────────────────────────────────────────────
+        if (!zoneAsset) {
+          zoneAsset = {
             chain_name: fa.chainName,
             base_denom: fa.sourceDenom,
-            path:       fa.ibcPath,
-            osmosis_unstable: true,
-            _comment:   `${fa.symbol} $${fa.symbol}`,
+            path: fa.ibcPath,
+            _comment: `${fa.symbol} $${fa.symbol}`,
           };
-          zoneData.assets.push(newEntry);
-          zoneByPath.set(fa.ibcPath, newEntry);
-          stats.flagged++;
-          newlyFlagged.push({ ...fa, status: result.status, clientId: result.clientId, added: true });
+          zoneData.assets.push(zoneAsset);
+          zoneByPath.set(fa.ibcPath, zoneAsset);
+        }
+
+        const before = { ...zoneAsset };
+
+        // osmosis_unstable
+        if (zoneAsset.osmosis_unstable !== true) {
+          if (canModifyUnstable(zoneAsset)) {
+            zoneAsset.osmosis_unstable = true;
+            zoneAsset.osmosis_unstable_reason = reasonOnDown;
+          }
+        }
+
+        // osmosis_halt_deposits
+        if (zoneAsset.osmosis_halt_deposits !== true) {
+          if (canModifyHalt(zoneAsset, 'osmosis_deposit_halt_reason')) {
+            zoneAsset.osmosis_halt_deposits = true;
+            zoneAsset.osmosis_deposit_halt_reason = haltReasonOnDown;
+          }
+        }
+
+        // osmosis_halt_withdrawals
+        if (zoneAsset.osmosis_halt_withdrawals !== true) {
+          if (canModifyHalt(zoneAsset, 'osmosis_withdrawal_halt_reason')) {
+            zoneAsset.osmosis_halt_withdrawals = true;
+            zoneAsset.osmosis_withdrawal_halt_reason = haltReasonOnDown;
+          }
+        }
+
+        // state.lastDowntimeDate via flap-vs-fresh rule
+        if (zoneAsset.osmosis_unstable === true) {
+          applyDowntimeDateRule(stateAsset, nowIso);
+        }
+
+        if (JSON.stringify(before) !== JSON.stringify(zoneAsset)) {
+          mutations.push({ kind: 'bridge_down', fa, reason: reasonOnDown, haltReason: haltReasonOnDown, zoneAsset });
+        }
+      } else if (bridgeUp) {
+        // ── Bridge-up ──────────────────────────────────────────────────────
+        if (!zoneAsset) continue;
+
+        const before = { ...zoneAsset };
+        let cleared = false;
+
+        if (zoneAsset.osmosis_halt_deposits === true &&
+            canModifyHalt(zoneAsset, 'osmosis_deposit_halt_reason')) {
+          delete zoneAsset.osmosis_halt_deposits;
+          delete zoneAsset.osmosis_deposit_halt_reason;
+          cleared = true;
+        }
+
+        if (zoneAsset.osmosis_halt_withdrawals === true &&
+            canModifyHalt(zoneAsset, 'osmosis_withdrawal_halt_reason')) {
+          delete zoneAsset.osmosis_halt_withdrawals;
+          delete zoneAsset.osmosis_withdrawal_halt_reason;
+          cleared = true;
+        }
+
+        if (cleared) {
+          // Record recovery. Keep osmosis_unstable populated so the 90-day
+          // window stays armed via the persistent lastDowntimeDate.
+          stateAsset.lastRecoveryDate = nowIso;
+
+          // If the resulting entry is a thin auto-added one, remove it entirely.
+          if (isThinEntry(zoneAsset)) {
+            zoneData.assets = zoneData.assets.filter((a) => a !== zoneAsset);
+            zoneByPath.delete(fa.ibcPath);
+            mutations.push({ kind: 'thin_removed', fa, zoneAsset: before });
+          } else {
+            mutations.push({ kind: 'bridge_up', fa, zoneAsset });
+          }
         }
       } else {
-        // Both sides Active — safe to clear
-        stats.active++;
-        if (zoneAsset?.osmosis_unstable === true) {
-          if (isThinEntry(zoneAsset)) {
-            // Auto-added entry with nothing else of value — remove it entirely
-            zoneData.assets = zoneData.assets.filter(a => a !== zoneAsset);
-            zoneByPath.delete(fa.ibcPath);
-            stats.removed++;
-            newlyRemoved.push({ ...fa, clientId: result.clientId });
-          } else {
-            // Manually curated entry — just clear the flag
-            delete zoneAsset.osmosis_unstable;
-            stats.cleared++;
-            newlyCleared.push({ ...fa, clientId: result.clientId });
-          }
+        // Unconfirmed (e.g. counterparty status unknown, source chain status unknown).
+        // Manual-flip safety net: if marked unstable without a downtime date, populate one.
+        if (zoneAsset?.osmosis_unstable === true && !stateAsset.lastDowntimeDate) {
+          stateAsset.lastDowntimeDate = nowIso;
+          mutations.push({ kind: 'safety_net', fa });
         }
       }
     }
   }
 
-  // Write back only if something changed
-  if (stats.flagged > 0 || stats.cleared > 0 || stats.removed > 0) {
+  // ── Safety-net pass for zone_assets we never iterated ────────────────────────
+  // Some assets, particularly killed-chain ones whose source chains have lost
+  // their transferMethods during generation, never appear in the channel walk.
+  // For these, apply the manual-flip safety net so curators get a populated
+  // lastDowntimeDate (anchoring the 90-day clock) even without channel data.
+  const visitedDenoms = new Set();
+  for (const cm of channelMap.values()) {
+    for (const fa of cm.assets) visitedDenoms.add(fa.coinMinimalDenom);
+  }
+  for (const za of zoneData.assets) {
+    if (za.osmosis_unstable !== true) continue;
+    // Build the same coinMinimalDenom the frontend uses. For IBC assets the
+    // path encodes it via an IBC hash, but we'd need the generator's
+    // computation. As a pragmatic shortcut, skip if the frontend already
+    // produced an entry for this zone_asset (visited above).
+    const fePath = za.path;
+    const fa = fePath ? [...channelMap.values()]
+      .flatMap((cm) => cm.assets)
+      .find((a) => a.ibcPath === fePath) : null;
+    if (fa) continue; // already visited
+    // No frontend match. Populate state.lastDowntimeDate by base_denom, which
+    // matches the state-indexing convention.
+    const stateAsset = getOrCreateStateAsset(state, za.base_denom);
+    if (!stateAsset.lastDowntimeDate) {
+      stateAsset.lastDowntimeDate = nowIso;
+      mutations.push({
+        kind: 'safety_net',
+        fa: { chainName: za.chain_name, symbol: za._comment ?? za.base_denom, ibcPath: za.path ?? '?', sourceDenom: za.base_denom },
+      });
+    }
+  }
+
+  // ── Mutation cap ────────────────────────────────────────────────────────────
+  const affectedChains = new Set(
+    mutations
+      .filter((m) => m.fa)
+      .map((m) => m.fa.chainName)
+  );
+  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
+    console.error(
+      `\n⛔ Mutation cap exceeded: would touch ${affectedChains.size} distinct source chains ` +
+      `(threshold ${MAX_CHAINS_PER_RUN}). Re-run with --force after manual review, or with ` +
+      `--dry-run to inspect the diff.`
+    );
+    process.exit(2);
+  }
+
+  // ── Dry-run report ──────────────────────────────────────────────────────────
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `bridge_state_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Bridge-state dry-run, ${nowIso}`,
+      ``,
+      `Channels checked: ${uniqueChannels.length}`,
+      `Mutations: ${mutations.length}`,
+      `Distinct source chains affected: ${affectedChains.size}`,
+      ``,
+      `| Kind | Chain | Symbol | Reason | Halt reason |`,
+      `|------|-------|--------|--------|-------------|`,
+    ];
+    for (const m of mutations) {
+      if (!m.fa) continue;
+      lines.push(
+        `| ${m.kind} | ${m.fa.chainName} | ${m.fa.symbol} | ${m.reason ?? '-'} | ${m.haltReason ?? '-'} |`
+      );
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    console.log(`(no files were modified)`);
+    return;
+  }
+
+  // ── Write ───────────────────────────────────────────────────────────────────
+  if (mutations.some((m) => m.kind !== 'ibc_error')) {
     fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
     console.log(`✓ Updated ${zoneAssetsPath}`);
+    console.log(`✓ Updated ${statePath}`);
   } else {
     console.log('No changes needed.');
   }
 
-  // Summary
+  // ── Summary ─────────────────────────────────────────────────────────────────
+  const byKind = {};
+  for (const m of mutations) {
+    byKind[m.kind] = (byKind[m.kind] || 0) + 1;
+  }
   console.log('\n' + '='.repeat(70));
-  console.log('  IBC CLIENT HEALTH SUMMARY');
+  console.log('  BRIDGE-STATE CHECK SUMMARY');
   console.log('='.repeat(70));
-  console.log(`  Channels checked      : ${uniqueChannels.length}`);
-  console.log(`  Active assets         : ${stats.active}`);
-  console.log(`  Already flagged       : ${stats.alreadyFlagged}`);
-  console.log(`  Newly flagged         : ${stats.flagged}`);
-  console.log(`  Flag cleared          : ${stats.cleared}`);
-  console.log(`  Entry removed         : ${stats.removed}`);
-  console.log(`  Counterparty skipped  : ${stats.counterpartySkipped}`);
-  console.log(`  Errors                : ${stats.errors}`);
+  for (const [kind, count] of Object.entries(byKind)) {
+    console.log(`  ${kind.padEnd(20)}: ${count}`);
+  }
+  console.log(`  distinct source chains touched: ${affectedChains.size}`);
   console.log('='.repeat(70));
 
-  if (newlyFlagged.length > 0) {
-    console.log('\n🔴 NEWLY FLAGGED unstable (expired/frozen client):');
-    for (const a of newlyFlagged) {
-      const marker = a.added ? ' [new entry]' : '';
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} status=${a.status}  client=${a.clientId ?? '?'}${marker}`);
-    }
-  }
-
-  if (newlyCleared.length > 0) {
-    console.log('\n🟢 FLAG CLEARED (both sides active, entry kept):');
-    for (const a of newlyCleared) {
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} client=${a.clientId ?? '?'}`);
-    }
-  }
-
-  if (newlyRemoved.length > 0) {
-    console.log('\n🗑️  ENTRY REMOVED (both sides active, thin entry):');
-    for (const a of newlyRemoved) {
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} client=${a.clientId ?? '?'}`);
-    }
-  }
-
-  if (counterpartySkipped.length > 0) {
-    console.log('\n🟡 SKIPPED CLEAR (Osmosis active but counterparty unconfirmed):');
-    for (const a of counterpartySkipped) {
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} counterparty=${a.counterpartyChainName}/${a.counterpartyChannelId} status=${a.cpStatus}`);
-    }
-  }
-
-  if (errorChannels.length > 0) {
-    console.log('\n⚪ ERRORS (flags unchanged):');
-    for (const { channelId, error } of errorChannels) {
-      console.log(`  ${channelId.padEnd(16)} ${error}`);
-    }
-  }
-
-  // Machine-readable summary for the workflow
-  console.log(`\nIBC_NEWLY_FLAGGED=${stats.flagged}`);
-  console.log(`IBC_NEWLY_CLEARED=${stats.cleared + stats.removed}`);
-  console.log(`IBC_ERRORS=${stats.errors}`);
+  // Machine-readable summary
+  console.log(`\nIBC_NEWLY_FLAGGED=${byKind.bridge_down ?? 0}`);
+  console.log(`IBC_NEWLY_CLEARED=${(byKind.bridge_up ?? 0) + (byKind.thin_removed ?? 0)}`);
+  console.log(`IBC_ERRORS=${byKind.ibc_error ?? 0}`);
+  console.log(`AFFECTED_CHAINS=${affectedChains.size}`);
 }
 
 main().catch((err) => {

--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -330,6 +330,13 @@ async function main() {
 
   const state = loadState();
 
+  // Snapshot the pre-run shape so we only write files that actually changed.
+  // getOrCreateStateAsset's create-on-miss behaviour can otherwise grow
+  // state.json with empty {base_denom} records every run, producing a dirty
+  // working tree even when no real lifecycle decision happened.
+  const zoneBefore = JSON.stringify(zoneData);
+  const stateBefore = JSON.stringify(state);
+
   const zoneChainsByName = new Map();
   try {
     const zc = JSON.parse(fs.readFileSync(zoneChainsPath, 'utf8'));
@@ -626,13 +633,18 @@ async function main() {
   }
 
   // ── Write ───────────────────────────────────────────────────────────────────
-  if (mutations.some((m) => m.kind !== 'ibc_error')) {
+  const zoneChanged = JSON.stringify(zoneData) !== zoneBefore;
+  const stateChanged = JSON.stringify(state) !== stateBefore;
+  if (zoneChanged) {
     fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+  }
+  if (stateChanged) {
     fs.mkdirSync(path.dirname(statePath), { recursive: true });
     fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
-    console.log(`✓ Updated ${zoneAssetsPath}`);
     console.log(`✓ Updated ${statePath}`);
-  } else {
+  }
+  if (!zoneChanged && !stateChanged) {
     console.log('No changes needed.');
   }
 

--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -253,7 +253,16 @@ function loadState() {
   }
 }
 
-function getOrCreateStateAsset(state, baseDenom) {
+// Read-only state lookup. Returns undefined if no entry exists; callers that
+// only need to read date/streak fields should use this so we don't pollute
+// state.assets with empty {base_denom} placeholders on every iteration.
+function findStateAsset(state, baseDenom) {
+  return state.assets?.find((a) => a.base_denom === baseDenom);
+}
+
+// Create-if-missing variant. Only callers about to write a real value
+// (lastDowntimeDate, lastRecoveryDate, etc.) should use this.
+function materialiseStateAsset(state, baseDenom) {
   if (!state.assets) state.assets = [];
   let s = state.assets.find((a) => a.base_denom === baseDenom);
   if (!s) {
@@ -331,9 +340,9 @@ async function main() {
   const state = loadState();
 
   // Snapshot the pre-run shape so we only write files that actually changed.
-  // getOrCreateStateAsset's create-on-miss behaviour can otherwise grow
-  // state.json with empty {base_denom} records every run, producing a dirty
-  // working tree even when no real lifecycle decision happened.
+  // Combined with the findStateAsset / materialiseStateAsset split below,
+  // this guarantees state.json is only rewritten when a real lifecycle
+  // decision happened (not just an iteration).
   const zoneBefore = JSON.stringify(zoneData);
   const stateBefore = JSON.stringify(state);
 
@@ -458,7 +467,9 @@ async function main() {
       const haltReasonOnDown = chainKilled ? 'source_chain_killed' : 'bridge_down';
 
       let zoneAsset = zoneByPath.get(fa.ibcPath);
-      const stateAsset = getOrCreateStateAsset(state, fa.coinMinimalDenom);
+      // Read-only lookup: never creates an empty placeholder. Calls that
+      // need to write to state must materialise the entry explicitly.
+      const stateAsset = findStateAsset(state, fa.coinMinimalDenom);
 
       if (bridgeDown) {
         // ── Bridge-down ────────────────────────────────────────────────────
@@ -501,7 +512,10 @@ async function main() {
 
         // state.lastDowntimeDate via flap-vs-fresh rule
         if (zoneAsset.osmosis_unstable === true) {
-          applyDowntimeDateRule(stateAsset, nowIso);
+          applyDowntimeDateRule(
+            stateAsset ?? materialiseStateAsset(state, fa.coinMinimalDenom),
+            nowIso
+          );
         }
 
         if (JSON.stringify(before) !== JSON.stringify(zoneAsset)) {
@@ -531,7 +545,7 @@ async function main() {
         if (cleared) {
           // Record recovery. Keep osmosis_unstable populated so the 90-day
           // window stays armed via the persistent lastDowntimeDate.
-          stateAsset.lastRecoveryDate = nowIso;
+          materialiseStateAsset(state, fa.coinMinimalDenom).lastRecoveryDate = nowIso;
 
           // If the resulting entry is a thin auto-added one, remove it entirely.
           if (isThinEntry(zoneAsset)) {
@@ -545,8 +559,8 @@ async function main() {
       } else {
         // Unconfirmed (e.g. counterparty status unknown, source chain status unknown).
         // Manual-flip safety net: if marked unstable without a downtime date, populate one.
-        if (zoneAsset?.osmosis_unstable === true && !stateAsset.lastDowntimeDate) {
-          stateAsset.lastDowntimeDate = nowIso;
+        if (zoneAsset?.osmosis_unstable === true && !stateAsset?.lastDowntimeDate) {
+          materialiseStateAsset(state, fa.coinMinimalDenom).lastDowntimeDate = nowIso;
           mutations.push({ kind: 'safety_net', fa });
         }
       }
@@ -572,9 +586,9 @@ async function main() {
     if (visitedPaths.has(za.path)) continue;
 
     const coinMinimalDenom = await calculateIbcHash(za.path);
-    const stateAsset = getOrCreateStateAsset(state, coinMinimalDenom);
-    if (!stateAsset.lastDowntimeDate) {
-      stateAsset.lastDowntimeDate = nowIso;
+    const stateAsset = findStateAsset(state, coinMinimalDenom);
+    if (!stateAsset?.lastDowntimeDate) {
+      materialiseStateAsset(state, coinMinimalDenom).lastDowntimeDate = nowIso;
       mutations.push({
         kind: 'safety_net',
         fa: {

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -113,6 +113,13 @@ async function main() {
   const frontendData = loadJSON(frontendPath);
   const state = loadJSON(statePath, { assets: [] });
 
+  // Snapshot the pre-run shape so we only write files that actually changed.
+  // getStateAsset's create-on-miss behaviour can otherwise grow state.json
+  // with empty {base_denom} records every run, producing a dirty working tree
+  // even when no real lifecycle decision happened.
+  const zoneBefore = JSON.stringify(zoneData);
+  const stateBefore = JSON.stringify(state);
+
   // Index zone by (chain_name, base_denom), the canonical join into zone_assets.
   // Each zone_asset's coinMinimalDenom is computed during generate; we'll match
   // via the frontend's existing coinMinimalDenom -> zone_asset chain_name+base_denom join.
@@ -264,13 +271,18 @@ async function main() {
     return;
   }
 
-  if (mutations.length > 0) {
+  const zoneChanged = JSON.stringify(zoneData) !== zoneBefore;
+  const stateChanged = JSON.stringify(state) !== stateBefore;
+  if (zoneChanged) {
     fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+  }
+  if (stateChanged) {
     fs.mkdirSync(path.dirname(statePath), { recursive: true });
     fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
-    console.log(`✓ Updated ${zoneAssetsPath}`);
     console.log(`✓ Updated ${statePath}`);
-  } else {
+  }
+  if (!zoneChanged && !stateChanged) {
     console.log('No changes needed.');
   }
 

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -45,21 +45,35 @@ const reportsDir = path.join(zonePath, 'generated', 'reports');
 const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
 
 async function fetchNumia() {
-  const res = await fetch(NUMIA_TOKENS_URL);
-  if (!res.ok) {
-    throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+  const controller = new AbortController();
+  const timeoutMs = 10000; // 10 second timeout
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  
+  try {
+    const res = await fetch(NUMIA_TOKENS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    
+    if (!res.ok) {
+      throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+    }
+    const data = await res.json();
+    const byDenom = new Map();
+    for (const t of data) {
+      if (!t.denom) continue;
+      byDenom.set(t.denom, {
+        liquidity: Number(t.liquidity ?? 0),
+        // Try several plausible field names; default to 0 if absent.
+        volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+      });
+    }
+    return byDenom;
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if (err.name === 'AbortError') {
+      throw new Error(`Request to ${NUMIA_TOKENS_URL} timed out after 10s (hard-fail policy)`);
+    }
+    throw new Error(`Failed to fetch from ${NUMIA_TOKENS_URL}: ${err.message}`);
   }
-  const data = await res.json();
-  const byDenom = new Map();
-  for (const t of data) {
-    if (!t.denom) continue;
-    byDenom.set(t.denom, {
-      liquidity: Number(t.liquidity ?? 0),
-      // Try several plausible field names; default to 0 if absent.
-      volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
-    });
-  }
-  return byDenom;
 }
 
 function loadJSON(p, fallback) {
@@ -184,11 +198,19 @@ async function main() {
         ) {
           delete zoneAsset.osmosis_halt_deposits;
           delete zoneAsset.osmosis_deposit_halt_reason;
-          mutations.push({ kind: 'extended_halt_cleared', asset: asset.symbol });
+          // Includes `chain` so this counts toward the mutation cap. A Numia
+          // glitch that resolves and bulk-passes many failing assets in one
+          // run would otherwise silently clear all their halts.
+          mutations.push({ kind: 'extended_halt_cleared', asset: asset.symbol, chain: asset.chainName });
         }
 
-        if (rstreak >= RECOVERY_RUNS_TO_CLEAR_UNSTABLE) {
-          // Full recovery, only safe to do here because reason is "market"
+        // Full recovery clears osmosis_unstable. Guarded by reason==='market'
+        // (above, line 186) AND tooltip_message empty here, mirroring the
+        // setting-path curator-lock contract.
+        if (
+          rstreak >= RECOVERY_RUNS_TO_CLEAR_UNSTABLE &&
+          !zoneAsset.tooltip_message
+        ) {
           delete zoneAsset.osmosis_unstable;
           delete zoneAsset.osmosis_unstable_reason;
           delete stateAsset.lastDowntimeDate;

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -113,12 +113,6 @@ async function main() {
   const frontendData = loadJSON(frontendPath);
   const state = loadJSON(statePath, { assets: [] });
 
-  // Index frontend by coinMinimalDenom; that's our join key.
-  const frontendByDenom = new Map();
-  for (const asset of frontendData.assets ?? []) {
-    frontendByDenom.set(asset.coinMinimalDenom, asset);
-  }
-
   // Index zone by (chain_name, base_denom), the canonical join into zone_assets.
   // Each zone_asset's coinMinimalDenom is computed during generate; we'll match
   // via the frontend's existing coinMinimalDenom -> zone_asset chain_name+base_denom join.

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -146,6 +146,10 @@ async function main() {
     if (!zoneAsset.osmosis_unstable) {
       // ── Not currently unstable: count failing-streak toward flagging ──
       if (!isPostGrace(stateAsset, nowMs)) continue;
+      // Curator lock: any non-empty tooltip_message blocks the flagging path,
+      // matching the contract used by the recovery path below and by
+      // check_ibc_clients's canModifyUnstable().
+      if (zoneAsset.tooltip_message) continue;
       if (failing) {
         const streak = (stateAsset.marketHealthStreak ?? 0) + 1;
         stateAsset.marketHealthStreak = streak;

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -85,7 +85,16 @@ function loadJSON(p, fallback) {
   }
 }
 
-function getStateAsset(state, baseDenom) {
+// Read-only state lookup. Returns undefined if no entry exists; callers that
+// only need to read date/streak fields should use this so we don't pollute
+// state.assets with empty {base_denom} placeholders on every iteration.
+function findStateAsset(state, baseDenom) {
+  return state.assets?.find((a) => a.base_denom === baseDenom);
+}
+
+// Create-if-missing variant. Only callers about to write a real value should
+// use this.
+function materialiseStateAsset(state, baseDenom) {
   if (!state.assets) state.assets = [];
   let s = state.assets.find((a) => a.base_denom === baseDenom);
   if (!s) {
@@ -103,8 +112,10 @@ function isAlloyed(asset) {
 }
 
 function isPostGrace(stateAsset, nowMs) {
-  const listingDate = stateAsset.listingDate ?? (stateAsset.legacyAsset ? LEGACY_LISTING_DATE : null);
-  if (!listingDate) return true; // unknown → behave post-grace (conservative)
+  // stateAsset may be undefined for assets that have never been tracked yet.
+  // No listing date known → behave post-grace (conservative).
+  const listingDate = stateAsset?.listingDate ?? (stateAsset?.legacyAsset ? LEGACY_LISTING_DATE : null);
+  if (!listingDate) return true;
   return nowMs - new Date(listingDate).getTime() >= GRACE_MS;
 }
 
@@ -114,9 +125,9 @@ async function main() {
   const state = loadJSON(statePath, { assets: [] });
 
   // Snapshot the pre-run shape so we only write files that actually changed.
-  // getStateAsset's create-on-miss behaviour can otherwise grow state.json
-  // with empty {base_denom} records every run, producing a dirty working tree
-  // even when no real lifecycle decision happened.
+  // Combined with the findStateAsset / materialiseStateAsset split below,
+  // this guarantees state.json is only rewritten when a real lifecycle
+  // decision happened (not just an iteration).
   const zoneBefore = JSON.stringify(zoneData);
   const stateBefore = JSON.stringify(state);
 
@@ -144,7 +155,15 @@ async function main() {
     const zoneAsset = zoneByOrigin.get(zoneKey);
     if (!zoneAsset) continue;
 
-    const stateAsset = getStateAsset(state, asset.coinMinimalDenom);
+    // Read-only lookup; never creates a placeholder. We only materialise the
+    // entry on the exact lines that write to it, so state.json doesn't drift
+    // every run.
+    let stateAsset = findStateAsset(state, asset.coinMinimalDenom);
+    const writeState = () => {
+      if (!stateAsset) stateAsset = materialiseStateAsset(state, asset.coinMinimalDenom);
+      return stateAsset;
+    };
+
     const market = numia.get(asset.coinMinimalDenom);
     const marketMissing = !market;
     const failing =
@@ -166,8 +185,8 @@ async function main() {
       // check_ibc_clients's canModifyUnstable().
       if (zoneAsset.tooltip_message) continue;
       if (failing) {
-        const streak = (stateAsset.marketHealthStreak ?? 0) + 1;
-        stateAsset.marketHealthStreak = streak;
+        const streak = (stateAsset?.marketHealthStreak ?? 0) + 1;
+        writeState().marketHealthStreak = streak;
         if (streak >= REQUIRED_CONSECUTIVE_RUNS) {
           zoneAsset.osmosis_unstable = true;
           zoneAsset.osmosis_unstable_reason = 'market';
@@ -179,7 +198,7 @@ async function main() {
           mutations.push({ kind: 'streak_increment', asset: asset.symbol, streak });
         }
       } else if (passing) {
-        if (stateAsset.marketHealthStreak) {
+        if (stateAsset?.marketHealthStreak) {
           stateAsset.marketHealthStreak = 0;
           mutations.push({ kind: 'streak_reset', asset: asset.symbol });
         }
@@ -187,8 +206,8 @@ async function main() {
     } else if (zoneAsset.osmosis_unstable_reason === 'market') {
       // ── Currently market-unstable: track recovery ──
       if (passing) {
-        const rstreak = (stateAsset.marketHealthRecoveryStreak ?? 0) + 1;
-        stateAsset.marketHealthRecoveryStreak = rstreak;
+        const rstreak = (stateAsset?.marketHealthRecoveryStreak ?? 0) + 1;
+        writeState().marketHealthRecoveryStreak = rstreak;
 
         // 1-day clear of extended-market-driven halt
         if (
@@ -206,8 +225,8 @@ async function main() {
         }
 
         // Full recovery clears osmosis_unstable. Guarded by reason==='market'
-        // (above, line 186) AND tooltip_message empty here, mirroring the
-        // setting-path curator-lock contract.
+        // (above) AND tooltip_message empty here, mirroring the setting-path
+        // curator-lock contract.
         if (
           rstreak >= RECOVERY_RUNS_TO_CLEAR_UNSTABLE &&
           !zoneAsset.tooltip_message
@@ -221,7 +240,7 @@ async function main() {
           mutations.push({ kind: 'market_recovered', asset: asset.symbol, chain: asset.chainName });
         }
       } else if (failing) {
-        if (stateAsset.marketHealthRecoveryStreak) {
+        if (stateAsset?.marketHealthRecoveryStreak) {
           stateAsset.marketHealthRecoveryStreak = 0;
           mutations.push({ kind: 'recovery_reset', asset: asset.symbol });
         }

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -1,0 +1,271 @@
+// Purpose:
+//   Independent market-health track. Daily cron. For each verified non-disabled
+//   asset that isn't already unstable, run a market-health check; on 7 consecutive
+//   failing daily runs, flag it unstable with reason="market" and stamp
+//   state.lastDowntimeDate. Owns recovery for market-unstable assets too:
+//     • 1 consecutive passing run → clear osmosis_halt_deposits if reason
+//       is extended_unstable_market (and no tooltip).
+//     • 7 consecutive passing runs → clear osmosis_unstable AND wipe state
+//       history fields, only if osmosis_unstable_reason === "market".
+//
+//   Reason-vocabulary contract: this script owns reasons {market}.
+//
+// Usage:
+//   node check_market_health.mjs [<zone_name>] [--dry-run] [--force]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const LOW_LIQUIDITY_USD = 1000;        // matches MIN_LIQUIDITY_USD elsewhere
+const LOW_VOLUME_24H_USD = 100;
+const REQUIRED_CONSECUTIVE_RUNS = 7;
+const RECOVERY_RUNS_TO_CLEAR_UNSTABLE = 7;
+// Post-listing grace period: assets within this window from their listing
+// date don't accumulate streak.
+const GRACE_DAYS = 23;
+const GRACE_MS = GRACE_DAYS * 24 * 60 * 60 * 1000;
+// Sentinel listing date used for assets without one (legacy assets).
+const LEGACY_LISTING_DATE = '2022-01-01T00:00:00.000Z';
+
+const MAX_CHAINS_PER_RUN = 10;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
+
+async function fetchNumia() {
+  const res = await fetch(NUMIA_TOKENS_URL);
+  if (!res.ok) {
+    throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+  }
+  const data = await res.json();
+  const byDenom = new Map();
+  for (const t of data) {
+    if (!t.denom) continue;
+    byDenom.set(t.denom, {
+      liquidity: Number(t.liquidity ?? 0),
+      // Try several plausible field names; default to 0 if absent.
+      volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+    });
+  }
+  return byDenom;
+}
+
+function loadJSON(p, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT' && fallback !== undefined) return fallback;
+    throw err;
+  }
+}
+
+function getStateAsset(state, baseDenom) {
+  if (!state.assets) state.assets = [];
+  let s = state.assets.find((a) => a.base_denom === baseDenom);
+  if (!s) {
+    s = { base_denom: baseDenom };
+    state.assets.push(s);
+  }
+  return s;
+}
+
+function isAlloyed(asset) {
+  return (
+    /\/alloyed\//.test(asset.coinMinimalDenom ?? '') ||
+    asset.isAlloyed === true
+  );
+}
+
+function isPostGrace(stateAsset, nowMs) {
+  const listingDate = stateAsset.listingDate ?? (stateAsset.legacyAsset ? LEGACY_LISTING_DATE : null);
+  if (!listingDate) return true; // unknown → behave post-grace (conservative)
+  return nowMs - new Date(listingDate).getTime() >= GRACE_MS;
+}
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+
+  // Index frontend by coinMinimalDenom; that's our join key.
+  const frontendByDenom = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
+  }
+
+  // Index zone by (chain_name, base_denom), the canonical join into zone_assets.
+  // Each zone_asset's coinMinimalDenom is computed during generate; we'll match
+  // via the frontend's existing coinMinimalDenom -> zone_asset chain_name+base_denom join.
+  const zoneByOrigin = new Map();
+  for (const a of zoneData.assets) {
+    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
+  }
+
+  const numia = await fetchNumia();
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+  const mutations = [];
+
+  for (const asset of frontendData.assets ?? []) {
+    if (!asset.verified) continue;
+    if (isAlloyed(asset)) continue;
+    if (asset.disabled) continue;
+    if (asset.preview) continue;
+
+    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
+    const zoneAsset = zoneByOrigin.get(zoneKey);
+    if (!zoneAsset) continue;
+
+    const stateAsset = getStateAsset(state, asset.coinMinimalDenom);
+    const market = numia.get(asset.coinMinimalDenom);
+    const marketMissing = !market;
+    const failing =
+      !marketMissing &&
+      market.liquidity < LOW_LIQUIDITY_USD &&
+      market.volume24h < LOW_VOLUME_24H_USD;
+    const passing = !marketMissing && !failing;
+
+    if (marketMissing) {
+      mutations.push({ kind: 'market_missing', asset: asset.symbol, denom: asset.coinMinimalDenom });
+      continue; // don't accumulate streak when we have no data
+    }
+
+    if (!zoneAsset.osmosis_unstable) {
+      // ── Not currently unstable: count failing-streak toward flagging ──
+      if (!isPostGrace(stateAsset, nowMs)) continue;
+      if (failing) {
+        const streak = (stateAsset.marketHealthStreak ?? 0) + 1;
+        stateAsset.marketHealthStreak = streak;
+        if (streak >= REQUIRED_CONSECUTIVE_RUNS) {
+          zoneAsset.osmosis_unstable = true;
+          zoneAsset.osmosis_unstable_reason = 'market';
+          stateAsset.lastDowntimeDate = nowIso;
+          stateAsset.marketHealthStreak = 0;
+          mutations.push({ kind: 'market_flagged', asset: asset.symbol, chain: asset.chainName });
+        } else {
+          // Informational only; not counted toward the mutation cap.
+          mutations.push({ kind: 'streak_increment', asset: asset.symbol, streak });
+        }
+      } else if (passing) {
+        if (stateAsset.marketHealthStreak) {
+          stateAsset.marketHealthStreak = 0;
+          mutations.push({ kind: 'streak_reset', asset: asset.symbol });
+        }
+      }
+    } else if (zoneAsset.osmosis_unstable_reason === 'market') {
+      // ── Currently market-unstable: track recovery ──
+      if (passing) {
+        const rstreak = (stateAsset.marketHealthRecoveryStreak ?? 0) + 1;
+        stateAsset.marketHealthRecoveryStreak = rstreak;
+
+        // 1-day clear of extended-market-driven halt
+        if (
+          rstreak === 1 &&
+          zoneAsset.osmosis_halt_deposits === true &&
+          zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
+          !zoneAsset.tooltip_message
+        ) {
+          delete zoneAsset.osmosis_halt_deposits;
+          delete zoneAsset.osmosis_deposit_halt_reason;
+          mutations.push({ kind: 'extended_halt_cleared', asset: asset.symbol });
+        }
+
+        if (rstreak >= RECOVERY_RUNS_TO_CLEAR_UNSTABLE) {
+          // Full recovery, only safe to do here because reason is "market"
+          delete zoneAsset.osmosis_unstable;
+          delete zoneAsset.osmosis_unstable_reason;
+          delete stateAsset.lastDowntimeDate;
+          delete stateAsset.lastRecoveryDate;
+          delete stateAsset.marketHealthStreak;
+          delete stateAsset.marketHealthRecoveryStreak;
+          mutations.push({ kind: 'market_recovered', asset: asset.symbol, chain: asset.chainName });
+        }
+      } else if (failing) {
+        if (stateAsset.marketHealthRecoveryStreak) {
+          stateAsset.marketHealthRecoveryStreak = 0;
+          mutations.push({ kind: 'recovery_reset', asset: asset.symbol });
+        }
+      }
+    }
+    // If unstable but reason !== "market", this script does nothing; the flag
+    // is owned by check_ibc_clients or manual.
+  }
+
+  // ── Mutation cap (per source chain) ─────────────────────────────────────────
+  // streak_increment / streak_reset / recovery_reset / market_missing are
+  // informational; they don't write halt or unstable flags.
+  const INFO_KINDS = new Set(['streak_increment', 'streak_reset', 'recovery_reset', 'market_missing']);
+  const affectedChains = new Set(
+    mutations
+      .filter((m) => m.chain && !INFO_KINDS.has(m.kind))
+      .map((m) => m.chain)
+  );
+  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
+    console.error(
+      `\n⛔ Mutation cap exceeded: would touch ${affectedChains.size} chains ` +
+      `(threshold ${MAX_CHAINS_PER_RUN}). Re-run with --force or --dry-run.`
+    );
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `market_health_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Market-health dry-run, ${nowIso}`,
+      ``,
+      `Mutations: ${mutations.length}`,
+      `Distinct source chains affected: ${affectedChains.size}`,
+      ``,
+      `| Kind | Asset | Chain |`,
+      `|------|-------|-------|`,
+    ];
+    for (const m of mutations) {
+      lines.push(`| ${m.kind} | ${m.asset ?? '-'} | ${m.chain ?? '-'} |`);
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    return;
+  }
+
+  if (mutations.length > 0) {
+    fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+    console.log(`✓ Updated ${statePath}`);
+  } else {
+    console.log('No changes needed.');
+  }
+
+  const byKind = {};
+  for (const m of mutations) byKind[m.kind] = (byKind[m.kind] || 0) + 1;
+  console.log('\n' + '='.repeat(70));
+  console.log('  MARKET-HEALTH SUMMARY');
+  console.log('='.repeat(70));
+  for (const [k, v] of Object.entries(byKind)) {
+    console.log(`  ${k.padEnd(28)}: ${v}`);
+  }
+  console.log(`  distinct chains touched   : ${affectedChains.size}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_unverify_candidates.mjs
+++ b/.github/workflows/utility/check_unverify_candidates.mjs
@@ -1,0 +1,181 @@
+// Purpose:
+//   Weekly check (Monday 16:00 UTC) for assets that have been continuously
+//   unstable for 90+ days. For each such asset, propose flipping
+//   osmosis_verified=false via a single PR. 30-day cooldown via
+//   state.lastUnverifyProposedAt prevents weekly re-proposal.
+//
+//   The script:
+//     1. Computes candidates.
+//     2. If --propose (default in CI), mutates zone_assets.json setting
+//        osmosis_verified=false for each, stamps state.lastUnverifyProposedAt,
+//        and writes a PR body markdown to generated/reports/.
+//     3. The calling workflow then uses peter-evans/create-pull-request to
+//        open/update the PR on a fixed branch (auto-unverify/weekly-candidates).
+//
+//   On merge, only osmosis_verified flips. osmosis_unstable + state history
+//   fields stay as record.
+//
+// Usage:
+//   node check_unverify_candidates.mjs [<zone_name>] [--dry-run] [--propose]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const propose = args.includes('--propose');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
+
+async function fetchNumia() {
+  try {
+    const res = await fetch(NUMIA_TOKENS_URL);
+    if (!res.ok) return new Map();
+    const data = await res.json();
+    const byDenom = new Map();
+    for (const t of data) {
+      if (!t.denom) continue;
+      byDenom.set(t.denom, {
+        liquidity: Number(t.liquidity ?? 0),
+        volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+      });
+    }
+    return byDenom;
+  } catch {
+    // Numia is non-critical here; we only use it for PR body enrichment.
+    return new Map();
+  }
+}
+
+function loadJSON(p, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT' && fallback !== undefined) return fallback;
+    throw err;
+  }
+}
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+
+  const zoneByOrigin = new Map();
+  for (const a of zoneData.assets) {
+    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
+  }
+
+  const stateByDenom = new Map();
+  for (const a of state.assets ?? []) {
+    stateByDenom.set(a.base_denom, a);
+  }
+
+  const numia = await fetchNumia();
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+  const candidates = [];
+
+  for (const asset of frontendData.assets ?? []) {
+    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
+    const zoneAsset = zoneByOrigin.get(zoneKey);
+    if (!zoneAsset) continue;
+    if (zoneAsset.osmosis_verified !== true) continue;
+    if (zoneAsset.osmosis_unstable !== true) continue;
+
+    const stateAsset = stateByDenom.get(asset.coinMinimalDenom);
+    if (!stateAsset?.lastDowntimeDate) continue;
+
+    const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
+    if (downtimeMs < NINETY_DAYS_MS) continue;
+
+    // Cooldown
+    if (stateAsset.lastUnverifyProposedAt) {
+      const elapsed = nowMs - new Date(stateAsset.lastUnverifyProposedAt).getTime();
+      if (elapsed < COOLDOWN_MS) continue;
+    }
+
+    const market = numia.get(asset.coinMinimalDenom);
+    candidates.push({
+      chain: asset.chainName,
+      symbol: asset.symbol,
+      baseDenom: asset.coinMinimalDenom,
+      daysUnstable: Math.floor(downtimeMs / (24 * 60 * 60 * 1000)),
+      reason: zoneAsset.osmosis_unstable_reason ?? '?',
+      lastDowntimeDate: stateAsset.lastDowntimeDate,
+      lastRecoveryDate: stateAsset.lastRecoveryDate ?? '',
+      liquidity: market?.liquidity ?? '?',
+      volume24h: market?.volume24h ?? '?',
+      haltDeposits: zoneAsset.osmosis_halt_deposits === true,
+      haltWithdrawals: zoneAsset.osmosis_halt_withdrawals === true,
+      zoneAsset,
+      stateAsset,
+    });
+  }
+
+  // PR body markdown
+  const prBodyLines = [
+    `## Unverify candidates (90-day unstable threshold)`,
+    ``,
+    `Generated: ${nowIso}`,
+    ``,
+    `${candidates.length} asset(s) have been continuously unstable for 90+ days. ` +
+    `This PR proposes flipping \`osmosis_verified\` to \`false\` for each.`,
+    ``,
+    `On merge, only \`osmosis_verified\` flips. \`osmosis_unstable\` and the ` +
+    `state.json history fields are preserved as record.`,
+    ``,
+    `| Chain | Symbol | Base denom | Days unstable | Reason | Last downtime | Last recovery | Liquidity | Vol 24h | Halt D | Halt W |`,
+    `|-------|--------|-----------|--------------|--------|---------------|---------------|-----------|---------|--------|--------|`,
+  ];
+  for (const c of candidates) {
+    prBodyLines.push(
+      `| ${c.chain} | ${c.symbol} | \`${c.baseDenom}\` | ${c.daysUnstable} | ${c.reason} | ${c.lastDowntimeDate} | ${c.lastRecoveryDate} | ${c.liquidity} | ${c.volume24h} | ${c.haltDeposits ? '✓' : ''} | ${c.haltWithdrawals ? '✓' : ''} |`
+    );
+  }
+
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const reportPath = path.join(reportsDir, 'unverify_candidates_pr_body.md');
+  fs.writeFileSync(reportPath, prBodyLines.join('\n') + '\n', 'utf8');
+
+  console.log(`\n📝 PR body: ${reportPath} (${candidates.length} candidates)`);
+
+  if (dryRun || !propose) {
+    return;
+  }
+
+  if (candidates.length === 0) {
+    console.log('No candidates; nothing to propose.');
+    return;
+  }
+
+  // Flip osmosis_verified=false and stamp cooldown
+  for (const c of candidates) {
+    c.zoneAsset.osmosis_verified = false;
+    c.stateAsset.lastUnverifyProposedAt = nowIso;
+  }
+
+  fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  console.log(`✓ Wrote ${candidates.length} unverify proposals.`);
+  console.log(`✓ Stamped state.lastUnverifyProposedAt for cooldown.`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_unverify_candidates.mjs
+++ b/.github/workflows/utility/check_unverify_candidates.mjs
@@ -147,6 +147,14 @@ async function main() {
     );
   }
 
+  if (candidates.length === 0) {
+    console.log('No candidates; nothing to propose.');
+    // Intentionally skip writing the PR body file. The weekly workflow gates
+    // PR creation on the file's existence, so suppressing it here keeps the
+    // workflow silent on quiet weeks (no empty "0 candidates" PR noise).
+    return;
+  }
+
   fs.mkdirSync(reportsDir, { recursive: true });
   const reportPath = path.join(reportsDir, 'unverify_candidates_pr_body.md');
   fs.writeFileSync(reportPath, prBodyLines.join('\n') + '\n', 'utf8');
@@ -154,11 +162,6 @@ async function main() {
   console.log(`\n📝 PR body: ${reportPath} (${candidates.length} candidates)`);
 
   if (dryRun || !propose) {
-    return;
-  }
-
-  if (candidates.length === 0) {
-    console.log('No candidates; nothing to propose.');
     return;
   }
 

--- a/.github/workflows/utility/check_unverify_candidates.mjs
+++ b/.github/workflows/utility/check_unverify_candidates.mjs
@@ -2,7 +2,7 @@
 //   Bi-weekly check (1st & 15th of each month, 16:00 UTC) for assets continuously
 //   unstable for 90+ days. For each such asset, propose flipping
 //   osmosis_verified=false via a single PR. 30-day cooldown via
-//   state.lastUnverifyProposedAt prevents weekly re-proposal.
+//   state.lastUnverifyProposedAt prevents re-proposal within 30 days.
 //
 //   The script:
 //     1. Computes candidates.
@@ -164,7 +164,7 @@ async function main() {
 
   if (candidates.length === 0) {
     console.log('No candidates; nothing to propose.');
-    // Intentionally skip writing the PR body file. The weekly workflow gates
+    // Intentionally skip writing the PR body file. The bi-weekly workflow gates
     // PR creation on the file's existence, so suppressing it here keeps the
     // workflow silent on quiet weeks (no empty "0 candidates" PR noise).
     return;

--- a/.github/workflows/utility/check_unverify_candidates.mjs
+++ b/.github/workflows/utility/check_unverify_candidates.mjs
@@ -1,5 +1,5 @@
 // Purpose:
-//   Weekly check (Monday 16:00 UTC) for assets that have been continuously
+//   Bi-weekly check (1st & 15th of each month, 16:00 UTC) for assets continuously
 //   unstable for 90+ days. For each such asset, propose flipping
 //   osmosis_verified=false via a single PR. 30-day cooldown via
 //   state.lastUnverifyProposedAt prevents weekly re-proposal.
@@ -20,6 +20,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { calculateIbcHash } from './assetlist_functions.mjs';
 
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
@@ -40,8 +41,11 @@ const reportsDir = path.join(zonePath, 'generated', 'reports');
 const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
 
 async function fetchNumia() {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
   try {
-    const res = await fetch(NUMIA_TOKENS_URL);
+    const res = await fetch(NUMIA_TOKENS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
     if (!res.ok) return new Map();
     const data = await res.json();
     const byDenom = new Map();
@@ -54,6 +58,7 @@ async function fetchNumia() {
     }
     return byDenom;
   } catch {
+    clearTimeout(timeoutId);
     // Numia is non-critical here; we only use it for PR body enrichment.
     return new Map();
   }
@@ -73,14 +78,17 @@ async function main() {
   const frontendData = loadJSON(frontendPath);
   const state = loadJSON(statePath, { assets: [] });
 
-  const zoneByOrigin = new Map();
-  for (const a of zoneData.assets) {
-    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
-  }
-
   const stateByDenom = new Map();
   for (const a of state.assets ?? []) {
     stateByDenom.set(a.base_denom, a);
+  }
+
+  // Frontend index by coinMinimalDenom for cheap metadata lookup (symbol etc).
+  // Killed-chain assets won't appear here but will still be evaluated via
+  // zone_assets iteration below.
+  const frontendByDenom = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
   }
 
   const numia = await fetchNumia();
@@ -89,14 +97,20 @@ async function main() {
   const nowMs = new Date(nowIso).getTime();
   const candidates = [];
 
-  for (const asset of frontendData.assets ?? []) {
-    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
-    const zoneAsset = zoneByOrigin.get(zoneKey);
-    if (!zoneAsset) continue;
+  // Iterate zone_assets directly so we cover killed-chain assets whose
+  // generator output disappeared. Compute coinMinimalDenom via the same IBC
+  // hash the generator uses.
+  for (const zoneAsset of zoneData.assets) {
+    if (!zoneAsset.path) continue; // non-IBC entries not handled here
     if (zoneAsset.osmosis_verified !== true) continue;
     if (zoneAsset.osmosis_unstable !== true) continue;
+    // Curator lock: a non-empty tooltip_message means the curator owns this
+    // asset; don't propose unverification. Unverify is a heavier action than
+    // a halt flip, and the lock contract should apply just as much here.
+    if (zoneAsset.tooltip_message) continue;
 
-    const stateAsset = stateByDenom.get(asset.coinMinimalDenom);
+    const coinMinimalDenom = await calculateIbcHash(zoneAsset.path);
+    const stateAsset = stateByDenom.get(coinMinimalDenom);
     if (!stateAsset?.lastDowntimeDate) continue;
 
     const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
@@ -108,11 +122,12 @@ async function main() {
       if (elapsed < COOLDOWN_MS) continue;
     }
 
-    const market = numia.get(asset.coinMinimalDenom);
+    const feAsset = frontendByDenom.get(coinMinimalDenom);
+    const market = numia.get(coinMinimalDenom);
     candidates.push({
-      chain: asset.chainName,
-      symbol: asset.symbol,
-      baseDenom: asset.coinMinimalDenom,
+      chain: zoneAsset.chain_name,
+      symbol: feAsset?.symbol ?? zoneAsset._comment ?? zoneAsset.base_denom,
+      baseDenom: coinMinimalDenom,
       daysUnstable: Math.floor(downtimeMs / (24 * 60 * 60 * 1000)),
       reason: zoneAsset.osmosis_unstable_reason ?? '?',
       lastDowntimeDate: stateAsset.lastDowntimeDate,

--- a/.github/workflows/utility/generate_assetlist.mjs
+++ b/.github/workflows/utility/generate_assetlist.mjs
@@ -343,6 +343,7 @@ const generateAssets = async (
     assetlist.setVerifiedStatus(asset_data);
     assetlist.setUnstableStatus(asset_data);
     assetlist.setDisabledStatus(asset_data);
+    assetlist.setHaltStatus(asset_data);
     assetlist.setPreviewStatus(asset_data);
     assetlist.setPrice(asset_data, pool_data);
     assetlist.setListingDate(asset_data);

--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -1229,12 +1229,23 @@ export function setVerifiedStatus(asset_data) {
 export function setUnstableStatus(asset_data) {
 
   asset_data.frontend.unstable = asset_data.zone_asset?.osmosis_unstable;
+  asset_data.frontend.unstableReason = asset_data.zone_asset?.osmosis_unstable_reason;
 
 }
 
 export function setDisabledStatus(asset_data) {
 
   asset_data.frontend.disabled = asset_data.zone_asset?.osmosis_disabled;
+
+}
+
+export function setHaltStatus(asset_data) {
+
+  asset_data.frontend.haltDeposits = asset_data.zone_asset?.osmosis_halt_deposits;
+  asset_data.frontend.depositHaltReason = asset_data.zone_asset?.osmosis_deposit_halt_reason;
+  asset_data.frontend.haltWithdrawals = asset_data.zone_asset?.osmosis_halt_withdrawals;
+  asset_data.frontend.withdrawalHaltReason = asset_data.zone_asset?.osmosis_withdrawal_halt_reason;
+  asset_data.frontend.plannedShutdownDate = asset_data.zone_asset?.planned_shutdown_date;
 
 }
 
@@ -1866,13 +1877,37 @@ export function reformatFrontendAssetFromAssetData(asset_data) {
     contract: asset_data.frontend.contract,
     verified: asset_data.frontend.verified ?? false,
     unstable: asset_data.frontend.unstable ?? false,
+    unstableReason: asset_data.frontend.unstableReason,
     disabled: asset_data.frontend.disabled ?? false,
+    haltDeposits: asset_data.frontend.haltDeposits,
+    depositHaltReason: asset_data.frontend.depositHaltReason,
+    haltWithdrawals: asset_data.frontend.haltWithdrawals,
+    withdrawalHaltReason: asset_data.frontend.withdrawalHaltReason,
+    plannedShutdownDate: asset_data.frontend.plannedShutdownDate,
+    lastDowntimeDate: asset_data.frontend.lastDowntimeDate,
+    lastRecoveryDate: asset_data.frontend.lastRecoveryDate,
     preview: asset_data.frontend.preview ?? false,
     tooltipMessage: asset_data.frontend.tooltipMessage,
     sortWith: asset_data.frontend.sortWith,
     listingDate: asset_data.frontend.listingDate,
     //relatedAssets: asset_data.frontend.relatedAssets,
   };
+
+  // Drop optional fields that are undefined or falsy so they don't appear
+  // as null/false placeholders in the output JSON. The frontend defaults
+  // each of these to false/undefined when absent.
+  for (const k of [
+    "unstableReason",
+    "haltDeposits",
+    "depositHaltReason",
+    "haltWithdrawals",
+    "withdrawalHaltReason",
+    "plannedShutdownDate",
+    "lastDowntimeDate",
+    "lastRecoveryDate",
+  ]) {
+    if (!reformattedAsset[k]) delete reformattedAsset[k];
+  }
 
   if (isNaN(asset_data.frontend.listingDate?.getTime())) {
     // Remove listing_date if it's null
@@ -1907,7 +1942,15 @@ export function reformatFrontendAsset(asset) {
     contract: asset.contract,
     verified: asset.verified ?? false,
     unstable: asset.unstable ?? false,
+    unstableReason: asset.unstableReason,
     disabled: asset.disabled ?? false,
+    haltDeposits: asset.haltDeposits,
+    depositHaltReason: asset.depositHaltReason,
+    haltWithdrawals: asset.haltWithdrawals,
+    withdrawalHaltReason: asset.withdrawalHaltReason,
+    plannedShutdownDate: asset.plannedShutdownDate,
+    lastDowntimeDate: asset.lastDowntimeDate,
+    lastRecoveryDate: asset.lastRecoveryDate,
     preview: asset.preview ?? false,
     tooltipMessage: asset.tooltipMessage,
     sortWith: asset.sortWith,

--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -1964,6 +1964,22 @@ export function reformatFrontendAsset(asset) {
     delete reformattedAsset.listingDate;
   }
 
+  // Drop optional lifecycle fields that are undefined or falsy. Matches the
+  // behaviour of reformatFrontendAssetFromAssetData; kept in sync so future
+  // edits to either copy stay consistent.
+  for (const k of [
+    "unstableReason",
+    "haltDeposits",
+    "depositHaltReason",
+    "haltWithdrawals",
+    "withdrawalHaltReason",
+    "plannedShutdownDate",
+    "lastDowntimeDate",
+    "lastRecoveryDate",
+  ]) {
+    if (!reformattedAsset[k]) delete reformattedAsset[k];
+  }
+
   asset = reformattedAsset;
   return;
 

--- a/.github/workflows/utility/update_assetlist_state.mjs
+++ b/.github/workflows/utility/update_assetlist_state.mjs
@@ -46,8 +46,29 @@ const stateLocations = [
 ];
 const stateAssetProperties = [
   "listingDate",
-  "legacyAsset"
+  "legacyAsset",
+  // New lifecycle fields (see "Graceful Shutdown of Asset Listings" plan).
+  // All ISO UTC strings unless noted.
+  "lastDowntimeDate",       // anchors the 60/90-day lifecycle clock
+  "lastRecoveryDate",       // when the bridge/market last recovered
+  "marketHealthStreak",     // consecutive failing market-check runs (numeric)
+  "marketHealthRecoveryStreak", // consecutive passing runs while currently unstable
+  "lastUnverifyProposedAt"  // last time check_unverify_candidates opened a PR
 ];
+
+/**
+ * Bidirectional-sync helper: copy a set of state-managed dates onto the
+ * generated assetlist asset so the frontend can read them.
+ * Mirrors the existing setAssetListingDate pattern.
+ */
+function syncStateFieldsToAssetlist(stateAsset, assetlistAsset) {
+  if (stateAsset.lastDowntimeDate) {
+    assetlistAsset.lastDowntimeDate = stateAsset.lastDowntimeDate;
+  }
+  if (stateAsset.lastRecoveryDate) {
+    assetlistAsset.lastRecoveryDate = stateAsset.lastRecoveryDate;
+  }
+}
 
 const currentDateUTC = new Date().toISOString();
 
@@ -143,7 +164,7 @@ function setAssetListingDate(stateAsset, assetlistAsset) {
  * getStateAsset("ibc/NEW...", state)
  * // Returns: { base_denom: "ibc/NEW..." } (newly created, added to state.assets)
  */
-function getStateAsset(base_denom, state) {
+export function getStateAsset(base_denom, state) {
   let stateAsset = state.assets?.find(stateAsset => stateAsset.base_denom === base_denom);
   if (!stateAsset) {
     stateAsset = {
@@ -227,19 +248,21 @@ const generateState = (chainName, assetlist) => {
 
     let stateAsset;
 
-    //see if it's verified, and skip if not
+    //see if it's verified, and skip listing-date logic if not
     if (assetlistAsset.verified) {
-
-      //get the state asset
       stateAsset = getStateAsset(assetlistAsset.coinMinimalDenom, state);
-
-      // Property 1: Get the listing Date
       setAssetListingDate(stateAsset, assetlistAsset);
+    }
 
-
-      // Property 2: anything else...
-
-
+    // Sync lifecycle fields (downtime/recovery dates) onto the assetlist for
+    // both verified and unverified assets, since the frontend banner needs them
+    // even on unverified entries that crossed the 90-day threshold and got
+    // unverified but still carry historical context.
+    const existingState = state.assets?.find(
+      s => s.base_denom === assetlistAsset.coinMinimalDenom
+    );
+    if (existingState) {
+      syncStateFieldsToAssetlist(existingState, assetlistAsset);
     }
 
   }

--- a/.github/workflows/utility/update_assetlist_state.mjs
+++ b/.github/workflows/utility/update_assetlist_state.mjs
@@ -44,17 +44,21 @@ const stateDir = path.join(zone.generatedDirectoryName, stateDirName);
 const stateLocations = [
   "assets"
 ];
-const stateAssetProperties = [
-  "listingDate",
-  "legacyAsset",
-  // New lifecycle fields (see "Graceful Shutdown of Asset Listings" plan).
-  // All ISO UTC strings unless noted.
-  "lastDowntimeDate",       // anchors the 60/90-day lifecycle clock
-  "lastRecoveryDate",       // when the bridge/market last recovered
-  "marketHealthStreak",     // consecutive failing market-check runs (numeric)
-  "marketHealthRecoveryStreak", // consecutive passing runs while currently unstable
-  "lastUnverifyProposedAt"  // last time check_unverify_candidates opened a PR
-];
+/**
+ * Documentation only. Fields tracked on each state.assets[] entry:
+ *
+ *   listingDate                   ISO UTC; existing, date asset was first verified
+ *   legacyAsset                   existing, true if verified before state tracking
+ *
+ *   lastDowntimeDate              ISO UTC; anchors the 60/90-day lifecycle clock
+ *   lastRecoveryDate              ISO UTC; when the bridge/market last recovered
+ *   marketHealthStreak            numeric; consecutive failing market-check runs
+ *   marketHealthRecoveryStreak    numeric; consecutive passing runs while unstable
+ *   lastUnverifyProposedAt        ISO UTC; last time check_unverify_candidates opened a PR
+ *
+ * Indexed by base_denom (which is coinMinimalDenom on Osmosis, e.g. uosmo or ibc/...).
+ * See "Graceful Shutdown of Asset Listings" plan for the lifecycle contract.
+ */
 
 /**
  * Bidirectional-sync helper: copy a set of state-managed dates onto the

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ new-chains.txt
 newly-verified.txt
 validation-summary.md
 workflow-summary.md
+
+# Local-only artifacts emitted by lifecycle check scripts in dry-run mode
+# and by manual workflow_dispatch runs of asset_status_report.mjs.
+osmosis-1/generated/reports/
+osmo-test-5/generated/reports/
+
+# Local-only output from the inlang localization pipeline; not tracked.
+language_files/

--- a/README.md
+++ b/README.md
@@ -116,14 +116,36 @@ Each asset object in _osmosis.zone_assets.json_ must include these identifying d
 
 #### Transfer & Reliability Flags
 
-- **`osmosis_unstable`** (boolean, default: `false`) - Indicates the asset **cannot reliably** be transferred to or from Osmosis.
-  - **Frontend Behavior**: Sets `unstable: true` in generated assetlist — displays a warning indicator on the asset
-  - **Common Causes**: Expired or frozen IBC client, unreliable relayers, frequent chain downtime
-  - **When to Remove**: After confirming the IBC channel is active and transfers work reliably
+Four orthogonal states describe an asset's transfer health. Each has a distinct UX and is owned by a specific automated script (or the curator).
 
-- **`osmosis_disabled`** (boolean, default: `false`) - Explicitly disables the native IBC Deposit and Withdraw buttons.
-  - **Frontend Behavior**: Sets `disabled: true` in generated assetlist — disables native IBC Deposit/Withdraw buttons
-  - **Common Reasons**: Forcing use of an external or custom transfer method, security or liquidity concerns
+- **`osmosis_unstable`** (boolean, default: `false`). Warning-only indicator. Does not gate the deposit or withdraw flow; surfaces an alert-circle icon on the asset cell and a localised banner on the asset info page.
+  - **Frontend output**: `unstable: true`
+  - **Common causes**: IBC client unstable, source chain killed, sustained low liquidity/volume, manual flag set during an incident
+  - **Companion field**: `osmosis_unstable_reason` (enum, see below) drives the localised banner. The existing `tooltip_message` field is reused for curator free-text.
+
+- **`osmosis_unstable_reason`** (enum: `"ibc_client" | "source_chain_killed" | "market" | "manual"`). Closed-set reason for `osmosis_unstable`. Each value maps to a localised string in the frontend.
+  - **Owners**: `ibc_client` and `source_chain_killed` are owned by `check_ibc_clients.mjs`. `market` is owned by `check_market_health.mjs`. `manual` is the curator's escape hatch; automation never overwrites or clears it.
+
+- **`osmosis_disabled`** (boolean, default: `false`). Internal-deposit UX override. The native flow is skipped in favour of routing the user to an external provider (Skip, Squid, Composable, etc.). **Not** a kill switch; for that, use the halt flags below.
+  - **Frontend output**: `disabled: true`
+  - **Common reasons**: an asset that is only safely transferable through a partner UI (Composable PICA, Wormhole BTC, alloyed asset originators).
+
+- **`osmosis_halt_deposits`** (boolean, default: `false`). Kill switch for the **deposit** direction. The asset-page Deposit button is greyed; the bridge flow renders a "deposits halted" screen with no external-provider fallback. Withdrawals remain available unless `osmosis_halt_withdrawals` is also set.
+  - **Frontend output**: `haltDeposits: true`
+  - **Companion field**: `osmosis_deposit_halt_reason` drives the localised banner.
+
+- **`osmosis_deposit_halt_reason`** (enum: `"bridge_down" | "extended_unstable_market" | "planned_shutdown" | "source_chain_killed" | "manual"`).
+  - **Owners**: `bridge_down` and `source_chain_killed` are owned by `check_ibc_clients.mjs`. `extended_unstable_market` is owned by `check_market_health.mjs` and `check_extended_halts.mjs`. `planned_shutdown` is owned by `check_extended_halts.mjs`. `manual` is curator-only.
+
+- **`osmosis_halt_withdrawals`** (boolean, default: `false`). Kill switch for the **withdraw** direction.
+  - **Frontend output**: `haltWithdrawals: true`
+  - **Companion field**: `osmosis_withdrawal_halt_reason` (enum: `"bridge_down" | "source_chain_killed" | "manual"`).
+
+- **`planned_shutdown_date`** (string, ISO 8601 UTC, optional). Date when the asset is scheduled to be shut down. When the date is within 14 days, `check_extended_halts.mjs` pre-emptively sets `osmosis_halt_deposits=true` with reason `planned_shutdown`.
+
+**Tooltip override / curator lock.** The existing `tooltip_message` field doubles as the override signal for automation. If any asset has a non-empty `tooltip_message`, **no automated script will modify its halt or unstable flags** (the curator has taken ownership). Use this when you want to set a halt manually with bespoke context, or when you want to prevent the automated lifecycle from clearing a flag during recovery.
+
+**Reason-vocabulary contract.** Each automated script only modifies flags whose current reason value it owns (see "Owners" above). This means `check_ibc_clients` will never overwrite a `manual` halt or an `extended_unstable_market` halt that another script set. To release a manual override, clear `tooltip_message` and either set the reason back to one the relevant script owns, or remove the flag and let the script re-derive it on the next run.
 
 - **`transfer_methods`** (array) - Custom transfer configurations for assets requiring special handling.
   - Should be included whenever basic IBC transfer cannot carry out an interchain transfer
@@ -211,7 +233,7 @@ For complete schema definitions, see `zone_assets.schema.json`.
 ```
 **Result**: Visible only with "Show Unverified Assets" toggle, native IBC works.
 
-#### Scenario 3: Unreliable IBC - Needs External Interface
+#### Scenario 3: Asset with an unstable IBC channel (warning only)
 ```json
 {
   "chain_name": "genesisl1",
@@ -219,12 +241,13 @@ For complete schema definitions, see `zone_assets.schema.json`.
   "path": "transfer/channel-253/el1",
   "osmosis_verified": false,
   "osmosis_unstable": true,
+  "osmosis_unstable_reason": "ibc_client",
   "_comment": "GenesisL1 $L1"
 }
 ```
-**Result**: Warning indicator shown on asset. Add `osmosis_disabled: true` to also disable native IBC buttons.
+**Result**: Warning indicator (alert-circle icon) shown next to the asset symbol. Both deposit and withdraw flows still work; the frontend renders a localised banner explaining the cause. Typically auto-set by `check_ibc_clients.mjs`.
 
-**To enable native IBC**: Remove `osmosis_unstable` after confirming channels work reliably.
+**To enable native IBC fully**: `check_ibc_clients.mjs` clears `osmosis_unstable` automatically once both IBC clients are Active again. To force-clear, remove the flag manually.
 
 #### Scenario 4: Asset with Custom Transfer Method
 ```json
@@ -246,7 +269,7 @@ For complete schema definitions, see `zone_assets.schema.json`.
 ```
 **Result**: Shows both native IBC and Squid Router options.
 
-#### Scenario 5: Intentionally Disabled Transfers
+#### Scenario 5: Asset routed via external provider only (`osmosis_disabled`)
 ```json
 {
   "chain_name": "composable",
@@ -264,27 +287,73 @@ For complete schema definitions, see `zone_assets.schema.json`.
   "_comment": "Picasso $PICA - use custom interface only"
 }
 ```
-**Result**: Native IBC disabled, shows only Picasso App transfer method.
+**Result**: Native flow is skipped; user is routed straight to the Picasso App. **Both** deposit and withdraw still work, just via the external provider.
 
-### Decision Guide: Enabling Native IBC Transfers
+#### Scenario 6: Deposits halted, withdrawals still open
+```json
+{
+  "chain_name": "namada",
+  "base_denom": "unam",
+  "path": "transfer/channel-XXXX/unam",
+  "osmosis_verified": true,
+  "osmosis_halt_deposits": true,
+  "osmosis_deposit_halt_reason": "manual",
+  "tooltip_message": "Deposits paused pending Namada IBC v0.x release.",
+  "_comment": "Namada $NAM"
+}
+```
+**Result**: Deposit button greyed on every surface (asset page, portfolio, bridge). Bridge flow shows "Deposits halted" with the tooltip text. Withdrawals work normally. The `manual` reason + non-empty `tooltip_message` together lock the halt against any automation.
 
-**Question: Why isn't my asset showing native deposit/withdraw buttons?**
+#### Scenario 7: Asset halted in both directions (incident response)
+```json
+{
+  "chain_name": "examplehub",
+  "base_denom": "uex",
+  "path": "transfer/channel-XXXX/uex",
+  "osmosis_unstable": true,
+  "osmosis_unstable_reason": "manual",
+  "osmosis_halt_deposits": true,
+  "osmosis_deposit_halt_reason": "manual",
+  "osmosis_halt_withdrawals": true,
+  "osmosis_withdrawal_halt_reason": "manual",
+  "tooltip_message": "Exploit response, working with the team. Status: https://status.example.com",
+  "_comment": "Example $EX - halted"
+}
+```
+**Result**: All transfer flows blocked, banner explains the cause, automation leaves the asset alone until the curator clears the tooltip and reasons.
 
-Check your asset configuration for these flags:
+### Decision Guide: Choosing the right flag
 
-1. **`osmosis_disabled: true`** → This disables native IBC buttons
-   - **Solution**: Remove this flag if you want to enable native transfers
-   - Consider: Was this set for security/liquidity management? Verify it's safe to remove
+**Question: My asset's deposit/withdraw buttons are greyed (or missing). Why?**
 
-2. **`osmosis_unstable: true`** → This shows a warning indicator on the asset
-   - The asset may still have IBC buttons enabled unless `osmosis_disabled` is also set
-   - **Solution**: Remove this flag after confirming the IBC channel is active and reliable
+Check the asset entry in order:
 
-**Question: When should I use `osmosis_unstable` vs `osmosis_disabled`?**
+1. **`osmosis_halt_deposits: true`** or **`osmosis_halt_withdrawals: true`** → that direction is halted (kill switch).
+   - **Solution**: clear the flag and its `*_halt_reason`. If `tooltip_message` is set, clearing the reason isn't enough; also clear the tooltip, otherwise automation won't pick the asset back up.
+   - **Consider**: was this auto-set by `check_ibc_clients` / `check_extended_halts`? If so, the underlying cause needs to resolve first (bridge back up, market recovers) or `check_market_health` clears it on the next passing run.
 
-- **Use `osmosis_unstable`**: When the IBC channel has reliability problems (expired client, downtime, slow relayers) — shows a warning flag to users
-- **Use `osmosis_disabled`**: When you want to disable native IBC deposit/withdraw buttons, regardless of reliability
-- **Use both**: When you want to show a warning and disable the buttons
+2. **`osmosis_disabled: true`** → native flow is skipped; the user is sent to an external provider. The button is **not** greyed in this case; it still opens the bridge flow, but the flow renders the external-provider list rather than a native quote.
+   - **Solution**: remove the flag if a native path is now available.
+
+3. **`osmosis_unstable: true`** → warning indicator only. Buttons stay enabled. If they look greyed, check 1 first.
+
+**Question: Which flag should I use?**
+
+| Symptom | Flag(s) to set |
+|---|---|
+| Warn the user but allow transfers | `osmosis_unstable` + `osmosis_unstable_reason` |
+| Force the user to a partner UI for this asset | `osmosis_disabled` |
+| Block deposits, keep withdraws (e.g. broken inbound IBC, planned migration) | `osmosis_halt_deposits` + `osmosis_deposit_halt_reason` |
+| Block withdraws, keep deposits (rare) | `osmosis_halt_withdrawals` + `osmosis_withdrawal_halt_reason` |
+| Block both directions (incident response) | both halt flags + reasons |
+
+**Question: Will automation overwrite my manual changes?**
+
+No, as long as one of the following is true:
+- The reason is set to `"manual"`, or
+- `tooltip_message` is non-empty.
+
+Both serve as curator-lock signals. To hand the asset back to automation, clear the tooltip and either change the reason to one of the script-owned values or remove the flag entirely.
 
 ## Chains
 
@@ -440,12 +509,9 @@ The `Generate All Files` bundle workflow runs automatically and includes:
   - Creates minimal entries (chain_name + comment) for chains in `zone_assets.json` not yet in `zone_chains.json`
   - Makes it easy for maintainers to add custom RPC/REST endpoints later
   - All fields default to Chain Registry values unless explicitly overridden
-- Checks IBC client health for all IBC assets and automatically updates `osmosis_unstable` in `osmosis.zone_assets.json`
-  - Sources assets from the generated frontend assetlist (catches auto-detected assets with no zone_assets entry)
-  - Sets `osmosis_unstable: true` for assets whose Osmosis-side IBC client is Expired or Frozen; adds a minimal entry if none exists
-  - Clears `osmosis_unstable` only when **both** the Osmosis-side and counterparty-side clients are confirmed Active
-  - Removes auto-added minimal entries entirely when they recover (entries with no other meaningful fields)
-  - Runs before assetlist generation so the generated frontend output reflects correct flags in the same run
+- Runs the **bridge-state check** (`check_ibc_clients.mjs`): unified detection that drives both the IBC and killed-chain branches of the lifecycle (see "Asset lifecycle automation" below).
+- Runs the **market-health check** (`check_market_health.mjs`): independent unstable track driven by Numia liquidity/volume.
+- Runs the **extended-halts check** (`check_extended_halts.mjs`): 60-day deposit halt and planned-shutdown halt.
 - Validates RPC/REST endpoints for all chains (full validation, batched 10 at a time)
   - Tracks validation results in `state/state.json` for endpoint optimization
   - Reorders endpoints based on health (working backups promoted, failed endpoints deprioritized)
@@ -466,6 +532,76 @@ Individual generation workflows can be triggered manually via GitHub Actions:
 - `Localization` - Update translations
 
 **Note on Pool Pricing:** Pool-based pricing functionality (`getPools.mjs`) exists in the codebase but is currently disabled via the `getPools = false` flag in `generate_assetlist.mjs`. This code includes pool querying, asset pricing calculations, and routing logic. It was previously used to add pricing information to generated assetlists but is not currently active. The code remains available for future re-implementation if needed.
+
+### Asset lifecycle automation
+
+When an asset stops working, it moves through a single observable timeline anchored on `state.lastDowntimeDate`. Five automated scripts cooperate to drive that timeline, each with a well-defined scope and a non-overlapping set of "reason" enum values it owns.
+
+#### The four-state model
+
+| State | Frontend effect | Set by |
+|---|---|---|
+| `osmosis_unstable` (warning only) | Alert-circle icon + localised banner; both directions still work | `check_ibc_clients`, `check_market_health`, or curator |
+| `osmosis_disabled` (external-router) | Native flow skipped; user is routed to an external provider | Curator only |
+| `osmosis_halt_deposits` (kill switch) | Deposit button greyed everywhere; bridge flow blocked, no external fallback | `check_ibc_clients`, `check_extended_halts`, or curator |
+| `osmosis_halt_withdrawals` (kill switch) | Withdraw button greyed everywhere; bridge flow blocked, no external fallback | `check_ibc_clients` or curator |
+
+Each flag has a paired `*_reason` enum field. The frontend uses the reason to pick a localised banner string. The existing `tooltip_message` field is reused for curator free-text, and a non-empty `tooltip_message` locks the asset against all automation.
+
+#### Daily timeline
+
+```
+   no flag
+      │
+      │  bridge_down detected
+      │  (IBC Expired/Frozen on either side, OR source chain status="killed")
+      ▼
+   osmosis_unstable=true, halt_deposits=true, halt_withdrawals=true
+   reasons: ibc_client | source_chain_killed
+   state.lastDowntimeDate = <now>
+      │
+      ├──── bridge_up detected (both clients Active AND chain status="live")
+      │     ▼
+      │     halt_deposits=false, halt_withdrawals=false
+      │     osmosis_unstable stays
+      │     state.lastRecoveryDate = <now>
+      │        │
+      │        │   60 days since state.lastDowntimeDate AND market still failing
+      │        ▼
+      │        halt_deposits=true (reason: extended_unstable_market)
+      │        withdrawals stay open
+      │
+      │  90 days since state.lastDowntimeDate (regardless of intervening recovery)
+      ▼
+   PR opened proposing osmosis_verified=false
+   state.lastUnverifyProposedAt = <now> (30-day cooldown)
+   On merge: only osmosis_verified flips; unstable + state history kept as record.
+```
+
+A second, independent track exists for market-driven unstable. When a verified, non-disabled asset is post-grace (23+ days past listing) and fails the market check (`liquidity < $1k && volume_24h < $100`) for 7 consecutive daily runs, it is flagged with reason `market`. The same 60/90-day timeline applies. Recovery is single-day for the halt and 7-day for the full unstable clear; on full recovery, state history is wiped.
+
+#### Scripts in the daily cron (in order)
+
+1. **`check_ibc_clients.mjs`**, the unified bridge-state check. Detects IBC client status and source chain `status="killed"`. Owns reasons `ibc_client`, `source_chain_killed` (unstable) and `bridge_down`, `source_chain_killed` (halts). Implements the flap-vs-fresh-incident rule (within 30 days of recovery = continuation; beyond = fresh incident). Includes a "manual-flip safety net" that populates `state.lastDowntimeDate` if a curator manually sets `osmosis_unstable` without one.
+
+2. **`check_market_health.mjs`**, the market track. Owns reason `market` for unstable and is the **only** writer that fully recovers an asset from market-driven instability. Skipped for alloyed assets, disabled assets, preview assets, and assets within the 23-day post-listing grace window.
+
+3. **`check_extended_halts.mjs`**, the 60-day rule and planned-shutdown rule. Owns reasons `extended_unstable_market` and `planned_shutdown` for deposit halts. Pre-emptively halts deposits 14 days before a `planned_shutdown_date`.
+
+#### Weekly cron
+
+**`check_unverify_candidates.mjs`** (Mondays at 16:00 UTC, via `propose_unverify.yml`). Collects every verified asset that has been continuously unstable for 90+ days and hasn't had an unverify PR opened in the last 30 days. Flips `osmosis_verified=false` for each, writes a markdown PR body, stamps `state.lastUnverifyProposedAt` for cooldown, and the workflow opens or updates a PR on a fixed branch (`auto-unverify/weekly-candidates`). The PR requires human approval.
+
+#### On-demand utility
+
+**`asset_status_report.mjs`** (read-only, `workflow_dispatch`-triggered). Produces a six-section markdown report covering unstable assets, halt status, disabled assets, verification-borderline assets, pending unverifies in cooldown, and detected invariant violations.
+
+#### Safety mechanisms
+
+- **`--dry-run` flag.** Every writer script accepts `--dry-run`, which emits a markdown report of intended mutations without writing any file. Always use this before enabling a fresh script in CI or after a chain-registry submodule bump that might flip many chains at once.
+- **Mutation cap.** No script will write changes touching more than **10 distinct source chains** in a single run. If exceeded, the script exits with code 2 and demands a `--force` flag. This catches mass-flips from upstream regressions.
+- **Reason-vocabulary contract.** Each reason enum value has exactly one owner script (or `manual` = the curator). No two scripts ever race on the same flag.
+- **Curator lock.** Any non-empty `tooltip_message` on a halted or unstable asset is treated as curator-owned and never overwritten by automation. To release the lock, clear the tooltip.
 
 ### Pull Request Workflow
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Four orthogonal states describe an asset's transfer health. Each has a distinct 
   - **Companion field**: `osmosis_deposit_halt_reason` drives the localised banner.
 
 - **`osmosis_deposit_halt_reason`** (enum: `"bridge_down" | "extended_unstable_market" | "planned_shutdown" | "source_chain_killed" | "manual"`).
-  - **Owners**: `bridge_down` and `source_chain_killed` are owned by `check_ibc_clients.mjs`. `extended_unstable_market` is owned by `check_market_health.mjs` and `check_extended_halts.mjs`. `planned_shutdown` is owned by `check_extended_halts.mjs`. `manual` is curator-only.
+  - **Owners**: `bridge_down` and `source_chain_killed` are owned by `check_ibc_clients.mjs`. `extended_unstable_market` is owned by `check_extended_halts.mjs` (which sets the flag and clears it on the 1-day recovery branch). `check_market_health.mjs` may also clear an `extended_unstable_market` halt as part of its market-recovery flow, but never sets it. `planned_shutdown` is owned by `check_extended_halts.mjs`. `manual` is curator-only.
 
 - **`osmosis_halt_withdrawals`** (boolean, default: `false`). Kill switch for the **withdraw** direction.
   - **Frontend output**: `haltWithdrawals: true`

--- a/RUNBOOKS.md
+++ b/RUNBOOKS.md
@@ -986,3 +986,54 @@ After emergency resolved:
    # Post in Discord if user-facing
    # Update status if posted outage notice
 ```
+
+---
+
+### RB006: Manually override an auto-set halt
+
+**Use when**: an automated halt (e.g. reason `bridge_down`) is in effect but you want to keep the asset halted with bespoke context, or override the cause description even though automation would otherwise clear the flag on recovery.
+
+#### Procedure
+
+Edit the zone_assets entry directly:
+
+```json
+{
+  "chain_name": "examplehub",
+  "base_denom": "uex",
+  "osmosis_halt_deposits": true,
+  "osmosis_deposit_halt_reason": "manual",
+  "tooltip_message": "Deposits paused pending the v0.5 chain upgrade scheduled 2026-06-10. Status: https://status.example.com"
+}
+```
+
+Two changes from an auto-set halt:
+
+1. The `*_halt_reason` is set to `manual`. Script-owned reasons get auto-cleared on recovery; `manual` does not.
+2. `tooltip_message` is non-empty. Any tooltip locks the asset against all automation.
+
+Commit and let the daily cron run. Verify the asset is now ignored by automation by checking the next workflow summary's "Manual halts currently in effect" section.
+
+#### Release the override
+
+Clear `tooltip_message` and set the reason back to a script-owned value (or just remove both flags entirely). The next daily run will re-derive the state.
+
+---
+
+### RB007: Weekly unverify PR, close vs merge
+
+**Use when**: the weekly `auto-unverify/weekly-candidates` PR is open and you need to decide what to do.
+
+#### Procedure
+
+The PR body lists each candidate with days unstable, reason, last downtime / recovery, halt status, liquidity, and volume. For each candidate:
+
+- **Merge if** the asset has been broken for 90+ days, the underlying issue isn't expected to resolve, and the market data confirms no real activity. Merge flips `osmosis_verified=false`; all history fields stay as record.
+- **Close (don't merge) if** the asset is recovering, has an active community working on the fix, or there's a strategic reason to keep it verified. Closing triggers a 30-day cooldown, so the asset won't be re-proposed until then.
+- **Edit the PR (remove rows) if** you want to unverify some but not all candidates. Use `git rebase` or commit a follow-up to the same branch, then merge.
+
+#### Notes
+
+- `osmosis_unstable` and the state history fields are preserved on unverify. This is intentional, so a later re-verification carries the prior incident record.
+- A re-verified asset that's still carrying stale dates should have them manually cleared at re-verify time.
+- The cooldown is per-asset, not per-PR. Closing the PR stamps `state.lastUnverifyProposedAt` for every candidate that was in the PR.

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -50,11 +50,45 @@
         },
         "osmosis_unstable": {
           "type": "boolean",
-          "description": "Whether the asset can reliably be transferred to or from Osmosis."
+          "description": "Whether the asset has experienced or is experiencing instability. Warning-only flag; does not gate transfers."
+        },
+        "osmosis_unstable_reason": {
+          "type": "string",
+          "enum": ["ibc_client", "source_chain_killed", "market", "manual"],
+          "description": "Closed-set reason for the unstable flag. Each has a localization key in the frontend. Curator-written context for any halt/unstable state lives in the existing `tooltip_message` field."
         },
         "osmosis_disabled": {
           "type": "boolean",
-          "description": "Whether the asset Deposit and Withdraw functions are disabled on Osmosis."
+          "description": "Whether the native Deposit/Withdraw flow should be skipped, routing the user to an external provider instead. UX router, not a kill switch."
+        },
+        "osmosis_halt_deposits": {
+          "type": "boolean",
+          "description": "Kill switch: deposits are halted. Asset-page Deposit button is greyed and the bridge flow blocks the deposit direction."
+        },
+        "osmosis_deposit_halt_reason": {
+          "type": "string",
+          "enum": [
+            "bridge_down",
+            "extended_unstable_market",
+            "planned_shutdown",
+            "source_chain_killed",
+            "manual"
+          ],
+          "description": "Closed-set reason for the deposit halt. Drives the localized banner. Curator-written context lives in the existing `tooltip_message` field."
+        },
+        "osmosis_halt_withdrawals": {
+          "type": "boolean",
+          "description": "Kill switch: withdrawals are halted."
+        },
+        "osmosis_withdrawal_halt_reason": {
+          "type": "string",
+          "enum": ["bridge_down", "source_chain_killed", "manual"],
+          "description": "Closed-set reason for the withdrawal halt. Curator-written context lives in the existing `tooltip_message` field."
+        },
+        "planned_shutdown_date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+          "description": "ISO UTC date when this asset is scheduled to be shut down. Used by check_extended_halts.mjs to pre-emptively halt deposits 14 days before the shutdown date."
         },
         "is_alloyed": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

Introduces an automated lifecycle for assets that have stopped working. An asset that breaks now follows a single, observable timeline: unstable warning, then deposits halted at 60 days, then an unverify PR at 90 days, then human approval. Anchored on a single \`state.lastDowntimeDate\`.

## Three commits

1. **Schema** (\`fbd26adb7\`): adds halt and unstable reason enums and state history fields. Schema and generator only; no behaviour change until the lifecycle scripts run.
2. **Lifecycle scripts** (\`d2c567fb8\`): rewrites \`check_ibc_clients\` as a unified bridge-state check that also covers killed chains. Adds three new daily-cron scripts and one workflow_dispatch utility. Wires the daily and weekly workflows. \`--dry-run\` and a 10-chain mutation cap protect against accidents.
3. **Docs** (\`283e713fc\`): rewrites the transfer & reliability flags section of README. Adds lifecycle automation section and two runbooks.

## The four-state model

| State | Frontend effect | Set by |
|---|---|---|
| \`osmosis_unstable\` (warning) | alert-circle icon + localised banner; both directions still work | \`check_ibc_clients\`, \`check_market_health\`, or curator |
| \`osmosis_disabled\` (external-router) | native flow skipped; user routed to an external provider | curator only |
| \`osmosis_halt_deposits\` (kill switch) | deposit button greyed everywhere; bridge flow blocked, no external fallback | \`check_ibc_clients\`, \`check_extended_halts\`, or curator |
| \`osmosis_halt_withdrawals\` (kill switch) | withdraw button greyed everywhere; bridge flow blocked, no external fallback | \`check_ibc_clients\` or curator |

Each flag has a paired \`*_reason\` enum field. The frontend uses the reason to pick a localised banner string. The existing \`tooltip_message\` field doubles as a curator-lock: any non-empty tooltip prevents all automation from modifying the asset.

## Reason-vocabulary contract

Each automated reason value has exactly one owner script:
- \`bridge_down\` and \`source_chain_killed\`: \`check_ibc_clients\`.
- \`extended_unstable_market\` and \`planned_shutdown\`: \`check_extended_halts\`.
- \`market\` (unstable): \`check_market_health\`.
- \`ibc_client\` (unstable): \`check_ibc_clients\`.
- \`manual\`: never auto-cleared. The curator's escape hatch.

This means no two scripts ever race on the same flag.

## After merge: first-run migration

The first live run of the unified bridge-state check will trip the 10-chain mutation cap because every existing \`osmosis_unstable=true\` asset needs its \`state.lastDowntimeDate\` populated and IBC-down chains need their halt flags set. Procedure:

1. After this PR merges, trigger \`Generate All Files\` via \`workflow_dispatch\`.
2. The bridge-state check will exit with the cap warning. Re-run \`check_ibc_clients.mjs osmosis-1 --force\` locally and open a PR with the resulting zone_assets.json + state.json diff (\"first-run migration of halt + state flags\").
3. Review that PR as a single migration snapshot. Expected: roughly 239 mutations across roughly 27 source chains, populating \`lastDowntimeDate\` for already-flagged assets and setting halt flags for assets whose IBC client is currently expired.
4. Merge the migration PR. From then on the daily cron handles deltas.

## Dry-run results from local testing

I ran each writer script in \`--dry-run\` mode against the current zone_assets.json:

| Script | Mutations | Distinct chains | Notes |
|---|---|---|---|
| \`check_ibc_clients --dry-run\` | 239 | 27 | Cap fires (10). Mix of bridge_down and safety_net (the latter for killed-chain assets without transferMethods in the frontend). |
| \`check_market_health --dry-run\` | 124 streak increments | 0 | 124 verified assets are currently failing the market thresholds. None will flag until 7 consecutive failing runs. |
| \`check_extended_halts --dry-run\` | 0 | 0 | Expected: no asset is 60+ days unstable with state set yet. Activates once the migration PR populates dates. |
| \`check_unverify_candidates --dry-run\` | 0 | 0 | Expected: no \`lastDowntimeDate\` yet >= 90 days old. Activates 90 days after the migration. |
| \`asset_status_report.mjs\` | 376 inconsistent | n/a | Every existing \`osmosis_unstable=true\` asset lacks \`state.lastDowntimeDate\`. Resolves automatically on the first live bridge-state run via the safety-net pass. |

## Frontend side

The matching frontend changes (\`MinimalAsset\` shape, \`amount-screen.tsx\` halt banner, portfolio table greying, asset cell unstable icon, per-reason localisation keys) are on a separate branch and will be opened as a follow-up PR. The generated assetlist already omits new fields when unset, so existing frontend code is unaffected until that PR lands.

## Verification

- \`node --check\` passes for all new and modified \`.mjs\` files.
- \`generate_assetlist.mjs\` runs clean and emits the new fields correctly (verified end-to-end with a test edit to MNTL, then reverted).
- Dry-run reports for every writer script reviewed; counts above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces new automated mutations to `osmosis.zone_assets.json`/`state.json` (halts, unstable reasons, unverification proposals) and wires them into scheduled GitHub workflows, which could mass-flip asset availability if the logic or upstream data is wrong.
> 
> **Overview**
> Implements a **graceful shutdown lifecycle** for broken assets by introducing new transfer-health flags/reason enums and automated scripts that mutate `zone_assets` + `state` to track downtime/recovery and progressively escalate actions.
> 
> The daily `generate_all_files` workflow now runs three lifecycle checks before generation: a rewritten `check_ibc_clients.mjs` as a unified *bridge-state* detector (IBC + killed-chain) that can set/clear `osmosis_unstable` and new deposit/withdraw halt flags while maintaining `lastDowntimeDate`/`lastRecoveryDate`, plus new `check_market_health.mjs` (7-day market-based unstable + recovery) and `check_extended_halts.mjs` (60-day market-based deposit halts and 14-day planned-shutdown halts). A new scheduled workflow `propose_unverify.yml` runs `check_unverify_candidates.mjs` to open/update a PR flipping `osmosis_verified=false` for 90+ day unstable assets with a cooldown.
> 
> Generation output is extended to include lifecycle fields in the frontend assetlist (`unstableReason`, halt flags/reasons, planned shutdown date, downtime/recovery dates), the schema is updated to validate the new fields, and docs/runbooks are updated; `generated/reports/` outputs from dry-runs/status reports are added to `.gitignore` and the workflow summary now includes a “manual halts” section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79350f5011f56d574426c8951927caf238f1b1f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->