### PR TITLE
cosmoshub: add Nether (NTHR)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -9549,6 +9549,16 @@
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "bridge_down"
+    },
+    {
+      "chain_name": "cosmoshub",
+      "base_denom": "factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
+      "path": "transfer/channel-0/factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
+      "osmosis_verified": false,
+      "categories": [
+        "nft_protocol"
+      ],
+      "_comment": "Nether $NTHR"
     }
   ]
 }


### PR DESCRIPTION
## Description

Adding token: **NTHR** from chain **cosmoshub**

Nether (NTHR) is a tokenfactory-issued token on Cosmos Hub by the Underworld NFT ecosystem (NecroVault platform). Fixed supply: 21,000. Already actively trading on Osmosis.

- **chain_name:** \`cosmoshub\`
- **base_denom:** \`factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether\`
- **path:** \`transfer/channel-0/factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether\`
- **IBC denom on Osmosis:** \`ibc/EFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF\`
- **categories:** \`nft_protocol\`

Live on Osmosis: https://app.osmosis.zone/assets/ibc/EFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF

## Checklist

### Adding Assets

- [x] Asset is registered to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry) — merged in [#7666](https://github.com/cosmos/chain-registry/pull/7666), metadata enriched in [#7686](https://github.com/cosmos/chain-registry/pull/7686).
- [x] Added asset to bottom of \`zone_assets.json\`
   - [x] \`chain_name\` and \`base_denom\` are provided and use values exactly as defined at the Chain Registry.
   - [x] \`path\` is provided, IBC channel (\`channel-0\` on Osmosis side, canonical Hub↔Osmosis) is registered.
   - [x] \`osmosis_verified\` is set to \`false\`
   - [x] \`categories\` set to \`nft_protocol\`
- [x] I am aware that upgrading an asset to 'Verified' status requires an additional PR to this repo.

### Project Links

- Website: https://www.necrovault.com/
- X: https://x.com/Underworld_NFTs