### PR TITLE
feat: lifecycle scripts, workflow display, and frontend propagation

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -41,13 +41,53 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Snapshot zone_assets before lifecycle scripts
+        run: |
+          # Per-mutation symbol extraction depends on a clean before/after
+          # diff of zone_assets. The three lifecycle scripts mutate it in
+          # sequence, so we snapshot once here and diff once at the end.
+          cp osmosis-1/osmosis.zone_assets.json /tmp/zone-before.json
+
       - name: Check IBC Client Status
         working-directory: ./.github/workflows/utility
         run: |
+          set +e
           node check_ibc_clients.mjs osmosis-1 2>&1 | tee ../../../ibc-check.log
+          rc=${PIPESTATUS[0]}
+          if [ "$rc" -eq 2 ]; then
+            # Mutation cap hit: not a failure, but flag it so the workflow
+            # summary surfaces the event for human follow-up.
+            echo "IBC_CAP_HIT=true" >> $GITHUB_ENV
+          elif [ "$rc" -ne 0 ]; then
+            exit $rc
+          fi
           echo "IBC_NEWLY_FLAGGED=$(grep -oP 'IBC_NEWLY_FLAGGED=\K[0-9]+' ../../../ibc-check.log || echo 0)" >> $GITHUB_ENV
           echo "IBC_NEWLY_CLEARED=$(grep -oP 'IBC_NEWLY_CLEARED=\K[0-9]+' ../../../ibc-check.log || echo 0)" >> $GITHUB_ENV
           echo "IBC_ERRORS=$(grep -oP 'IBC_ERRORS=\K[0-9]+' ../../../ibc-check.log || echo 0)" >> $GITHUB_ENV
+
+      - name: Check Market Health (independent unstable track)
+        working-directory: ./.github/workflows/utility
+        run: |
+          set +e
+          node check_market_health.mjs osmosis-1 2>&1 | tee ../../../market-health.log
+          rc=${PIPESTATUS[0]}
+          if [ "$rc" -eq 2 ]; then
+            echo "MARKET_HEALTH_CAP_HIT=true" >> $GITHUB_ENV
+          elif [ "$rc" -ne 0 ]; then
+            exit $rc
+          fi
+
+      - name: Check Extended Halts (60d + planned shutdown)
+        working-directory: ./.github/workflows/utility
+        run: |
+          set +e
+          node check_extended_halts.mjs osmosis-1 2>&1 | tee ../../../extended-halts.log
+          rc=${PIPESTATUS[0]}
+          if [ "$rc" -eq 2 ]; then
+            echo "EXTENDED_HALTS_CAP_HIT=true" >> $GITHUB_ENV
+          elif [ "$rc" -ne 0 ]; then
+            exit $rc
+          fi
 
       - name: Add Chain Stubs
         working-directory: ./.github/workflows/utility
@@ -128,6 +168,70 @@ jobs:
           comm -13 /tmp/chains-before.txt /tmp/chains-after.txt > new-chains.txt
           echo "NEW_CHAINS_COUNT=$(wc -l < new-chains.txt)" >> $GITHUB_ENV
 
+      - name: Extract per-mutation symbol lists
+        run: |
+          # Diff /tmp/zone-before.json (snapshot pre-lifecycle) against the
+          # current zone_assets.json to produce one symbol list per mutation
+          # category. Each file is "chain_name|SYMBOL" per line. Symbol is
+          # resolved against the freshly-generated frontend assetlist.
+          jq -r --slurpfile fe osmosis-1/generated/frontend/assetlist.json --slurpfile before /tmp/zone-before.json '
+            ($fe[0].assets | map({key: (.chainName + "|" + .sourceDenom), value: .symbol}) | from_entries) as $symByOrigin
+            | ($before[0].assets | map({key: (.chain_name + "|" + .base_denom), value: .}) | from_entries) as $beforeByOrigin
+            | .assets as $now
+            | $now | map(
+                . as $a
+                | $beforeByOrigin[$a.chain_name + "|" + $a.base_denom] as $b
+                | ($symByOrigin[$a.chain_name + "|" + $a.base_denom] // $a._comment // $a.base_denom) as $sym
+                | {
+                    chain: $a.chain_name,
+                    symbol: $sym,
+                    ibcFlagged:
+                      ((($a.osmosis_unstable // false) == true) and (($b.osmosis_unstable // false) != true)),
+                    ibcCleared:
+                      ((($a.osmosis_unstable // false) != true) and (($b.osmosis_unstable // false) == true)),
+                    marketFlagged:
+                      ((($a.osmosis_unstable // false) == true)
+                        and (($a.osmosis_unstable_reason // "") == "market")
+                        and (($b.osmosis_unstable_reason // "") != "market")),
+                    marketRecovered:
+                      ((($a.osmosis_unstable // false) != true)
+                        and (($b.osmosis_unstable_reason // "") == "market")),
+                    extendedHaltSet:
+                      ((($a.osmosis_halt_deposits // false) == true)
+                        and (($a.osmosis_deposit_halt_reason // "") == "extended_unstable_market")
+                        and (($b.osmosis_deposit_halt_reason // "") != "extended_unstable_market")),
+                    extendedHaltCleared:
+                      ((($a.osmosis_halt_deposits // false) != true)
+                        and (($b.osmosis_deposit_halt_reason // "") == "extended_unstable_market")),
+                    plannedShutdownSet:
+                      ((($a.osmosis_halt_deposits // false) == true)
+                        and (($a.osmosis_deposit_halt_reason // "") == "planned_shutdown")
+                        and (($b.osmosis_deposit_halt_reason // "") != "planned_shutdown")),
+                    plannedShutdownCleared:
+                      ((($a.osmosis_halt_deposits // false) != true)
+                        and (($b.osmosis_deposit_halt_reason // "") == "planned_shutdown")),
+                  }
+              ) as $rows
+            | $rows
+          ' osmosis-1/osmosis.zone_assets.json > /tmp/lifecycle-diff.json
+
+          # Write one file per category, "chain|symbol" per line.
+          for kind in ibcFlagged ibcCleared marketFlagged marketRecovered extendedHaltSet extendedHaltCleared plannedShutdownSet plannedShutdownCleared; do
+            jq -r --arg k "$kind" '.[] | select(.[$k] == true) | "\(.chain)|\(.symbol)"' /tmp/lifecycle-diff.json > /tmp/lc-${kind}.txt
+          done
+
+          # Capture summary counts from the lifecycle script logs.
+          if [ -f market-health.log ]; then
+            echo "MARKET_FLAGGED=$(grep -oP 'market_flagged\s+:\s+\K[0-9]+' market-health.log || echo 0)" >> $GITHUB_ENV
+            echo "MARKET_RECOVERED=$(grep -oP 'market_recovered\s+:\s+\K[0-9]+' market-health.log || echo 0)" >> $GITHUB_ENV
+          fi
+          if [ -f extended-halts.log ]; then
+            echo "EXTENDED_HALT_SET=$(grep -oP 'extended_halt_set\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
+            echo "EXTENDED_HALT_CLEARED=$(grep -oP 'extended_halt_cleared\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
+            echo "PLANNED_SHUTDOWN_SET=$(grep -oP 'planned_shutdown_set\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
+            echo "PLANNED_SHUTDOWN_CLEARED=$(grep -oP 'planned_shutdown_cleared\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
+          fi
+
       - name: Run code to Update State
         working-directory: ./.github/workflows/utility
         run: node update_assetlist_state.mjs
@@ -149,6 +253,99 @@ jobs:
           cat > workflow-summary.md << 'HEADER'
           # Automated Update Summary
           HEADER
+
+          # ── Quick summary (top-of-PR glance) ──────────────────────────────
+          # One row per category. Lists chain names or asset symbols inline;
+          # empty categories render with a dim "none" so the reader can see
+          # what's currently quiet vs busy.
+          echo "## 📋 Quick summary" >> workflow-summary.md
+          echo "" >> workflow-summary.md
+
+          # Helper: emit "- {emoji} {label} ({count}): {comma-joined items}".
+          # Items are read from the supplied file (one per line). If the file
+          # is empty/missing, prints "— none" instead. For lifecycle-script
+          # files keyed by "chain|symbol", takes only the symbol column.
+          emit_row() {
+            local emoji="$1" label="$2" file="$3" mode="$4"
+            local count=0 items=""
+            if [ -f "$file" ] && [ -s "$file" ]; then
+              if [ "$mode" = "symbol" ]; then
+                items=$(awk -F'|' 'NF>0{print $2}' "$file" | paste -sd', ' -)
+                count=$(awk 'NF>0' "$file" | wc -l | tr -d ' ')
+              else
+                items=$(awk 'NF>0' "$file" | paste -sd', ' -)
+                count=$(awk 'NF>0' "$file" | wc -l | tr -d ' ')
+              fi
+            fi
+            if [ "$count" = "0" ]; then
+              echo "- ${emoji} **${label}** — none" >> workflow-summary.md
+            else
+              echo "- ${emoji} **${label} (${count}):** ${items}" >> workflow-summary.md
+            fi
+          }
+
+          emit_row "🆕" "New Chains" new-chains.txt name
+          emit_row "🆕" "New Assets" new-assets.txt name
+          emit_row "🔴" "IBC flagged unstable" /tmp/lc-ibcFlagged.txt symbol
+          emit_row "🟢" "IBC cleared" /tmp/lc-ibcCleared.txt symbol
+
+          # Manual halts: list chain names of assets whose halt reason is
+          # "manual" on either direction. Distinct chains, sorted.
+          MANUAL_HALT_CHAINS=$(jq -r '
+            .assets
+            | map(select(
+                (.osmosis_deposit_halt_reason == "manual")
+                or (.osmosis_withdrawal_halt_reason == "manual")
+              ))
+            | map(.chain_name) | unique | .[]
+          ' osmosis-1/osmosis.zone_assets.json 2>/dev/null > /tmp/lc-manualHalts.txt && echo ok || echo err)
+          emit_row "⚠️" "Manual halts in effect" /tmp/lc-manualHalts.txt name
+
+          emit_row "⏸️" "Extended halt set" /tmp/lc-extendedHaltSet.txt symbol
+          emit_row "▶️" "Extended halt cleared" /tmp/lc-extendedHaltCleared.txt symbol
+          emit_row "⏰" "Planned shutdown set" /tmp/lc-plannedShutdownSet.txt symbol
+          emit_row "▶️" "Planned shutdown cleared" /tmp/lc-plannedShutdownCleared.txt symbol
+          emit_row "📉" "Market flagged" /tmp/lc-marketFlagged.txt symbol
+          emit_row "📈" "Market recovered" /tmp/lc-marketRecovered.txt symbol
+
+          echo "" >> workflow-summary.md
+          echo "---" >> workflow-summary.md
+          echo "" >> workflow-summary.md
+
+          # Mutation cap hits: surface loudly if any lifecycle script exited
+          # with code 2 (cap exceeded). The script's intended mutations were
+          # not applied; an operator needs to inspect and decide whether to
+          # re-run locally with --force.
+          if [ "$IBC_CAP_HIT" = "true" ] || [ "$MARKET_HEALTH_CAP_HIT" = "true" ] || [ "$EXTENDED_HALTS_CAP_HIT" = "true" ]; then
+            echo "## ⚠️ Mutation cap hit" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo "One or more lifecycle scripts exited with code 2 because their" >> workflow-summary.md
+            echo "intended diff would touch more than 10 distinct source chains" >> workflow-summary.md
+            echo "in a single run. No mutations from the affected script(s) were" >> workflow-summary.md
+            echo "applied this run. Inspect the logs and re-run locally with" >> workflow-summary.md
+            echo "\`--force\` if the diff is legitimate." >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            if [ "$IBC_CAP_HIT" = "true" ]; then
+              echo "- 🛑 \`check_ibc_clients\` cap exceeded" >> workflow-summary.md
+            fi
+            if [ "$MARKET_HEALTH_CAP_HIT" = "true" ]; then
+              echo "- 🛑 \`check_market_health\` cap exceeded" >> workflow-summary.md
+            fi
+            if [ "$EXTENDED_HALTS_CAP_HIT" = "true" ]; then
+              echo "- 🛑 \`check_extended_halts\` cap exceeded" >> workflow-summary.md
+            fi
+            echo "" >> workflow-summary.md
+            echo "To inspect and apply the diff locally:" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo '```bash' >> workflow-summary.md
+            echo "cd .github/workflows/utility" >> workflow-summary.md
+            echo "node <script-name>.mjs osmosis-1 --dry-run    # review" >> workflow-summary.md
+            echo "node <script-name>.mjs osmosis-1 --force      # apply" >> workflow-summary.md
+            echo '```' >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo "---" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+          fi
 
           # Chainlist Generation
           echo "## Chainlist Generation" >> workflow-summary.md
@@ -251,9 +448,67 @@ jobs:
             echo "<details><summary>IBC check details</summary>" >> workflow-summary.md
             echo "" >> workflow-summary.md
             echo '```' >> workflow-summary.md
-            grep -A 100 'IBC CLIENT HEALTH SUMMARY' ibc-check.log | head -60 >> workflow-summary.md || true
+            grep -A 100 'BRIDGE-STATE CHECK SUMMARY' ibc-check.log | head -60 >> workflow-summary.md || true
             echo '```' >> workflow-summary.md
             echo "</details>" >> workflow-summary.md
+          fi
+
+          echo "" >> workflow-summary.md
+          echo "---" >> workflow-summary.md
+          echo "" >> workflow-summary.md
+
+          # Market Health Summary (the full summary block from the script's log)
+          if [ -f market-health.log ]; then
+            echo "## Market Health Summary" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo '```' >> workflow-summary.md
+            grep -A 30 'MARKET-HEALTH SUMMARY' market-health.log | head -30 >> workflow-summary.md || true
+            echo '```' >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo "---" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+          fi
+
+          # Extended Halts Summary
+          if [ -f extended-halts.log ]; then
+            echo "## Extended Halts Summary" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo '```' >> workflow-summary.md
+            grep -A 30 'EXTENDED HALTS SUMMARY' extended-halts.log | head -30 >> workflow-summary.md || true
+            echo '```' >> workflow-summary.md
+            echo "" >> workflow-summary.md
+            echo "---" >> workflow-summary.md
+            echo "" >> workflow-summary.md
+          fi
+
+          # Manual halts currently in effect (visibility for drift detection)
+          echo "## Manual halts currently in effect" >> workflow-summary.md
+          echo "" >> workflow-summary.md
+
+          MANUAL_HALTS=$(jq -r '
+            .assets
+            | map(select(
+                (.osmosis_deposit_halt_reason == "manual")
+                or (.osmosis_withdrawal_halt_reason == "manual")
+              ))
+          ' osmosis-1/osmosis.zone_assets.json)
+          MANUAL_HALT_COUNT=$(echo "$MANUAL_HALTS" | jq 'length')
+
+          if [ "$MANUAL_HALT_COUNT" -eq 0 ]; then
+            echo "_None._" >> workflow-summary.md
+          else
+            echo "| Chain | Base denom | Direction | Tooltip |" >> workflow-summary.md
+            echo "|-------|-----------|-----------|---------|" >> workflow-summary.md
+            echo "$MANUAL_HALTS" | jq -r '
+              .[] | (
+                (if .osmosis_deposit_halt_reason == "manual" then
+                   "| \(.chain_name) | \(.base_denom) | deposit | \(.tooltip_message // "") |"
+                 else "" end),
+                (if .osmosis_withdrawal_halt_reason == "manual" then
+                   "| \(.chain_name) | \(.base_denom) | withdrawal | \(.tooltip_message // "") |"
+                 else "" end)
+              ) | select(. != "")
+            ' >> workflow-summary.md
           fi
 
           echo "" >> workflow-summary.md

--- a/.github/workflows/propose_unverify.yml
+++ b/.github/workflows/propose_unverify.yml
@@ -1,0 +1,63 @@
+# Bi-weekly: open/update a PR proposing osmosis_verified=false for assets that
+# have been continuously unstable for 90+ days, subject to a 30-day per-asset
+# cooldown via state.lastUnverifyProposedAt.
+#
+# Runs on the 1st and 15th of each month at 16:00 UTC, after the daily
+# generate_all_files cron. This gives ~14-day cadence without weekly noise.
+
+on:
+  schedule:
+    - cron: "0 16 1,15 * *" # 1st and 15th of each month at 16:00 UTC
+  workflow_dispatch:
+
+name: Propose Unverify Candidates
+jobs:
+  propose_unverify:
+    name: Propose unverify candidates
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unverify-candidate check (propose mode)
+        working-directory: ./.github/workflows/utility
+        run: node check_unverify_candidates.mjs osmosis-1 --propose
+
+      - name: Capture PR body
+        id: prbody
+        run: |
+          if [ -f osmosis-1/generated/reports/unverify_candidates_pr_body.md ]; then
+            echo "has_body=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_body=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create or update PR
+        if: steps.prbody.outputs.has_body == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(unverify): unverify candidate sweep"
+          branch: auto-unverify/weekly-candidates
+          title: "chore(unverify): assets exceeded 90-day unstable threshold"
+          body-path: osmosis-1/generated/reports/unverify_candidates_pr_body.md
+          labels: |
+            auto-unverify
+            needs-review
+          delete-branch: false

--- a/.github/workflows/utility/asset_status_report.mjs
+++ b/.github/workflows/utility/asset_status_report.mjs
@@ -1,0 +1,289 @@
+// Purpose:
+//   workflow_dispatch utility: emit a markdown status report covering
+//     1. Unstable assets (with reason, dates, halt status, days until 60d/90d milestones)
+//     2. Halt status (every asset with halt_deposits or halt_withdrawals)
+//     3. Disabled assets (osmosis_disabled === true)
+//     4. Verification-borderline assets (verified but failing market thresholds)
+//     5. Pending unverify (in cooldown), assets that crossed 90d but had a PR opened recently
+//     6. Inconsistencies (invariants violated; e.g. osmosis_unstable=true with no state.lastDowntimeDate)
+//
+//   Read-only. No mutations.
+//
+// Usage:
+//   node asset_status_report.mjs [<zone_name>]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { calculateIbcHash } from './assetlist_functions.mjs';
+import {
+  fetchAlloyConstituentMap,
+  fetchNumia,
+  loadJSON,
+  resolveMarket,
+} from './lifecycle_helpers.mjs';
+
+const LOW_LIQUIDITY_USD = 1000;
+const LOW_VOLUME_24H_USD = 100;
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+
+const args = process.argv.slice(2);
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+function daysBetween(nowMs, isoStart) {
+  return Math.floor((nowMs - new Date(isoStart).getTime()) / (24 * 60 * 60 * 1000));
+}
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+  // Numia is non-critical here; the report degrades to '?' when unavailable.
+  const numia = await fetchNumia({ hardFail: false });
+
+  // Alloy-aware market signal: constituents inherit max(self, alloy) so the
+  // verification-borderline section does not surface assets that look weak in
+  // their own Numia row but trade actively through an alloyed pool.
+  const alloyedDenomSet = new Set(
+    (frontendData.assets ?? [])
+      .filter((a) => a.isAlloyed)
+      .map((a) => a.coinMinimalDenom)
+  );
+  const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
+
+  const stateByDenom = new Map();
+  for (const a of state.assets ?? []) stateByDenom.set(a.base_denom, a);
+
+  const frontendByDenom = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
+  }
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+
+  const unstable = [];
+  const halts = [];
+  const disabled = [];
+  const borderline = [];
+  const pending = [];
+  const inconsistencies = [];
+
+  // Iterate zone_assets directly so we cover killed-chain assets whose
+  // generator output disappeared. Compute coinMinimalDenom via the same IBC
+  // hash the generator uses.
+  for (const za of zoneData.assets) {
+    if (!za.path) continue; // non-IBC entries skipped
+    const coinMinimalDenom = await calculateIbcHash(za.path);
+    const sa = stateByDenom.get(coinMinimalDenom);
+    // Alloy-aware: constituents inherit the alloy's market signal so neither
+    // the unstable display nor the verification-borderline detector treats a
+    // healthy alloy constituent as low-market.
+    const m = resolveMarket(numia, constituentToAlloy, coinMinimalDenom);
+    const feAsset = frontendByDenom.get(coinMinimalDenom);
+    const symbol = feAsset?.symbol ?? za._comment ?? za.base_denom;
+
+    if (za.osmosis_unstable === true) {
+      if (!sa?.lastDowntimeDate) {
+        inconsistencies.push({
+          chain: za.chain_name,
+          symbol,
+          issue: 'osmosis_unstable=true but no state.lastDowntimeDate',
+        });
+      }
+      const days = sa?.lastDowntimeDate ? daysBetween(nowMs, sa.lastDowntimeDate) : null;
+      const daysUntilHalt = days != null ? Math.max(0, 60 - days) : null;
+      const daysUntilUnverify = days != null ? Math.max(0, 90 - days) : null;
+      unstable.push({
+        chain: za.chain_name,
+        symbol,
+        baseDenom: coinMinimalDenom,
+        verified: za.osmosis_verified === true,
+        reason: za.osmosis_unstable_reason ?? '?',
+        lastDowntime: sa?.lastDowntimeDate ?? '-',
+        lastRecovery: sa?.lastRecoveryDate ?? '-',
+        days,
+        daysUntilHalt,
+        daysUntilUnverify,
+        liquidity: m?.liquidity ?? '?',
+        volume24h: m?.volume24h ?? '?',
+        mcap: m?.mcap ?? '?',
+      });
+    }
+
+    if (za.osmosis_halt_deposits === true) {
+      if (!za.osmosis_deposit_halt_reason) {
+        inconsistencies.push({
+          chain: za.chain_name,
+          symbol,
+          issue: 'osmosis_halt_deposits=true with no reason',
+        });
+      }
+      halts.push({
+        chain: za.chain_name,
+        symbol,
+        direction: 'deposit',
+        reason: za.osmosis_deposit_halt_reason ?? '?',
+        tooltip: za.tooltip_message ?? '',
+        manual: za.osmosis_deposit_halt_reason === 'manual',
+      });
+    }
+    if (za.osmosis_halt_withdrawals === true) {
+      halts.push({
+        chain: za.chain_name,
+        symbol,
+        direction: 'withdrawal',
+        reason: za.osmosis_withdrawal_halt_reason ?? '?',
+        tooltip: za.tooltip_message ?? '',
+        manual: za.osmosis_withdrawal_halt_reason === 'manual',
+      });
+    }
+
+    if (za.osmosis_disabled === true) {
+      disabled.push({
+        chain: za.chain_name,
+        symbol,
+        baseDenom: coinMinimalDenom,
+        verified: za.osmosis_verified === true,
+        liquidity: m?.liquidity ?? '?',
+        volume24h: m?.volume24h ?? '?',
+        mcap: m?.mcap ?? '?',
+        comment: za._comment ?? '',
+      });
+    }
+
+    // Verification-borderline: verified, no unstable flag, but market check fails
+    if (
+      za.osmosis_verified === true &&
+      za.osmosis_unstable !== true &&
+      m &&
+      m.liquidity < LOW_LIQUIDITY_USD &&
+      m.volume24h < LOW_VOLUME_24H_USD
+    ) {
+      borderline.push({
+        chain: za.chain_name,
+        symbol,
+        liquidity: m.liquidity,
+        volume24h: m.volume24h,
+      });
+    }
+
+    // Pending unverify (in cooldown)
+    if (
+      za.osmosis_verified === true &&
+      za.osmosis_unstable === true &&
+      sa?.lastDowntimeDate &&
+      sa?.lastUnverifyProposedAt
+    ) {
+      const days = daysBetween(nowMs, sa.lastDowntimeDate);
+      const cooldownLeft =
+        COOLDOWN_MS - (nowMs - new Date(sa.lastUnverifyProposedAt).getTime());
+      if (days >= 90 && cooldownLeft > 0) {
+        pending.push({
+          chain: za.chain_name,
+          symbol,
+          daysUnstable: days,
+          lastProposed: sa.lastUnverifyProposedAt,
+          daysUntilRepropose: Math.ceil(cooldownLeft / (24 * 60 * 60 * 1000)),
+        });
+      }
+    }
+  }
+
+  // ── Compose markdown ────────────────────────────────────────────────────────
+  const lines = [];
+  lines.push(`# Asset status report, ${nowIso}`);
+  lines.push('');
+
+  lines.push(`## 1. Unstable assets (${unstable.length})`);
+  lines.push('');
+  lines.push(`| Chain | Symbol | Base denom | Verified | Reason | Last downtime | Last recovery | Days | Days→halt | Days→unverify | Liquidity | Vol 24h | MCap |`);
+  lines.push(`|-------|--------|-----------|----------|--------|---------------|---------------|------|----------|---------------|-----------|---------|------|`);
+  for (const u of unstable) {
+    lines.push(
+      `| ${u.chain} | ${u.symbol} | \`${u.baseDenom}\` | ${u.verified ? '✓' : ''} | ${u.reason} | ${u.lastDowntime} | ${u.lastRecovery} | ${u.days ?? '-'} | ${u.daysUntilHalt ?? '-'} | ${u.daysUntilUnverify ?? '-'} | ${u.liquidity} | ${u.volume24h} | ${u.mcap} |`
+    );
+  }
+  lines.push('');
+
+  lines.push(`## 2. Halt status (${halts.length})`);
+  lines.push('');
+  lines.push(`| Chain | Symbol | Direction | Reason | Manual? | Tooltip |`);
+  lines.push(`|-------|--------|-----------|--------|---------|---------|`);
+  for (const h of halts) {
+    lines.push(`| ${h.chain} | ${h.symbol} | ${h.direction} | ${h.reason} | ${h.manual ? '✓' : ''} | ${h.tooltip} |`);
+  }
+  lines.push('');
+
+  lines.push(`## 3. Disabled assets (${disabled.length})`);
+  lines.push('');
+  lines.push(`| Chain | Symbol | Base denom | Verified | Liquidity | Vol 24h | MCap | Comment |`);
+  lines.push(`|-------|--------|-----------|----------|-----------|---------|------|---------|`);
+  for (const d of disabled) {
+    lines.push(
+      `| ${d.chain} | ${d.symbol} | \`${d.baseDenom}\` | ${d.verified ? '✓' : ''} | ${d.liquidity} | ${d.volume24h} | ${d.mcap} | ${d.comment} |`
+    );
+  }
+  lines.push('');
+
+  lines.push(`## 4. Verification-borderline assets (${borderline.length})`);
+  lines.push('');
+  lines.push('Verified, not currently unstable, but market check is failing today. ' +
+    'Watch list for assets that may enter the unstable lifecycle soon.');
+  lines.push('');
+  lines.push(`| Chain | Symbol | Liquidity | Vol 24h |`);
+  lines.push(`|-------|--------|-----------|---------|`);
+  for (const b of borderline) {
+    lines.push(`| ${b.chain} | ${b.symbol} | ${b.liquidity} | ${b.volume24h} |`);
+  }
+  lines.push('');
+
+  lines.push(`## 5. Pending unverify (in cooldown) (${pending.length})`);
+  lines.push('');
+  lines.push('Assets that crossed 90 days unstable and had a PR proposed within the ' +
+    'last 30 days. They\'re hidden from the candidate pool until cooldown ends.');
+  lines.push('');
+  lines.push(`| Chain | Symbol | Days unstable | Last proposed | Days until re-propose |`);
+  lines.push(`|-------|--------|--------------|---------------|----------------------|`);
+  for (const p of pending) {
+    lines.push(`| ${p.chain} | ${p.symbol} | ${p.daysUnstable} | ${p.lastProposed} | ${p.daysUntilRepropose} |`);
+  }
+  lines.push('');
+
+  lines.push(`## 6. Inconsistencies (${inconsistencies.length})`);
+  lines.push('');
+  if (inconsistencies.length === 0) {
+    lines.push('_None._');
+  } else {
+    lines.push(`| Chain | Symbol | Issue |`);
+    lines.push(`|-------|--------|-------|`);
+    for (const i of inconsistencies) {
+      lines.push(`| ${i.chain} | ${i.symbol} | ${i.issue} |`);
+    }
+  }
+  lines.push('');
+
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const reportPath = path.join(
+    reportsDir,
+    `asset_status_${nowIso.slice(0, 10)}.md`
+  );
+  fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+  console.log(`\n📝 Status report: ${reportPath}`);
+  console.log(`Unstable: ${unstable.length} | Halts: ${halts.length} | Disabled: ${disabled.length} | Borderline: ${borderline.length} | Pending: ${pending.length} | Inconsistencies: ${inconsistencies.length}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -1,0 +1,258 @@
+// Purpose:
+//   60-day extended deposit halt + planned-shutdown halt. Daily cron, runs
+//   after check_ibc_clients and check_market_health. Two independent triggers,
+//   both write osmosis_halt_deposits=true:
+//
+//     • 60 days since state.lastDowntimeDate AND osmosis_unstable=true AND
+//       market check still failing → halt_deposits with reason
+//       "extended_unstable_market".
+//
+//     • planned_shutdown_date within 14 days → halt_deposits with reason
+//       "planned_shutdown".
+//
+//   Reason-vocabulary contract: this script owns reasons
+//   {extended_unstable_market, planned_shutdown}. Clearing rules:
+//     • extended_unstable_market: cleared on a single passing market run.
+//       (Note: check_market_health also implements this clearing path for
+//       the market-recovery flow; both are safe because they're guarded by
+//       the same reason check.)
+//     • planned_shutdown: cleared when planned_shutdown_date is absent or
+//       > 14 days in the future.
+//
+// Usage:
+//   node check_extended_halts.mjs [<zone_name>] [--dry-run] [--force]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { calculateIbcHash } from './assetlist_functions.mjs';
+import {
+  fetchAlloyConstituentMap,
+  fetchNumia,
+  loadJSON,
+  resolveMarket,
+} from './lifecycle_helpers.mjs';
+
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const SHUTDOWN_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+const LOW_LIQUIDITY_USD = 1000;
+const LOW_VOLUME_24H_USD = 100;
+const MAX_CHAINS_PER_RUN = 10;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+  const numia = await fetchNumia();
+
+  // Alloy-aware market signal: constituents inherit max(self, alloy) so the
+  // 60-day rule does not re-set a halt that check_market_health.mjs just
+  // cleared on the basis of inherited volume.
+  const alloyedDenomSet = new Set(
+    (frontendData.assets ?? [])
+      .filter((a) => a.isAlloyed)
+      .map((a) => a.coinMinimalDenom)
+  );
+  const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
+
+  const zoneByOrigin = new Map();
+  for (const a of zoneData.assets) {
+    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
+  }
+
+  // Build the evaluation list. For every zone_asset that's IBC (has a path),
+  // compute its coinMinimalDenom via the same IBC hash the generator uses.
+  // This lets us iterate the canonical key even when an asset is missing
+  // from the frontend (killed-chain case).
+  const frontendByDenom = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
+  }
+
+  const evaluations = [];
+  for (const za of zoneData.assets) {
+    if (!za.path) continue; // skip non-IBC entries; they aren't bridged
+    const coinMinimalDenom = await calculateIbcHash(za.path);
+    const feAsset = frontendByDenom.get(coinMinimalDenom);
+    evaluations.push({
+      coinMinimalDenom,
+      chainName: za.chain_name,
+      symbol: feAsset?.symbol ?? za._comment ?? za.base_denom,
+      zoneAsset: za,
+    });
+  }
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+  const mutations = [];
+
+  for (const ev of evaluations) {
+    const { coinMinimalDenom, chainName, symbol, zoneAsset } = ev;
+
+    const stateAsset = state.assets?.find(
+      (a) => a.base_denom === coinMinimalDenom
+    );
+
+    // ── Trigger A: extended unstable + failing market ───────────────────────
+    // Curator lock: any non-empty tooltip_message blocks automation. Same
+    // contract as the clearing path below and check_ibc_clients's
+    // canModifyHalt().
+    if (
+      zoneAsset.osmosis_unstable === true &&
+      stateAsset?.lastDowntimeDate &&
+      zoneAsset.osmosis_halt_deposits !== true &&
+      !zoneAsset.tooltip_message
+    ) {
+      const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
+      if (downtimeMs >= SIXTY_DAYS_MS) {
+        const market = resolveMarket(numia, constituentToAlloy, coinMinimalDenom);
+        const failing =
+          !!market &&
+          market.liquidity < LOW_LIQUIDITY_USD &&
+          market.volume24h < LOW_VOLUME_24H_USD;
+        if (failing) {
+          zoneAsset.osmosis_halt_deposits = true;
+          zoneAsset.osmosis_deposit_halt_reason = 'extended_unstable_market';
+          mutations.push({
+            kind: 'extended_halt_set',
+            asset: symbol,
+            chain: chainName,
+            days: Math.floor(downtimeMs / (24 * 60 * 60 * 1000)),
+          });
+        }
+      }
+    }
+
+    // ── Trigger A clearing: market recovered (single passing run) ──────────
+    if (
+      zoneAsset.osmosis_halt_deposits === true &&
+      zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
+      !zoneAsset.tooltip_message
+    ) {
+      const market = resolveMarket(numia, constituentToAlloy, coinMinimalDenom);
+      const passing =
+        !!market &&
+        (market.liquidity >= LOW_LIQUIDITY_USD ||
+          market.volume24h >= LOW_VOLUME_24H_USD);
+      if (passing) {
+        delete zoneAsset.osmosis_halt_deposits;
+        delete zoneAsset.osmosis_deposit_halt_reason;
+        mutations.push({
+          kind: 'extended_halt_cleared',
+          asset: symbol,
+          chain: chainName,
+        });
+      }
+    }
+
+    // ── Trigger B: planned shutdown approaching ─────────────────────────────
+    // Curator lock honoured: non-empty tooltip_message blocks the set path,
+    // matching the contract used elsewhere.
+    const plannedDate = zoneAsset.planned_shutdown_date;
+    if (
+      plannedDate &&
+      zoneAsset.osmosis_halt_deposits !== true &&
+      !zoneAsset.tooltip_message
+    ) {
+      const untilMs = new Date(plannedDate).getTime() - nowMs;
+      if (untilMs >= 0 && untilMs <= SHUTDOWN_WINDOW_MS) {
+        zoneAsset.osmosis_halt_deposits = true;
+        zoneAsset.osmosis_deposit_halt_reason = 'planned_shutdown';
+        mutations.push({
+          kind: 'planned_shutdown_set',
+          asset: symbol,
+          chain: chainName,
+          shutdown: plannedDate,
+        });
+      }
+    }
+
+    // ── Trigger B clearing ──────────────────────────────────────────────────
+    if (
+      zoneAsset.osmosis_halt_deposits === true &&
+      zoneAsset.osmosis_deposit_halt_reason === 'planned_shutdown' &&
+      !zoneAsset.tooltip_message
+    ) {
+      const untilMs = plannedDate
+        ? new Date(plannedDate).getTime() - nowMs
+        : Infinity;
+      if (!plannedDate || untilMs > SHUTDOWN_WINDOW_MS) {
+        delete zoneAsset.osmosis_halt_deposits;
+        delete zoneAsset.osmosis_deposit_halt_reason;
+        mutations.push({
+          kind: 'planned_shutdown_cleared',
+          asset: symbol,
+          chain: chainName,
+        });
+      }
+    }
+  }
+
+  const affectedChains = new Set(
+    mutations.filter((m) => m.chain).map((m) => m.chain)
+  );
+  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
+    console.error(
+      `\n⛔ Mutation cap exceeded: ${affectedChains.size} chains > ${MAX_CHAINS_PER_RUN}.`
+    );
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `extended_halts_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Extended halts dry-run, ${nowIso}`,
+      ``,
+      `Mutations: ${mutations.length}`,
+      ``,
+      `| Kind | Asset | Chain | Days / Shutdown |`,
+      `|------|-------|-------|-----------------|`,
+    ];
+    for (const m of mutations) {
+      lines.push(
+        `| ${m.kind} | ${m.asset ?? '-'} | ${m.chain ?? '-'} | ${m.days ?? m.shutdown ?? '-'} |`
+      );
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    return;
+  }
+
+  if (mutations.length > 0) {
+    fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+  } else {
+    console.log('No changes needed.');
+  }
+
+  const byKind = {};
+  for (const m of mutations) byKind[m.kind] = (byKind[m.kind] || 0) + 1;
+  console.log('\n' + '='.repeat(70));
+  console.log('  EXTENDED HALTS SUMMARY');
+  console.log('='.repeat(70));
+  for (const [k, v] of Object.entries(byKind)) {
+    console.log(`  ${k.padEnd(28)}: ${v}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -1,21 +1,36 @@
 // Purpose:
-//   Check IBC client health for all IBC assets in the generated frontend
-//   assetlist. Automatically sets/clears osmosis_unstable in zone_assets.json,
-//   adding new minimal entries for assets not yet present and removing them
-//   when they recover.
+//   Unified bridge-state check. For every IBC asset in the generated frontend
+//   assetlist:
+//     • Detect "bridge-down" condition (IBC client Expired/Frozen on either
+//       side, OR source chain marked status="killed" in the chain registry).
+//     • Detect "bridge-up" condition (IBC client Active on both sides AND
+//       source chain status="live").
+//     • Set/clear osmosis_unstable + osmosis_halt_deposits +
+//       osmosis_halt_withdrawals in zone_assets.json, with reasons.
+//     • Maintain state.json's lastDowntimeDate / lastRecoveryDate fields
+//       (flap-vs-fresh-incident rule).
 //
-//   When clearing a flag, both the Osmosis-side client AND the counterparty-side
-//   client are verified as Active before clearing, since withdrawals from Osmosis
-//   require the counterparty's client of Osmosis to be healthy.
+//   Reason-vocabulary contract: this script owns reasons {ibc_client,
+//   source_chain_killed} for both unstable and halts, and {bridge_down,
+//   source_chain_killed} for halts. Halts with any other reason (notably
+//   "manual" or one owned by check_extended_halts.mjs) are NEVER touched
+//   by this script. A non-empty tooltip on a halt also locks the halt
+//   (curator has taken ownership).
 //
 // Usage:
-//   node check_ibc_clients.mjs <zone_name>
+//   node check_ibc_clients.mjs [<zone_name>] [--dry-run] [--force] [--lcd <url>]
 //   Example: node check_ibc_clients.mjs osmosis-1
+//   Example: node check_ibc_clients.mjs osmosis-1 --dry-run
+//   Example: node check_ibc_clients.mjs osmosis-1 --lcd https://osmosis-lcd.publicnode.com
+//
+//   --dry-run : no writes; emits markdown report; exit 0.
+//   --force   : bypass the mutation cap (>10 distinct source chains touched).
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { calculateIbcHash } from './assetlist_functions.mjs';
 
-const LCD = "https://lcd.osmosis.zone";
+const DEFAULT_LCD = "https://lcd.osmosis.zone";
 const CONCURRENCY = 5;
 const RETRY_DELAY_MS = 1500;
 const MAX_RETRIES = 3;
@@ -23,26 +38,105 @@ const COUNTERPARTY_TIMEOUT_MS = 5000;
 const COUNTERPARTY_MAX_ENDPOINTS = 5;
 const CHAIN_REGISTRY_PATH = path.join('..', '..', '..', 'chain-registry');
 
-const zoneBasePath = process.argv[2] || 'osmosis-1';
+// Mutation safeguard: if a single run would touch assets across more than
+// MAX_CHAINS_PER_RUN distinct source chains, the script exits without
+// committing. Counts the unique `chain_name` field on each affected
+// zone_asset entry. Intended to catch mass-flips from chain-registry
+// submodule bumps or upstream regressions. Per-chain (not per-asset) so a
+// single big chain producing many asset rows passes through normally.
+const MAX_CHAINS_PER_RUN = 10;
+
+// 30-day flap threshold: if an asset recovered <= 30d ago and goes
+// unstable again, treat as a continuation of the original incident
+// (preserve lastDowntimeDate). Beyond 30d → fresh incident.
+const FLAP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// CLI args
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+
+/** Pull the value of a --flag <value> pair out of argv, returning undefined
+ *  if absent. Leaves the surrounding code free to default sensibly. */
+function getFlagValue(name) {
+  const i = args.indexOf(name);
+  if (i === -1 || i === args.length - 1) return undefined;
+  const v = args[i + 1];
+  return v.startsWith('--') ? undefined : v;
+}
+
+const LCD = getFlagValue('--lcd') ?? DEFAULT_LCD;
+
+// Strip recognised --flag <value> pairs and standalone --flags before
+// reading positional args, so `--lcd https://x osmosis-1` works in any order.
+const FLAG_PAIRS = new Set(['--lcd']);
+const positional = (() => {
+  const out = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (FLAG_PAIRS.has(a)) { i++; continue; }
+    if (a.startsWith('--')) continue;
+    out.push(a);
+  }
+  return out;
+})();
+const zoneBasePath = positional[0] || 'osmosis-1';
+
 const zonePath = path.join('..', '..', '..', zoneBasePath);
 const filePrefix = zoneBasePath.split('-')[0];
 const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
-const frontendPath  = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
 const chainlistPath = path.join(zonePath, 'generated', 'frontend', 'chainlist.json');
 const zoneChainsPath = path.join(zonePath, `${filePrefix}.zone_chains.json`);
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
 
-// Fields that constitute a "thin" auto-added entry (safe to remove entirely
-// when the client recovers, since there's nothing else of value in the entry)
-const THIN_FIELDS = new Set(['chain_name', 'base_denom', 'path', 'osmosis_unstable', '_comment']);
+// Auto-managed fields. A "thin entry" is one where everything was auto-set
+// by this script (no curator content), so it can be removed entirely on
+// recovery rather than just having its flags cleared. Note that
+// tooltip_message is intentionally NOT in this set: any curator-set tooltip
+// counts as content that must be preserved.
+const AUTO_MANAGED_FIELDS = new Set([
+  'chain_name',
+  'base_denom',
+  'path',
+  '_comment',
+  'osmosis_unstable',
+  'osmosis_unstable_reason',
+  'osmosis_halt_deposits',
+  'osmosis_deposit_halt_reason',
+  'osmosis_halt_withdrawals',
+  'osmosis_withdrawal_halt_reason',
+]);
 
 function isThinEntry(asset) {
-  return Object.keys(asset).every(k => THIN_FIELDS.has(k));
+  return Object.keys(asset).every((k) => AUTO_MANAGED_FIELDS.has(k));
 }
+
+// Reasons this script is allowed to clear. Anything else (extended_unstable_market,
+// planned_shutdown, manual) is owned by another script or the curator and is
+// left alone.
+const OWNED_HALT_REASONS = new Set(['bridge_down', 'source_chain_killed']);
+const OWNED_UNSTABLE_REASONS = new Set(['ibc_client', 'source_chain_killed']);
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Categorise a fetch failure so the run summary can show what's actually
+ *  going wrong (rate-limit vs. server error vs. network/timeout). */
+function categoriseFetchError(err, status) {
+  if (status === 429) return 'rate_limit';
+  if (typeof status === 'number' && status >= 500) return 'server_error';
+  if (typeof status === 'number' && status >= 400) return 'client_error';
+  const msg = err?.message ?? '';
+  if (/HTTP 429/.test(msg)) return 'rate_limit';
+  if (/HTTP 5\d\d/.test(msg)) return 'server_error';
+  if (/HTTP 4\d\d/.test(msg)) return 'client_error';
+  if (err?.name === 'AbortError' || /timeout|timed out/i.test(msg)) return 'timeout';
+  return 'network';
 }
 
 async function fetchJSON(url, retries = MAX_RETRIES) {
@@ -53,10 +147,18 @@ async function fetchJSON(url, retries = MAX_RETRIES) {
         await sleep(RETRY_DELAY_MS * attempt);
         continue;
       }
-      if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+      if (!res.ok) {
+        const e = new Error(`HTTP ${res.status} for ${url}`);
+        e.status = res.status;
+        e.errorKind = categoriseFetchError(e, res.status);
+        throw e;
+      }
       return await res.json();
     } catch (err) {
-      if (attempt === retries) throw err;
+      if (attempt === retries) {
+        if (!err.errorKind) err.errorKind = categoriseFetchError(err);
+        throw err;
+      }
       await sleep(RETRY_DELAY_MS * attempt);
     }
   }
@@ -87,6 +189,18 @@ async function processInBatches(items, batchSize, fn) {
   return results;
 }
 
+// ── Chain registry: source chain status ──────────────────────────────────────
+
+function getSourceChainStatus(chainName) {
+  try {
+    const chainFile = path.join(CHAIN_REGISTRY_PATH, chainName, 'chain.json');
+    const chainData = JSON.parse(fs.readFileSync(chainFile, 'utf8'));
+    return chainData.status ?? 'unknown'; // typically 'live', 'killed', 'upcoming'
+  } catch {
+    return 'unknown';
+  }
+}
+
 // ── IBC client lookup (Osmosis side) ─────────────────────────────────────────
 
 async function getClientStatusForChannel(channelId) {
@@ -110,11 +224,6 @@ async function getClientStatusForChannel(channelId) {
 
 // ── IBC client lookup (counterparty side) ────────────────────────────────────
 
-// Returns REST endpoints for a counterparty chain in priority order:
-//   1. zone_chains.json  — single manually curated endpoint (highest quality)
-//   2. chainlist.json    — validated and ordered endpoints from endpoint validation
-//   3. chain registry    — raw unvalidated fallback
-// Returns null if the chain is marked "killed" in the chain registry (skip queries).
 function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName) {
   const seen = new Set();
   const endpoints = [];
@@ -128,38 +237,31 @@ function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByNa
     }
   }
 
-  // 1. zone_chains.json — single curated REST endpoint
   const zoneChain = zoneChainsByName.get(chainName);
   if (zoneChain?.rest) add(zoneChain.rest);
 
-  // 2. Generated chainlist — validated endpoints in order
   const chainlistChain = chainlistByName.get(chainName);
   for (const e of chainlistChain?.apis?.rest ?? []) add(e.address);
 
-  // 3. Chain registry — raw fallback; also check for killed status
   try {
     const chainFile = path.join(CHAIN_REGISTRY_PATH, chainName, 'chain.json');
     const chainData = JSON.parse(fs.readFileSync(chainFile, 'utf8'));
-    if (chainData.status === 'killed') return null; // chain is permanently dead
+    if (chainData.status === 'killed') return null;
     for (const e of chainData.apis?.rest ?? []) add(e.address);
   } catch { /* chain not in registry */ }
 
   return endpoints;
 }
 
-// Returns 'Active', 'Expired', 'Frozen', or 'unknown' (if unreachable/missing).
-// 'unknown' is treated as a reason NOT to clear — preserves the flag.
-// deadEndpoints: Set<string> shared across calls — endpoints that have already
-// failed are skipped immediately, preventing repeated timeouts for dead chains.
 async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByName, chainlistByName, deadEndpoints) {
   if (!chainName || !channelId) return 'unknown';
 
   const endpoints = getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName);
-  if (endpoints === null) return 'killed'; // chain registry marks this chain as dead
+  if (endpoints === null) return 'killed';
   if (endpoints.length === 0) return 'unknown';
 
   for (const endpoint of endpoints.slice(0, COUNTERPARTY_MAX_ENDPOINTS)) {
-    if (deadEndpoints.has(endpoint)) continue; // skip known-dead endpoints immediately
+    if (deadEndpoints.has(endpoint)) continue;
 
     try {
       const channelData = await fetchJSONWithTimeout(
@@ -177,9 +279,9 @@ async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByNam
       const statusData = await fetchJSONWithTimeout(
         `${endpoint}/ibc/core/client/v1/client_status/${clientId}`
       );
-      return statusData.status; // 'Active', 'Expired', 'Frozen'
+      return statusData.status;
     } catch {
-      deadEndpoints.add(endpoint); // mark endpoint dead for all subsequent channels
+      deadEndpoints.add(endpoint);
       continue;
     }
   }
@@ -187,7 +289,124 @@ async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByNam
   return 'unknown';
 }
 
-// ── Main ──────────────────────────────────────────────────────────────────────
+// ── State helpers ───────────────────────────────────────────────────────────
+
+function loadState() {
+  try {
+    return JSON.parse(fs.readFileSync(statePath, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') return { assets: [] };
+    throw err;
+  }
+}
+
+// Read-only state lookup. Returns undefined if no entry exists; callers that
+// only need to read date/streak fields should use this so we don't pollute
+// state.assets with empty {base_denom} placeholders on every iteration.
+function findStateAsset(state, baseDenom) {
+  return state.assets?.find((a) => a.base_denom === baseDenom);
+}
+
+// Create-if-missing variant. Only callers about to write a real value
+// (lastDowntimeDate, lastRecoveryDate, etc.) should use this.
+function materialiseStateAsset(state, baseDenom) {
+  if (!state.assets) state.assets = [];
+  let s = state.assets.find((a) => a.base_denom === baseDenom);
+  if (!s) {
+    s = { base_denom: baseDenom };
+    state.assets.push(s);
+  }
+  return s;
+}
+
+/**
+ * Apply the flap-vs-fresh-incident rule to lastDowntimeDate / lastRecoveryDate.
+ * Mutates stateAsset in place.
+ */
+function applyDowntimeDateRule(stateAsset, nowIso) {
+  const now = new Date(nowIso).getTime();
+  if (!stateAsset.lastDowntimeDate) {
+    stateAsset.lastDowntimeDate = nowIso;
+    return;
+  }
+  if (!stateAsset.lastRecoveryDate) {
+    // continuously unstable; clock keeps running
+    return;
+  }
+  const recoveredAt = new Date(stateAsset.lastRecoveryDate).getTime();
+  if (now - recoveredAt <= FLAP_WINDOW_MS) {
+    // short flap, preserve original downtime, clear recovery
+    delete stateAsset.lastRecoveryDate;
+  } else {
+    // fresh incident
+    stateAsset.lastDowntimeDate = nowIso;
+    delete stateAsset.lastRecoveryDate;
+  }
+}
+
+// ── Halt mutation helpers ────────────────────────────────────────────────────
+
+/** Returns true if this script may safely modify the halt flag based on its
+ *  current reason and the shared tooltip_message field. A non-empty
+ *  tooltip_message is treated as a curator-owned override that locks all
+ *  halt/unstable automation for this asset. */
+function canModifyHalt(zoneAsset, reasonField) {
+  const currentReason = zoneAsset[reasonField];
+  if (currentReason && !OWNED_HALT_REASONS.has(currentReason)) return false;
+  if (zoneAsset.tooltip_message) return false;
+  return true;
+}
+
+function canModifyUnstable(zoneAsset) {
+  const currentReason = zoneAsset.osmosis_unstable_reason;
+  if (currentReason && !OWNED_UNSTABLE_REASONS.has(currentReason)) return false;
+  if (zoneAsset.tooltip_message) return false;
+  return true;
+}
+
+/**
+ * Best-effort classification of *why* an asset is unstable, used by the
+ * safety-net paths when we don't have channel-walk evidence in hand.
+ * Returns the most specific script-owned reason that can be proved from
+ * static state (chain-registry status), and falls back to 'manual' for
+ * curator-flipped entries we can't classify any other way.
+ *
+ * Note: 'ibc_client' is intentionally not returned here. That reason
+ * requires positive evidence from the channel walk and should only be
+ * set on the bridge-down code path above.
+ */
+function classifyUnstableReasonForBackfill(chainName) {
+  if (getSourceChainStatus(chainName) === 'killed') return 'source_chain_killed';
+  return 'manual';
+}
+
+/**
+ * Backfill osmosis_unstable_reason on an already-unstable asset, and the
+ * matching halt reasons when the reason is `source_chain_killed`. Only
+ * writes empty fields, and only when the existing reason is empty or is
+ * one this script owns (gated by canModify*). 'manual' is treated as a
+ * fallback label for curator-flipped entries: it does NOT populate halt
+ * reasons, because we have no evidence the curator wanted deposits or
+ * withdrawals halted.
+ */
+function backfillReasons(zoneAsset, reason) {
+  if (!zoneAsset.osmosis_unstable_reason && canModifyUnstable(zoneAsset)) {
+    zoneAsset.osmosis_unstable_reason = reason;
+  }
+  if (reason !== 'source_chain_killed') return;
+  if (zoneAsset.osmosis_halt_deposits !== true &&
+      canModifyHalt(zoneAsset, 'osmosis_deposit_halt_reason')) {
+    zoneAsset.osmosis_halt_deposits = true;
+    zoneAsset.osmosis_deposit_halt_reason = reason;
+  }
+  if (zoneAsset.osmosis_halt_withdrawals !== true &&
+      canModifyHalt(zoneAsset, 'osmosis_withdrawal_halt_reason')) {
+    zoneAsset.osmosis_halt_withdrawals = true;
+    zoneAsset.osmosis_withdrawal_halt_reason = reason;
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
   // Load zone_assets.json
@@ -199,7 +418,6 @@ async function main() {
     process.exit(1);
   }
 
-  // Load generated frontend assetlist as the source of truth for IBC assets
   let frontendData;
   try {
     frontendData = JSON.parse(fs.readFileSync(frontendPath, 'utf8'));
@@ -208,7 +426,15 @@ async function main() {
     process.exit(1);
   }
 
-  // Build counterparty endpoint lookups (zone_chains → chainlist → registry)
+  const state = loadState();
+
+  // Snapshot the pre-run shape so we only write files that actually changed.
+  // Combined with the findStateAsset / materialiseStateAsset split below,
+  // this guarantees state.json is only rewritten when a real lifecycle
+  // decision happened (not just an iteration).
+  const zoneBefore = JSON.stringify(zoneData);
+  const stateBefore = JSON.stringify(state);
+
   const zoneChainsByName = new Map();
   try {
     const zc = JSON.parse(fs.readFileSync(zoneChainsPath, 'utf8'));
@@ -221,18 +447,15 @@ async function main() {
     for (const chain of cl.chains ?? []) chainlistByName.set(chain.chain_name, chain);
   } catch { /* optional */ }
 
-  // Build a lookup of zone_assets entries by path for fast matching
   const zoneByPath = new Map();
   for (const asset of zoneData.assets) {
     if (asset.path) zoneByPath.set(asset.path, asset);
   }
 
-  // Collect IBC assets from the frontend assetlist, grouped by channel.
-  // Store counterparty info at the channel level (all assets on a channel
-  // share the same counterparty chain and channel ID).
-  const channelMap = new Map(); // channelId -> { assets, counterpartyChainName, counterpartyChannelId }
+  // Group frontend IBC assets by channel.
+  const channelMap = new Map();
   for (const asset of frontendData.assets ?? []) {
-    const ibcMethod = asset.transferMethods?.find(m => m.type === 'ibc');
+    const ibcMethod = asset.transferMethods?.find((m) => m.type === 'ibc');
     if (!ibcMethod?.chain?.channelId || !ibcMethod?.chain?.path) continue;
 
     const channelId = ibcMethod.chain.channelId;
@@ -244,20 +467,21 @@ async function main() {
       });
     }
     channelMap.get(channelId).assets.push({
-      chainName:   asset.chainName,
+      chainName: asset.chainName,
       sourceDenom: asset.sourceDenom,
-      symbol:      asset.symbol,
+      coinMinimalDenom: asset.coinMinimalDenom,
+      symbol: asset.symbol,
       channelId,
-      ibcPath:     ibcMethod.chain.path,
+      ibcPath: ibcMethod.chain.path,
     });
   }
 
   const uniqueChannels = [...channelMap.keys()];
   const totalAssets = [...channelMap.values()].reduce((n, c) => n + c.assets.length, 0);
-  console.log(`Checking IBC client status for ${uniqueChannels.length} unique channels (${totalAssets} IBC assets in frontend)...\n`);
+  console.log(`Checking IBC client + chain status for ${uniqueChannels.length} channels (${totalAssets} IBC assets)...\n`);
 
-  // Query Osmosis LCD in batches
-  const results = await processInBatches(
+  // Phase 1: Osmosis-side IBC client status
+  const ibcResults = await processInBatches(
     uniqueChannels,
     CONCURRENCY,
     async (channelId) => {
@@ -265,194 +489,359 @@ async function main() {
         const result = await getClientStatusForChannel(channelId);
         return { channelId, ...result, error: null };
       } catch (err) {
-        return { channelId, status: 'error', error: err.message };
+        return {
+          channelId,
+          status: 'error',
+          error: err.message,
+          errorKind: err.errorKind ?? categoriseFetchError(err),
+        };
       }
     }
   );
 
-  const stats = {
-    active: 0, flagged: 0, cleared: 0, removed: 0,
-    alreadyFlagged: 0, counterpartySkipped: 0, errors: 0,
-  };
-  const newlyFlagged         = [];
-  const newlyCleared         = [];
-  const newlyRemoved         = [];
-  const counterpartySkipped  = [];
-  const errorChannels        = [];
+  // Hard-fail when the LCD is essentially unusable. If ≥ 90% of channel
+  // lookups errored, we can't tell anything from this run and writing a
+  // partial state is worse than not running. Emit a per-category breakdown
+  // so the operator can tell rate-limit from server-down from timeout.
+  const errorBreakdown = {};
+  for (const r of ibcResults) {
+    if (r.status === 'error') {
+      const k = r.errorKind ?? 'unknown';
+      errorBreakdown[k] = (errorBreakdown[k] || 0) + 1;
+    }
+  }
+  const totalErrored = Object.values(errorBreakdown).reduce((a, b) => a + b, 0);
+  if (totalErrored / ibcResults.length >= 0.9) {
+    console.error(
+      `\n⛔ Aborting: ${totalErrored}/${ibcResults.length} channel lookups failed; ` +
+      `LCD appears unusable. No files written.`
+    );
+    for (const [k, v] of Object.entries(errorBreakdown)) {
+      console.error(`   ${k.padEnd(14)}: ${v}`);
+    }
+    process.exit(3);
+  }
 
-  // ── Phase 1: identify channels needing a counterparty check ─────────────────
-  // Only Osmosis-Active channels with currently unstable-flagged assets need it.
-  const cpCheckNeeded = new Map(); // osmosisChannelId -> { counterpartyChainName, counterpartyChannelId }
-  for (const result of results) {
-    if (result.error || result.status !== 'Active') continue;
-    const { assets: channelAssets, counterpartyChainName, counterpartyChannelId } = channelMap.get(result.channelId);
-    const hasUnstableAssets = channelAssets.some(fa => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true);
-    if (hasUnstableAssets && counterpartyChainName && counterpartyChannelId) {
-      cpCheckNeeded.set(result.channelId, { counterpartyChainName, counterpartyChannelId });
+  // Phase 2: counterparty checks for channels we might clear
+  const cpCheckNeeded = new Map();
+  for (const r of ibcResults) {
+    if (r.error || r.status !== 'Active') continue;
+    const cm = channelMap.get(r.channelId);
+    const hasUnstableAssets = cm.assets.some(
+      (fa) => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true
+    );
+    if (hasUnstableAssets && cm.counterpartyChainName && cm.counterpartyChannelId) {
+      cpCheckNeeded.set(r.channelId, cm);
     }
   }
 
-  // ── Phase 2: run counterparty checks in concurrent batches ──────────────────
-  // deadEndpoints is shared across all calls so a failed endpoint is never
-  // retried for a different channel on the same dead chain.
-  const cpStatuses = new Map(); // osmosisChannelId -> status string
+  const cpStatuses = new Map();
   if (cpCheckNeeded.size > 0) {
-    console.log(`Checking counterparty client status for ${cpCheckNeeded.size} channel(s)...\n`);
+    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} channel(s)...\n`);
     const deadEndpoints = new Set();
-    const cpEntries = [...cpCheckNeeded.entries()];
-    const cpBatchResults = await processInBatches(
-      cpEntries,
+    const cpResults = await processInBatches(
+      [...cpCheckNeeded.entries()],
       CONCURRENCY,
-      async ([channelId, { counterpartyChainName, counterpartyChannelId }]) => {
+      async ([channelId, cm]) => {
         const status = await getCounterpartyClientStatus(
-          counterpartyChainName, counterpartyChannelId,
-          zoneChainsByName, chainlistByName, deadEndpoints
+          cm.counterpartyChainName,
+          cm.counterpartyChannelId,
+          zoneChainsByName,
+          chainlistByName,
+          deadEndpoints
         );
         return [channelId, status];
       }
     );
-    for (const [channelId, status] of cpBatchResults) {
-      cpStatuses.set(channelId, status);
-    }
+    for (const [channelId, status] of cpResults) cpStatuses.set(channelId, status);
   }
 
-  // ── Phase 3: apply flags using pre-computed results ──────────────────────────
-  for (const result of results) {
-    const { assets: channelAssets, counterpartyChainName, counterpartyChannelId } = channelMap.get(result.channelId);
+  // Phase 3: apply mutations (collected first, written later so dry-run can short-circuit)
+  const mutations = [];
+  const nowIso = new Date().toISOString();
 
-    if (result.error) {
-      stats.errors++;
-      errorChannels.push({ channelId: result.channelId, error: result.error });
-      continue; // leave flags unchanged on error
+  for (const r of ibcResults) {
+    const cm = channelMap.get(r.channelId);
+
+    if (r.error) {
+      mutations.push({
+        kind: 'ibc_error',
+        channelId: r.channelId,
+        error: r.error,
+        errorKind: r.errorKind ?? 'unknown',
+      });
+      continue;
     }
 
-    const isProblematic = result.status !== 'Active';
+    const osmosisDown = r.status !== 'Active';
+    const cpStatus = cpStatuses.get(r.channelId); // undefined if no unstable assets
 
-    if (!isProblematic) {
-      // Osmosis-side client is Active. Check pre-computed counterparty status
-      // before clearing any flags (covers the withdrawal direction).
-      const cpStatus = cpStatuses.get(result.channelId); // undefined = no unstable assets, skip check
-      if (cpStatus !== undefined && cpStatus !== 'Active') {
-        // Counterparty side unconfirmed or broken — skip clearing for all assets on this channel
-        for (const fa of channelAssets) {
-          if (zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true) {
-            stats.counterpartySkipped++;
-            counterpartySkipped.push({ ...fa, cpStatus, counterpartyChainName, counterpartyChannelId });
-          }
-        }
-        continue;
-      }
-    }
+    for (const fa of cm.assets) {
+      // Per-asset evaluation, since source chain status is per-chain.
+      const sourceStatus = getSourceChainStatus(fa.chainName);
+      const chainKilled = sourceStatus === 'killed';
+      const chainLive = sourceStatus === 'live';
 
-    for (const fa of channelAssets) {
-      const zoneAsset = zoneByPath.get(fa.ibcPath);
+      const bridgeDown = osmosisDown || chainKilled;
+      const bridgeUp = !osmosisDown && chainLive && (cpStatus === undefined || cpStatus === 'Active');
 
-      if (isProblematic) {
-        if (zoneAsset) {
-          if (zoneAsset.osmosis_unstable === true) {
-            stats.alreadyFlagged++;
-          } else {
-            zoneAsset.osmosis_unstable = true;
-            stats.flagged++;
-            newlyFlagged.push({ ...fa, status: result.status, clientId: result.clientId });
-          }
-        } else {
-          // Asset not in zone_assets yet — add a minimal entry
-          const newEntry = {
+      const reasonOnDown = chainKilled ? 'source_chain_killed' : 'ibc_client';
+      const haltReasonOnDown = chainKilled ? 'source_chain_killed' : 'bridge_down';
+
+      let zoneAsset = zoneByPath.get(fa.ibcPath);
+      // Read-only lookup: never creates an empty placeholder. Calls that
+      // need to write to state must materialise the entry explicitly.
+      const stateAsset = findStateAsset(state, fa.coinMinimalDenom);
+
+      if (bridgeDown) {
+        // ── Bridge-down ────────────────────────────────────────────────────
+        if (!zoneAsset) {
+          zoneAsset = {
             chain_name: fa.chainName,
             base_denom: fa.sourceDenom,
-            path:       fa.ibcPath,
-            osmosis_unstable: true,
-            _comment:   `${fa.symbol} $${fa.symbol}`,
+            path: fa.ibcPath,
+            _comment: `${fa.symbol} $${fa.symbol}`,
           };
-          zoneData.assets.push(newEntry);
-          zoneByPath.set(fa.ibcPath, newEntry);
-          stats.flagged++;
-          newlyFlagged.push({ ...fa, status: result.status, clientId: result.clientId, added: true });
+          zoneData.assets.push(zoneAsset);
+          zoneByPath.set(fa.ibcPath, zoneAsset);
+        }
+
+        const before = { ...zoneAsset };
+
+        // osmosis_unstable: set the flag, and (back)fill the reason whenever
+        // it's missing. The reason can be absent on assets that were manually
+        // flagged unstable before this script started writing it, so we
+        // populate on transitions AND on already-unstable assets whose
+        // reason field is empty. canModifyUnstable still gates against
+        // curator-locked entries via tooltip_message.
+        if (canModifyUnstable(zoneAsset)) {
+          if (zoneAsset.osmosis_unstable !== true) {
+            zoneAsset.osmosis_unstable = true;
+          }
+          if (!zoneAsset.osmosis_unstable_reason) {
+            zoneAsset.osmosis_unstable_reason = reasonOnDown;
+          }
+        }
+
+        // osmosis_halt_deposits
+        if (zoneAsset.osmosis_halt_deposits !== true) {
+          if (canModifyHalt(zoneAsset, 'osmosis_deposit_halt_reason')) {
+            zoneAsset.osmosis_halt_deposits = true;
+            zoneAsset.osmosis_deposit_halt_reason = haltReasonOnDown;
+          }
+        }
+
+        // osmosis_halt_withdrawals
+        if (zoneAsset.osmosis_halt_withdrawals !== true) {
+          if (canModifyHalt(zoneAsset, 'osmosis_withdrawal_halt_reason')) {
+            zoneAsset.osmosis_halt_withdrawals = true;
+            zoneAsset.osmosis_withdrawal_halt_reason = haltReasonOnDown;
+          }
+        }
+
+        // state.lastDowntimeDate via flap-vs-fresh rule
+        if (zoneAsset.osmosis_unstable === true) {
+          applyDowntimeDateRule(
+            stateAsset ?? materialiseStateAsset(state, fa.coinMinimalDenom),
+            nowIso
+          );
+        }
+
+        if (JSON.stringify(before) !== JSON.stringify(zoneAsset)) {
+          mutations.push({ kind: 'bridge_down', fa, reason: reasonOnDown, haltReason: haltReasonOnDown, zoneAsset });
+        }
+      } else if (bridgeUp) {
+        // ── Bridge-up ──────────────────────────────────────────────────────
+        if (!zoneAsset) continue;
+
+        const before = { ...zoneAsset };
+        let cleared = false;
+
+        if (zoneAsset.osmosis_halt_deposits === true &&
+            canModifyHalt(zoneAsset, 'osmosis_deposit_halt_reason')) {
+          delete zoneAsset.osmosis_halt_deposits;
+          delete zoneAsset.osmosis_deposit_halt_reason;
+          cleared = true;
+        }
+
+        if (zoneAsset.osmosis_halt_withdrawals === true &&
+            canModifyHalt(zoneAsset, 'osmosis_withdrawal_halt_reason')) {
+          delete zoneAsset.osmosis_halt_withdrawals;
+          delete zoneAsset.osmosis_withdrawal_halt_reason;
+          cleared = true;
+        }
+
+        if (cleared) {
+          // Record recovery. Keep osmosis_unstable populated so the 90-day
+          // window stays armed via the persistent lastDowntimeDate.
+          materialiseStateAsset(state, fa.coinMinimalDenom).lastRecoveryDate = nowIso;
+
+          // If the resulting entry is a thin auto-added one, remove it entirely.
+          if (isThinEntry(zoneAsset)) {
+            zoneData.assets = zoneData.assets.filter((a) => a !== zoneAsset);
+            zoneByPath.delete(fa.ibcPath);
+            mutations.push({ kind: 'thin_removed', fa, zoneAsset: before });
+          } else {
+            mutations.push({ kind: 'bridge_up', fa, zoneAsset });
+          }
         }
       } else {
-        // Both sides Active — safe to clear
-        stats.active++;
+        // Unconfirmed (e.g. counterparty status unknown, source chain status unknown).
+        // Safety net for already-unstable assets that the channel walk could not
+        // confirm: populate lastDowntimeDate (so the 90-day clock has an anchor)
+        // and best-effort backfill the unstable reason. Halt fields are backfilled
+        // on the same basis when source chain is killed.
         if (zoneAsset?.osmosis_unstable === true) {
-          if (isThinEntry(zoneAsset)) {
-            // Auto-added entry with nothing else of value — remove it entirely
-            zoneData.assets = zoneData.assets.filter(a => a !== zoneAsset);
-            zoneByPath.delete(fa.ibcPath);
-            stats.removed++;
-            newlyRemoved.push({ ...fa, clientId: result.clientId });
-          } else {
-            // Manually curated entry — just clear the flag
-            delete zoneAsset.osmosis_unstable;
-            stats.cleared++;
-            newlyCleared.push({ ...fa, clientId: result.clientId });
+          if (!stateAsset?.lastDowntimeDate) {
+            materialiseStateAsset(state, fa.coinMinimalDenom).lastDowntimeDate = nowIso;
           }
+          const backfillReason = classifyUnstableReasonForBackfill(fa.chainName);
+          backfillReasons(zoneAsset, backfillReason);
+          mutations.push({
+            kind: 'safety_net',
+            fa,
+            reason: backfillReason,
+            haltReason: backfillReason === 'source_chain_killed' ? backfillReason : undefined,
+          });
         }
       }
     }
   }
 
-  // Write back only if something changed
-  if (stats.flagged > 0 || stats.cleared > 0 || stats.removed > 0) {
+  // ── Safety-net pass for zone_assets we never iterated ────────────────────────
+  // Some assets, particularly killed-chain ones whose source chains have lost
+  // their transferMethods during generation, never appear in the channel walk.
+  // For these, apply the manual-flip safety net so curators get a populated
+  // lastDowntimeDate (anchoring the 90-day clock) even without channel data.
+  //
+  // State entries are keyed by coinMinimalDenom (matching update_assetlist_state.mjs
+  // and every other lifecycle script). For IBC assets we compute that hash from
+  // the path, since the frontend assetlist has no entry for these.
+  const visitedPaths = new Set();
+  for (const cm of channelMap.values()) {
+    for (const fa of cm.assets) visitedPaths.add(fa.ibcPath);
+  }
+  for (const za of zoneData.assets) {
+    if (za.osmosis_unstable !== true) continue;
+    if (!za.path) continue; // non-IBC entries are not handled here
+    if (visitedPaths.has(za.path)) continue;
+
+    const coinMinimalDenom = await calculateIbcHash(za.path);
+    const stateAsset = findStateAsset(state, coinMinimalDenom);
+    const needsDowntimeDate = !stateAsset?.lastDowntimeDate;
+    const needsReasonBackfill = !za.osmosis_unstable_reason;
+
+    if (!needsDowntimeDate && !needsReasonBackfill) continue;
+
+    if (needsDowntimeDate) {
+      materialiseStateAsset(state, coinMinimalDenom).lastDowntimeDate = nowIso;
+    }
+    const backfillReason = classifyUnstableReasonForBackfill(za.chain_name);
+    backfillReasons(za, backfillReason);
+
+    mutations.push({
+      kind: 'safety_net',
+      reason: backfillReason,
+      haltReason: backfillReason === 'source_chain_killed' ? backfillReason : undefined,
+      fa: {
+        chainName: za.chain_name,
+        symbol: za._comment ?? za.base_denom,
+        ibcPath: za.path,
+        sourceDenom: za.base_denom,
+        coinMinimalDenom,
+      },
+    });
+  }
+
+  // ── Mutation cap ────────────────────────────────────────────────────────────
+  const affectedChains = new Set(
+    mutations
+      .filter((m) => m.fa)
+      .map((m) => m.fa.chainName)
+  );
+  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
+    console.error(
+      `\n⛔ Mutation cap exceeded: would touch ${affectedChains.size} distinct source chains ` +
+      `(threshold ${MAX_CHAINS_PER_RUN}). Re-run with --force after manual review, or with ` +
+      `--dry-run to inspect the diff.`
+    );
+    process.exit(2);
+  }
+
+  // ── Dry-run report ──────────────────────────────────────────────────────────
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `bridge_state_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Bridge-state dry-run, ${nowIso}`,
+      ``,
+      `Channels checked: ${uniqueChannels.length}`,
+      `Mutations: ${mutations.length}`,
+      `Distinct source chains affected: ${affectedChains.size}`,
+      ``,
+      `| Kind | Chain | Symbol | Reason | Halt reason |`,
+      `|------|-------|--------|--------|-------------|`,
+    ];
+    for (const m of mutations) {
+      if (!m.fa) continue;
+      lines.push(
+        `| ${m.kind} | ${m.fa.chainName} | ${m.fa.symbol} | ${m.reason ?? '-'} | ${m.haltReason ?? '-'} |`
+      );
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    console.log(`(no files were modified)`);
+    return;
+  }
+
+  // ── Write ───────────────────────────────────────────────────────────────────
+  const zoneChanged = JSON.stringify(zoneData) !== zoneBefore;
+  const stateChanged = JSON.stringify(state) !== stateBefore;
+  if (zoneChanged) {
     fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
     console.log(`✓ Updated ${zoneAssetsPath}`);
-  } else {
+  }
+  if (stateChanged) {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${statePath}`);
+  }
+  if (!zoneChanged && !stateChanged) {
     console.log('No changes needed.');
   }
 
-  // Summary
+  // ── Summary ─────────────────────────────────────────────────────────────────
+  const byKind = {};
+  const byErrorKind = {};
+  for (const m of mutations) {
+    byKind[m.kind] = (byKind[m.kind] || 0) + 1;
+    if (m.kind === 'ibc_error' && m.errorKind) {
+      byErrorKind[m.errorKind] = (byErrorKind[m.errorKind] || 0) + 1;
+    }
+  }
   console.log('\n' + '='.repeat(70));
-  console.log('  IBC CLIENT HEALTH SUMMARY');
+  console.log('  BRIDGE-STATE CHECK SUMMARY');
   console.log('='.repeat(70));
-  console.log(`  Channels checked      : ${uniqueChannels.length}`);
-  console.log(`  Active assets         : ${stats.active}`);
-  console.log(`  Already flagged       : ${stats.alreadyFlagged}`);
-  console.log(`  Newly flagged         : ${stats.flagged}`);
-  console.log(`  Flag cleared          : ${stats.cleared}`);
-  console.log(`  Entry removed         : ${stats.removed}`);
-  console.log(`  Counterparty skipped  : ${stats.counterpartySkipped}`);
-  console.log(`  Errors                : ${stats.errors}`);
+  for (const [kind, count] of Object.entries(byKind)) {
+    console.log(`  ${kind.padEnd(20)}: ${count}`);
+  }
+  if (Object.keys(byErrorKind).length > 0) {
+    console.log('  error breakdown:');
+    for (const [k, v] of Object.entries(byErrorKind)) {
+      console.log(`    ${k.padEnd(18)}: ${v}`);
+    }
+  }
+  console.log(`  distinct source chains touched: ${affectedChains.size}`);
   console.log('='.repeat(70));
 
-  if (newlyFlagged.length > 0) {
-    console.log('\n🔴 NEWLY FLAGGED unstable (expired/frozen client):');
-    for (const a of newlyFlagged) {
-      const marker = a.added ? ' [new entry]' : '';
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} status=${a.status}  client=${a.clientId ?? '?'}${marker}`);
-    }
-  }
-
-  if (newlyCleared.length > 0) {
-    console.log('\n🟢 FLAG CLEARED (both sides active, entry kept):');
-    for (const a of newlyCleared) {
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} client=${a.clientId ?? '?'}`);
-    }
-  }
-
-  if (newlyRemoved.length > 0) {
-    console.log('\n🗑️  ENTRY REMOVED (both sides active, thin entry):');
-    for (const a of newlyRemoved) {
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} client=${a.clientId ?? '?'}`);
-    }
-  }
-
-  if (counterpartySkipped.length > 0) {
-    console.log('\n🟡 SKIPPED CLEAR (Osmosis active but counterparty unconfirmed):');
-    for (const a of counterpartySkipped) {
-      console.log(`  ${a.symbol.padEnd(20)} ${a.ibcPath.padEnd(45)} counterparty=${a.counterpartyChainName}/${a.counterpartyChannelId} status=${a.cpStatus}`);
-    }
-  }
-
-  if (errorChannels.length > 0) {
-    console.log('\n⚪ ERRORS (flags unchanged):');
-    for (const { channelId, error } of errorChannels) {
-      console.log(`  ${channelId.padEnd(16)} ${error}`);
-    }
-  }
-
-  // Machine-readable summary for the workflow
-  console.log(`\nIBC_NEWLY_FLAGGED=${stats.flagged}`);
-  console.log(`IBC_NEWLY_CLEARED=${stats.cleared + stats.removed}`);
-  console.log(`IBC_ERRORS=${stats.errors}`);
+  // Machine-readable summary
+  console.log(`\nIBC_NEWLY_FLAGGED=${byKind.bridge_down ?? 0}`);
+  console.log(`IBC_NEWLY_CLEARED=${(byKind.bridge_up ?? 0) + (byKind.thin_removed ?? 0)}`);
+  console.log(`IBC_ERRORS=${byKind.ibc_error ?? 0}`);
+  console.log(`AFFECTED_CHAINS=${affectedChains.size}`);
 }
 
 main().catch((err) => {

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -1,0 +1,274 @@
+// Purpose:
+//   Independent market-health track. Daily cron. For each verified non-disabled
+//   asset that isn't already unstable, run a market-health check; on 7 consecutive
+//   failing daily runs, flag it unstable with reason="market" and stamp
+//   state.lastDowntimeDate. Owns recovery for market-unstable assets too:
+//     • 1 consecutive passing run → clear osmosis_halt_deposits if reason
+//       is extended_unstable_market (and no tooltip).
+//     • 7 consecutive passing runs → clear osmosis_unstable AND wipe state
+//       history fields, only if osmosis_unstable_reason === "market".
+//
+//   Reason-vocabulary contract: this script owns reasons {market}.
+//
+// Usage:
+//   node check_market_health.mjs [<zone_name>] [--dry-run] [--force]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  fetchAlloyConstituentMap,
+  fetchNumia,
+  findStateAsset,
+  loadJSON,
+  materialiseStateAsset,
+  resolveMarket,
+} from './lifecycle_helpers.mjs';
+
+const LOW_LIQUIDITY_USD = 1000;        // matches MIN_LIQUIDITY_USD elsewhere
+const LOW_VOLUME_24H_USD = 100;
+const REQUIRED_CONSECUTIVE_RUNS = 7;
+const RECOVERY_RUNS_TO_CLEAR_UNSTABLE = 7;
+// Post-listing grace period: assets within this window from their listing
+// date don't accumulate streak.
+const GRACE_DAYS = 23;
+const GRACE_MS = GRACE_DAYS * 24 * 60 * 60 * 1000;
+// Sentinel listing date used for assets without one (legacy assets).
+const LEGACY_LISTING_DATE = '2022-01-01T00:00:00.000Z';
+
+const MAX_CHAINS_PER_RUN = 10;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const force = args.includes('--force');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+function isPostGrace(stateAsset, nowMs) {
+  // stateAsset may be undefined for assets that have never been tracked yet.
+  // No listing date known → behave post-grace (conservative).
+  const listingDate = stateAsset?.listingDate ?? (stateAsset?.legacyAsset ? LEGACY_LISTING_DATE : null);
+  if (!listingDate) return true;
+  return nowMs - new Date(listingDate).getTime() >= GRACE_MS;
+}
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+
+  // Snapshot the pre-run shape so we only write files that actually changed.
+  // Combined with the findStateAsset / materialiseStateAsset split below,
+  // this guarantees state.json is only rewritten when a real lifecycle
+  // decision happened (not just an iteration).
+  const zoneBefore = JSON.stringify(zoneData);
+  const stateBefore = JSON.stringify(state);
+
+  // Index zone by (chain_name, base_denom), the canonical join into zone_assets.
+  // Each zone_asset's coinMinimalDenom is computed during generate; we'll match
+  // via the frontend's existing coinMinimalDenom -> zone_asset chain_name+base_denom join.
+  const zoneByOrigin = new Map();
+  for (const a of zoneData.assets) {
+    zoneByOrigin.set(`${a.chain_name}:${a.base_denom}`, a);
+  }
+
+  const numia = await fetchNumia();
+
+  // Build the set of alloyed coinMinimalDenoms from the frontend assetlist so
+  // fetchAlloyConstituentMap can intersect SQS pool composition against them.
+  // Then resolve constituent -> alloy denom for every variant currently
+  // sitting in an alloy pool.
+  const alloyedDenomSet = new Set(
+    (frontendData.assets ?? [])
+      .filter((a) => a.isAlloyed)
+      .map((a) => a.coinMinimalDenom)
+  );
+  const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+  const mutations = [];
+
+  for (const asset of frontendData.assets ?? []) {
+    if (!asset.verified) continue;
+    if (asset.disabled) continue;
+    if (asset.preview) continue;
+
+    const zoneKey = `${asset.chainName}:${asset.sourceDenom}`;
+    const zoneAsset = zoneByOrigin.get(zoneKey);
+    if (!zoneAsset) continue;
+
+    // Read-only lookup; never creates a placeholder. We only materialise the
+    // entry on the exact lines that write to it, so state.json doesn't drift
+    // every run.
+    let stateAsset = findStateAsset(state, asset.coinMinimalDenom);
+    const writeState = () => {
+      if (!stateAsset) stateAsset = materialiseStateAsset(state, asset.coinMinimalDenom);
+      return stateAsset;
+    };
+
+    // Alloy-aware market lookup: constituents inherit max(self, alloy).
+    // See lifecycle_helpers.resolveMarket.
+    const market = resolveMarket(numia, constituentToAlloy, asset.coinMinimalDenom);
+    const marketMissing = !market;
+    const failing =
+      !marketMissing &&
+      market.liquidity < LOW_LIQUIDITY_USD &&
+      market.volume24h < LOW_VOLUME_24H_USD;
+    const passing = !marketMissing && !failing;
+
+    if (marketMissing) {
+      mutations.push({ kind: 'market_missing', asset: asset.symbol, denom: asset.coinMinimalDenom });
+      continue; // don't accumulate streak when we have no data
+    }
+
+    if (!zoneAsset.osmosis_unstable) {
+      // ── Not currently unstable: count failing-streak toward flagging ──
+      if (!isPostGrace(stateAsset, nowMs)) continue;
+      // Curator lock: any non-empty tooltip_message blocks the flagging path,
+      // matching the contract used by the recovery path below and by
+      // check_ibc_clients's canModifyUnstable().
+      if (zoneAsset.tooltip_message) continue;
+      if (failing) {
+        const streak = (stateAsset?.marketHealthStreak ?? 0) + 1;
+        writeState().marketHealthStreak = streak;
+        if (streak >= REQUIRED_CONSECUTIVE_RUNS) {
+          zoneAsset.osmosis_unstable = true;
+          zoneAsset.osmosis_unstable_reason = 'market';
+          stateAsset.lastDowntimeDate = nowIso;
+          stateAsset.marketHealthStreak = 0;
+          mutations.push({ kind: 'market_flagged', asset: asset.symbol, chain: asset.chainName });
+        } else {
+          // Informational only; not counted toward the mutation cap.
+          mutations.push({ kind: 'streak_increment', asset: asset.symbol, streak });
+        }
+      } else if (passing) {
+        if (stateAsset?.marketHealthStreak) {
+          stateAsset.marketHealthStreak = 0;
+          mutations.push({ kind: 'streak_reset', asset: asset.symbol });
+        }
+      }
+    } else if (zoneAsset.osmosis_unstable_reason === 'market') {
+      // ── Currently market-unstable: track recovery ──
+      if (passing) {
+        const rstreak = (stateAsset?.marketHealthRecoveryStreak ?? 0) + 1;
+        writeState().marketHealthRecoveryStreak = rstreak;
+
+        // 1-day clear of extended-market-driven halt
+        if (
+          rstreak === 1 &&
+          zoneAsset.osmosis_halt_deposits === true &&
+          zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
+          !zoneAsset.tooltip_message
+        ) {
+          delete zoneAsset.osmosis_halt_deposits;
+          delete zoneAsset.osmosis_deposit_halt_reason;
+          // Includes `chain` so this counts toward the mutation cap. A Numia
+          // glitch that resolves and bulk-passes many failing assets in one
+          // run would otherwise silently clear all their halts.
+          mutations.push({ kind: 'extended_halt_cleared', asset: asset.symbol, chain: asset.chainName });
+        }
+
+        // Full recovery clears osmosis_unstable. Guarded by reason==='market'
+        // (above) AND tooltip_message empty here, mirroring the setting-path
+        // curator-lock contract.
+        if (
+          rstreak >= RECOVERY_RUNS_TO_CLEAR_UNSTABLE &&
+          !zoneAsset.tooltip_message
+        ) {
+          delete zoneAsset.osmosis_unstable;
+          delete zoneAsset.osmosis_unstable_reason;
+          delete stateAsset.lastDowntimeDate;
+          delete stateAsset.lastRecoveryDate;
+          delete stateAsset.marketHealthStreak;
+          delete stateAsset.marketHealthRecoveryStreak;
+          mutations.push({ kind: 'market_recovered', asset: asset.symbol, chain: asset.chainName });
+        }
+      } else if (failing) {
+        if (stateAsset?.marketHealthRecoveryStreak) {
+          stateAsset.marketHealthRecoveryStreak = 0;
+          mutations.push({ kind: 'recovery_reset', asset: asset.symbol });
+        }
+      }
+    }
+    // If unstable but reason !== "market", this script does nothing; the flag
+    // is owned by check_ibc_clients or manual.
+  }
+
+  // ── Mutation cap (per source chain) ─────────────────────────────────────────
+  // streak_increment / streak_reset / recovery_reset / market_missing are
+  // informational; they don't write halt or unstable flags.
+  const INFO_KINDS = new Set(['streak_increment', 'streak_reset', 'recovery_reset', 'market_missing']);
+  const affectedChains = new Set(
+    mutations
+      .filter((m) => m.chain && !INFO_KINDS.has(m.kind))
+      .map((m) => m.chain)
+  );
+  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
+    console.error(
+      `\n⛔ Mutation cap exceeded: would touch ${affectedChains.size} chains ` +
+      `(threshold ${MAX_CHAINS_PER_RUN}). Re-run with --force or --dry-run.`
+    );
+    process.exit(2);
+  }
+
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `market_health_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Market-health dry-run, ${nowIso}`,
+      ``,
+      `Mutations: ${mutations.length}`,
+      `Distinct source chains affected: ${affectedChains.size}`,
+      ``,
+      `| Kind | Asset | Chain |`,
+      `|------|-------|-------|`,
+    ];
+    for (const m of mutations) {
+      lines.push(`| ${m.kind} | ${m.asset ?? '-'} | ${m.chain ?? '-'} |`);
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    return;
+  }
+
+  const zoneChanged = JSON.stringify(zoneData) !== zoneBefore;
+  const stateChanged = JSON.stringify(state) !== stateBefore;
+  if (zoneChanged) {
+    fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+  }
+  if (stateChanged) {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+    console.log(`✓ Updated ${statePath}`);
+  }
+  if (!zoneChanged && !stateChanged) {
+    console.log('No changes needed.');
+  }
+
+  const byKind = {};
+  for (const m of mutations) byKind[m.kind] = (byKind[m.kind] || 0) + 1;
+  console.log('\n' + '='.repeat(70));
+  console.log('  MARKET-HEALTH SUMMARY');
+  console.log('='.repeat(70));
+  for (const [k, v] of Object.entries(byKind)) {
+    console.log(`  ${k.padEnd(28)}: ${v}`);
+  }
+  console.log(`  distinct chains touched   : ${affectedChains.size}`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/check_unverify_candidates.mjs
+++ b/.github/workflows/utility/check_unverify_candidates.mjs
@@ -1,0 +1,197 @@
+// Purpose:
+//   Bi-weekly check (1st & 15th of each month, 16:00 UTC) for assets continuously
+//   unstable for 90+ days. For each such asset, propose flipping
+//   osmosis_verified=false via a single PR. 30-day cooldown via
+//   state.lastUnverifyProposedAt prevents re-proposal within 30 days.
+//
+//   The script:
+//     1. Computes candidates.
+//     2. If --propose (default in CI), mutates zone_assets.json setting
+//        osmosis_verified=false for each, stamps state.lastUnverifyProposedAt,
+//        and writes a PR body markdown to generated/reports/.
+//     3. The calling workflow then uses peter-evans/create-pull-request to
+//        open/update the PR on a fixed branch (auto-unverify/weekly-candidates).
+//
+//   On merge, only osmosis_verified flips. osmosis_unstable + state history
+//   fields stay as record.
+//
+// Usage:
+//   node check_unverify_candidates.mjs [<zone_name>] [--dry-run] [--propose]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { calculateIbcHash } from './assetlist_functions.mjs';
+import {
+  fetchAlloyConstituentMap,
+  fetchNumia,
+  loadJSON,
+  resolveMarket,
+} from './lifecycle_helpers.mjs';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+// Mirrors FLAP_WINDOW_MS in check_ibc_clients.mjs: a recovery older than this
+// is treated as the asset being out of a current incident, not a short flap.
+const FLAP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const propose = args.includes('--propose');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+const statePath = path.join(zonePath, 'generated', 'state', 'state.json');
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+async function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const frontendData = loadJSON(frontendPath);
+  const state = loadJSON(statePath, { assets: [] });
+
+  const stateByDenom = new Map();
+  for (const a of state.assets ?? []) {
+    stateByDenom.set(a.base_denom, a);
+  }
+
+  // Frontend index by coinMinimalDenom for cheap metadata lookup (symbol etc).
+  // Killed-chain assets won't appear here but will still be evaluated via
+  // zone_assets iteration below.
+  const frontendByDenom = new Map();
+  for (const asset of frontendData.assets ?? []) {
+    frontendByDenom.set(asset.coinMinimalDenom, asset);
+  }
+
+  // Numia is non-critical here; we only use it for PR body enrichment.
+  const numia = await fetchNumia({ hardFail: false });
+
+  // Alloy-aware market display: a constituent's standalone Numia row often
+  // reads zero because real trading happens through the alloy. Show the
+  // alloy's signal so reviewers see realistic numbers in the PR body.
+  const alloyedDenomSet = new Set(
+    (frontendData.assets ?? [])
+      .filter((a) => a.isAlloyed)
+      .map((a) => a.coinMinimalDenom)
+  );
+  const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
+
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+  const candidates = [];
+
+  // Iterate zone_assets directly so we cover killed-chain assets whose
+  // generator output disappeared. Compute coinMinimalDenom via the same IBC
+  // hash the generator uses.
+  for (const zoneAsset of zoneData.assets) {
+    if (!zoneAsset.path) continue; // non-IBC entries not handled here
+    if (zoneAsset.osmosis_verified !== true) continue;
+    if (zoneAsset.osmosis_unstable !== true) continue;
+    // Curator lock: a non-empty tooltip_message means the curator owns this
+    // asset; don't propose unverification. Unverify is a heavier action than
+    // a halt flip, and the lock contract should apply just as much here.
+    if (zoneAsset.tooltip_message) continue;
+
+    const coinMinimalDenom = await calculateIbcHash(zoneAsset.path);
+    const stateAsset = stateByDenom.get(coinMinimalDenom);
+    if (!stateAsset?.lastDowntimeDate) continue;
+
+    const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
+    if (downtimeMs < NINETY_DAYS_MS) continue;
+
+    // Skip if the asset has recovered and stayed recovered past the flap
+    // window. check_ibc_clients keeps osmosis_unstable=true after a bridge-up
+    // (to keep the 90-day clock armed in case of re-flap), so a short outage
+    // followed by sustained recovery would otherwise look "continuously
+    // unstable for 90 days" by lastDowntimeDate alone. A recovery older than
+    // FLAP_WINDOW_MS means the asset isn't in a current incident — it would
+    // have been treated as a fresh incident if it went down again.
+    if (stateAsset.lastRecoveryDate) {
+      const recoveredMs = nowMs - new Date(stateAsset.lastRecoveryDate).getTime();
+      if (recoveredMs > FLAP_WINDOW_MS) continue;
+    }
+
+    // Cooldown
+    if (stateAsset.lastUnverifyProposedAt) {
+      const elapsed = nowMs - new Date(stateAsset.lastUnverifyProposedAt).getTime();
+      if (elapsed < COOLDOWN_MS) continue;
+    }
+
+    const feAsset = frontendByDenom.get(coinMinimalDenom);
+    const market = resolveMarket(numia, constituentToAlloy, coinMinimalDenom);
+    candidates.push({
+      chain: zoneAsset.chain_name,
+      symbol: feAsset?.symbol ?? zoneAsset._comment ?? zoneAsset.base_denom,
+      baseDenom: coinMinimalDenom,
+      daysUnstable: Math.floor(downtimeMs / (24 * 60 * 60 * 1000)),
+      reason: zoneAsset.osmosis_unstable_reason ?? '?',
+      lastDowntimeDate: stateAsset.lastDowntimeDate,
+      lastRecoveryDate: stateAsset.lastRecoveryDate ?? '',
+      liquidity: market?.liquidity ?? '?',
+      volume24h: market?.volume24h ?? '?',
+      haltDeposits: zoneAsset.osmosis_halt_deposits === true,
+      haltWithdrawals: zoneAsset.osmosis_halt_withdrawals === true,
+      zoneAsset,
+      stateAsset,
+    });
+  }
+
+  // PR body markdown
+  const prBodyLines = [
+    `## Unverify candidates (90-day unstable threshold)`,
+    ``,
+    `Generated: ${nowIso}`,
+    ``,
+    `${candidates.length} asset(s) have been continuously unstable for 90+ days. ` +
+    `This PR proposes flipping \`osmosis_verified\` to \`false\` for each.`,
+    ``,
+    `On merge, only \`osmosis_verified\` flips. \`osmosis_unstable\` and the ` +
+    `state.json history fields are preserved as record.`,
+    ``,
+    `| Chain | Symbol | Base denom | Days unstable | Reason | Last downtime | Last recovery | Liquidity | Vol 24h | Halt D | Halt W |`,
+    `|-------|--------|-----------|--------------|--------|---------------|---------------|-----------|---------|--------|--------|`,
+  ];
+  for (const c of candidates) {
+    prBodyLines.push(
+      `| ${c.chain} | ${c.symbol} | \`${c.baseDenom}\` | ${c.daysUnstable} | ${c.reason} | ${c.lastDowntimeDate} | ${c.lastRecoveryDate} | ${c.liquidity} | ${c.volume24h} | ${c.haltDeposits ? '✓' : ''} | ${c.haltWithdrawals ? '✓' : ''} |`
+    );
+  }
+
+  if (candidates.length === 0) {
+    console.log('No candidates; nothing to propose.');
+    // Intentionally skip writing the PR body file. The bi-weekly workflow gates
+    // PR creation on the file's existence, so suppressing it here keeps the
+    // workflow silent on quiet weeks (no empty "0 candidates" PR noise).
+    return;
+  }
+
+  fs.mkdirSync(reportsDir, { recursive: true });
+  const reportPath = path.join(reportsDir, 'unverify_candidates_pr_body.md');
+  fs.writeFileSync(reportPath, prBodyLines.join('\n') + '\n', 'utf8');
+
+  console.log(`\n📝 PR body: ${reportPath} (${candidates.length} candidates)`);
+
+  if (dryRun || !propose) {
+    return;
+  }
+
+  // Flip osmosis_verified=false and stamp cooldown
+  for (const c of candidates) {
+    c.zoneAsset.osmosis_verified = false;
+    c.stateAsset.lastUnverifyProposedAt = nowIso;
+  }
+
+  fs.writeFileSync(zoneAssetsPath, JSON.stringify(zoneData, null, 2) + '\n', 'utf8');
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  console.log(`✓ Wrote ${candidates.length} unverify proposals.`);
+  console.log(`✓ Stamped state.lastUnverifyProposedAt for cooldown.`);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/utility/generate_assetlist.mjs
+++ b/.github/workflows/utility/generate_assetlist.mjs
@@ -343,6 +343,7 @@ const generateAssets = async (
     assetlist.setVerifiedStatus(asset_data);
     assetlist.setUnstableStatus(asset_data);
     assetlist.setDisabledStatus(asset_data);
+    assetlist.setHaltStatus(asset_data);
     assetlist.setPreviewStatus(asset_data);
     assetlist.setPrice(asset_data, pool_data);
     assetlist.setListingDate(asset_data);

--- a/.github/workflows/utility/generate_assetlist_functions.mjs
+++ b/.github/workflows/utility/generate_assetlist_functions.mjs
@@ -1229,12 +1229,23 @@ export function setVerifiedStatus(asset_data) {
 export function setUnstableStatus(asset_data) {
 
   asset_data.frontend.unstable = asset_data.zone_asset?.osmosis_unstable;
+  asset_data.frontend.unstableReason = asset_data.zone_asset?.osmosis_unstable_reason;
 
 }
 
 export function setDisabledStatus(asset_data) {
 
   asset_data.frontend.disabled = asset_data.zone_asset?.osmosis_disabled;
+
+}
+
+export function setHaltStatus(asset_data) {
+
+  asset_data.frontend.haltDeposits = asset_data.zone_asset?.osmosis_halt_deposits;
+  asset_data.frontend.depositHaltReason = asset_data.zone_asset?.osmosis_deposit_halt_reason;
+  asset_data.frontend.haltWithdrawals = asset_data.zone_asset?.osmosis_halt_withdrawals;
+  asset_data.frontend.withdrawalHaltReason = asset_data.zone_asset?.osmosis_withdrawal_halt_reason;
+  asset_data.frontend.plannedShutdownDate = asset_data.zone_asset?.planned_shutdown_date;
 
 }
 
@@ -1866,13 +1877,37 @@ export function reformatFrontendAssetFromAssetData(asset_data) {
     contract: asset_data.frontend.contract,
     verified: asset_data.frontend.verified ?? false,
     unstable: asset_data.frontend.unstable ?? false,
+    unstableReason: asset_data.frontend.unstableReason,
     disabled: asset_data.frontend.disabled ?? false,
+    haltDeposits: asset_data.frontend.haltDeposits,
+    depositHaltReason: asset_data.frontend.depositHaltReason,
+    haltWithdrawals: asset_data.frontend.haltWithdrawals,
+    withdrawalHaltReason: asset_data.frontend.withdrawalHaltReason,
+    plannedShutdownDate: asset_data.frontend.plannedShutdownDate,
+    lastDowntimeDate: asset_data.frontend.lastDowntimeDate,
+    lastRecoveryDate: asset_data.frontend.lastRecoveryDate,
     preview: asset_data.frontend.preview ?? false,
     tooltipMessage: asset_data.frontend.tooltipMessage,
     sortWith: asset_data.frontend.sortWith,
     listingDate: asset_data.frontend.listingDate,
     //relatedAssets: asset_data.frontend.relatedAssets,
   };
+
+  // Drop optional fields that are undefined or falsy so they don't appear
+  // as null/false placeholders in the output JSON. The frontend defaults
+  // each of these to false/undefined when absent.
+  for (const k of [
+    "unstableReason",
+    "haltDeposits",
+    "depositHaltReason",
+    "haltWithdrawals",
+    "withdrawalHaltReason",
+    "plannedShutdownDate",
+    "lastDowntimeDate",
+    "lastRecoveryDate",
+  ]) {
+    if (!reformattedAsset[k]) delete reformattedAsset[k];
+  }
 
   if (isNaN(asset_data.frontend.listingDate?.getTime())) {
     // Remove listing_date if it's null
@@ -1883,6 +1918,20 @@ export function reformatFrontendAssetFromAssetData(asset_data) {
   return;
 }
 
+// NOTE: this function is currently a no-op. The body reassigns the local
+// `asset` parameter (last line: `asset = reformattedAsset; return;`) which
+// does not mutate the caller's array element, and there is no return value
+// either. The caller at generate_assetlist.mjs:454 invokes it via
+// `frontend_assets.forEach(asset => assetlist.reformatFrontendAsset(asset))`
+// and discards the result. Lifecycle propagation flows through the sister
+// function reformatFrontendAssetFromAssetData (above) instead.
+//
+// If you fix the no-op so this function actually reorders properties on the
+// frontend asset, add the eight lifecycle keys (unstableReason, haltDeposits,
+// depositHaltReason, haltWithdrawals, withdrawalHaltReason,
+// plannedShutdownDate, lastDowntimeDate, lastRecoveryDate) plus a matching
+// drop-if-falsy loop, mirroring reformatFrontendAssetFromAssetData. Otherwise
+// the lifecycle fields will silently disappear from the published JSON.
 export function reformatFrontendAsset(asset) {
 
   //--Setup Frontend Asset--

--- a/.github/workflows/utility/lifecycle_helpers.mjs
+++ b/.github/workflows/utility/lifecycle_helpers.mjs
@@ -1,0 +1,181 @@
+// Shared helpers for the daily/weekly lifecycle cron scripts:
+//   - check_market_health.mjs
+//   - check_extended_halts.mjs
+//   - check_unverify_candidates.mjs
+//   - asset_status_report.mjs
+//
+// Consolidates what was previously duplicated across all four. Generation-time
+// helpers (update_assetlist_state.mjs's getStateAsset, etc.) intentionally
+// stay separate because they mutate during generation rather than reading a
+// frozen frontend assetlist.
+
+import * as fs from 'fs';
+
+// ── Numia ────────────────────────────────────────────────────────────────────
+
+export const NUMIA_TOKENS_URL = 'https://public-osmosis-api.numia.xyz/tokens/v2/all';
+
+/**
+ * Fetch the Numia token list and build a Map keyed by denom. Each entry holds
+ * { liquidity, volume24h, mcap }; mcap is populated for callers that need it
+ * (asset_status_report) and ignored by everyone else.
+ *
+ * Pass { hardFail: true } when the script cannot meaningfully continue without
+ * Numia data (check_market_health / check_extended_halts). Pass false to
+ * degrade quietly to an empty map (asset_status_report / check_unverify_candidates,
+ * where Numia data is informational).
+ */
+export async function fetchNumia({ hardFail = true } = {}) {
+  const controller = new AbortController();
+  const timeoutMs = 10000;
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(NUMIA_TOKENS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!res.ok) {
+      if (hardFail) {
+        throw new Error(`Numia returned HTTP ${res.status}; aborting (hard-fail policy)`);
+      }
+      return new Map();
+    }
+    const data = await res.json();
+    const byDenom = new Map();
+    for (const t of data) {
+      if (!t.denom) continue;
+      byDenom.set(t.denom, {
+        liquidity: Number(t.liquidity ?? 0),
+        // Several plausible field names in Numia's history; default to 0.
+        volume24h: Number(t.volume_24h ?? t.volume_24h_usd ?? t.volume24h ?? 0),
+        mcap: Number(t.market_cap ?? 0),
+      });
+    }
+    return byDenom;
+  } catch (err) {
+    clearTimeout(timeoutId);
+    if (!hardFail) return new Map();
+    if (err.name === 'AbortError') {
+      throw new Error(`Request to ${NUMIA_TOKENS_URL} timed out after 10s (hard-fail policy)`);
+    }
+    throw new Error(`Failed to fetch from ${NUMIA_TOKENS_URL}: ${err.message}`);
+  }
+}
+
+// ── SQS alloy constituent map ────────────────────────────────────────────────
+
+export const SQS_POOLS_URL = 'https://sqs.osmosis.zone/pools?filter%5Btype%5D=3';
+
+// Mainnet alloyed-transmuter contract code ids. Mirrors the frontend's
+// getAlloyedPoolCodeIds(false) constant in packages/pools/src/pool-constants.ts.
+// Update this set when a new alloyed-transmuter code id is instantiated on
+// chain governance, and confirm the frontend is updated in lockstep.
+export const ALLOYED_POOL_CODE_IDS = new Set([814, 867, 996]);
+
+/**
+ * Build a map from constituent denom -> alloy coinMinimalDenom by pulling
+ * cosmwasm pool composition from SQS and intersecting it with the frontend
+ * assetlist's alloyed assets. A constituent is included only if it currently
+ * holds a positive balance in the alloy pool (whitelisted-but-empty
+ * constituents are excluded; they aren't contributing volume).
+ *
+ * Returns an empty map on SQS error so callers degrade to self-only
+ * evaluation. That fallback matches pre-alloy-awareness behaviour and is
+ * safe in all four lifecycle scripts.
+ */
+export async function fetchAlloyConstituentMap(alloyedDenomSet) {
+  const constituentToAlloy = new Map();
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    const res = await fetch(SQS_POOLS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!res.ok) {
+      console.error(`SQS returned HTTP ${res.status}; alloy-volume inheritance disabled for this run`);
+      return constituentToAlloy;
+    }
+    const body = await res.json();
+    const pools = body?.data ?? [];
+    for (const pool of pools) {
+      const cm = pool?.chain_model ?? {};
+      const codeId = Number(cm.code_id);
+      if (!ALLOYED_POOL_CODE_IDS.has(codeId)) continue;
+      const contractAddr = cm.contract_address;
+      if (!contractAddr) continue;
+      // The factory denom for an alloyed asset is
+      // factory/<contract_address>/alloyed/<sub>, so a startsWith match on
+      // factory/<contract_address>/ is sufficient and avoids parsing the
+      // base64 instantiate_msg.
+      const expectedPrefix = `factory/${contractAddr}/`;
+      const alloyDenom = [...alloyedDenomSet].find((d) => d.startsWith(expectedPrefix));
+      if (!alloyDenom) continue;
+      for (const b of (pool?.balances ?? [])) {
+        if (!b?.denom) continue;
+        // First-write wins. A constituent in multiple alloys does not occur
+        // in current Osmosis state; if it ever does, the first wins.
+        if (!constituentToAlloy.has(b.denom)) {
+          constituentToAlloy.set(b.denom, alloyDenom);
+        }
+      }
+    }
+  } catch (err) {
+    console.error(`SQS fetch failed (${err.message}); alloy-volume inheritance disabled for this run`);
+  }
+  return constituentToAlloy;
+}
+
+/**
+ * Resolve the market signal for an asset, taking max(self, alloy) when the
+ * asset is currently a constituent of an alloyed transmuter pool. Variants
+ * outside any alloy fall back to their own Numia row. Returns undefined when
+ * neither side has data; callers treat that as "market missing".
+ *
+ * mcap is forwarded so asset_status_report's borderline detector can include
+ * it; other callers can ignore the field.
+ */
+export function resolveMarket(numia, constituentToAlloy, coinMinimalDenom) {
+  const self = numia.get(coinMinimalDenom);
+  const alloyDenom = constituentToAlloy.get(coinMinimalDenom);
+  const alloy = alloyDenom ? numia.get(alloyDenom) : undefined;
+  if (!self && !alloy) return undefined;
+  return {
+    liquidity: Math.max(self?.liquidity ?? 0, alloy?.liquidity ?? 0),
+    volume24h: Math.max(self?.volume24h ?? 0, alloy?.volume24h ?? 0),
+    mcap: self?.mcap ?? alloy?.mcap ?? 0,
+  };
+}
+
+// ── Misc ─────────────────────────────────────────────────────────────────────
+
+export function loadJSON(p, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT' && fallback !== undefined) return fallback;
+    throw err;
+  }
+}
+
+// ── State helpers (cron-lifecycle semantics) ────────────────────────────────
+
+/**
+ * Read-only state lookup. Returns undefined when no entry exists. Callers that
+ * only read date/streak fields should use this so the iteration doesn't
+ * pollute state.assets with empty {base_denom} placeholders.
+ */
+export function findStateAsset(state, baseDenom) {
+  return state.assets?.find((a) => a.base_denom === baseDenom);
+}
+
+/**
+ * Create-if-missing state lookup, called only at the exact line that writes
+ * a real value (lastDowntimeDate, marketHealthStreak, etc.). Pair with
+ * findStateAsset to keep state.json stable across no-op runs.
+ */
+export function materialiseStateAsset(state, baseDenom) {
+  let s = findStateAsset(state, baseDenom);
+  if (!s) {
+    s = { base_denom: baseDenom };
+    if (!state.assets) state.assets = [];
+    state.assets.push(s);
+  }
+  return s;
+}

--- a/.github/workflows/utility/update_assetlist_state.mjs
+++ b/.github/workflows/utility/update_assetlist_state.mjs
@@ -44,10 +44,35 @@ const stateDir = path.join(zone.generatedDirectoryName, stateDirName);
 const stateLocations = [
   "assets"
 ];
-const stateAssetProperties = [
-  "listingDate",
-  "legacyAsset"
-];
+/**
+ * Documentation only. Fields tracked on each state.assets[] entry:
+ *
+ *   listingDate                   ISO UTC; existing, date asset was first verified
+ *   legacyAsset                   existing, true if verified before state tracking
+ *
+ *   lastDowntimeDate              ISO UTC; anchors the 60/90-day lifecycle clock
+ *   lastRecoveryDate              ISO UTC; when the bridge/market last recovered
+ *   marketHealthStreak            numeric; consecutive failing market-check runs
+ *   marketHealthRecoveryStreak    numeric; consecutive passing runs while unstable
+ *   lastUnverifyProposedAt        ISO UTC; last time check_unverify_candidates opened a PR
+ *
+ * Indexed by base_denom (which is coinMinimalDenom on Osmosis, e.g. uosmo or ibc/...).
+ * See "Graceful Shutdown of Asset Listings" plan for the lifecycle contract.
+ */
+
+/**
+ * Bidirectional-sync helper: copy a set of state-managed dates onto the
+ * generated assetlist asset so the frontend can read them.
+ * Mirrors the existing setAssetListingDate pattern.
+ */
+function syncStateFieldsToAssetlist(stateAsset, assetlistAsset) {
+  if (stateAsset.lastDowntimeDate) {
+    assetlistAsset.lastDowntimeDate = stateAsset.lastDowntimeDate;
+  }
+  if (stateAsset.lastRecoveryDate) {
+    assetlistAsset.lastRecoveryDate = stateAsset.lastRecoveryDate;
+  }
+}
 
 const currentDateUTC = new Date().toISOString();
 
@@ -143,7 +168,7 @@ function setAssetListingDate(stateAsset, assetlistAsset) {
  * getStateAsset("ibc/NEW...", state)
  * // Returns: { base_denom: "ibc/NEW..." } (newly created, added to state.assets)
  */
-function getStateAsset(base_denom, state) {
+export function getStateAsset(base_denom, state) {
   let stateAsset = state.assets?.find(stateAsset => stateAsset.base_denom === base_denom);
   if (!stateAsset) {
     stateAsset = {
@@ -227,19 +252,21 @@ const generateState = (chainName, assetlist) => {
 
     let stateAsset;
 
-    //see if it's verified, and skip if not
+    //see if it's verified, and skip listing-date logic if not
     if (assetlistAsset.verified) {
-
-      //get the state asset
       stateAsset = getStateAsset(assetlistAsset.coinMinimalDenom, state);
-
-      // Property 1: Get the listing Date
       setAssetListingDate(stateAsset, assetlistAsset);
+    }
 
-
-      // Property 2: anything else...
-
-
+    // Sync lifecycle fields (downtime/recovery dates) onto the assetlist for
+    // both verified and unverified assets, since the frontend banner needs them
+    // even on unverified entries that crossed the 90-day threshold and got
+    // unverified but still carry historical context.
+    const existingState = state.assets?.find(
+      s => s.base_denom === assetlistAsset.coinMinimalDenom
+    );
+    if (existingState) {
+      syncStateFieldsToAssetlist(existingState, assetlistAsset);
     }
 
   }

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 node_modules/
 package-lock.json
-validation.log
+*.log
 new-assets.txt
 new-chains.txt
 newly-verified.txt
 validation-summary.md
 workflow-summary.md
+
+# Local-only artifacts emitted by lifecycle check scripts in dry-run mode
+# and by manual workflow_dispatch runs of asset_status_report.mjs.
+osmosis-1/generated/reports/
+osmo-test-5/generated/reports/
+
+# Local-only output from the inlang localization pipeline; not tracked.
+language_files/

--- a/README.md
+++ b/README.md
@@ -116,14 +116,36 @@ Each asset object in _osmosis.zone_assets.json_ must include these identifying d
 
 #### Transfer & Reliability Flags
 
-- **`osmosis_unstable`** (boolean, default: `false`) - Indicates the asset **cannot reliably** be transferred to or from Osmosis.
-  - **Frontend Behavior**: Sets `unstable: true` in generated assetlist — displays a warning indicator on the asset
-  - **Common Causes**: Expired or frozen IBC client, unreliable relayers, frequent chain downtime
-  - **When to Remove**: After confirming the IBC channel is active and transfers work reliably
+Four orthogonal states describe an asset's transfer health. Each has a distinct UX and is owned by a specific automated script (or the curator).
 
-- **`osmosis_disabled`** (boolean, default: `false`) - Explicitly disables the native IBC Deposit and Withdraw buttons.
-  - **Frontend Behavior**: Sets `disabled: true` in generated assetlist — disables native IBC Deposit/Withdraw buttons
-  - **Common Reasons**: Forcing use of an external or custom transfer method, security or liquidity concerns
+- **`osmosis_unstable`** (boolean, default: `false`). Warning-only indicator. Does not gate the deposit or withdraw flow; surfaces an alert-circle icon on the asset cell and a localised banner on the asset info page.
+  - **Frontend output**: `unstable: true`
+  - **Common causes**: IBC client unstable, source chain killed, sustained low liquidity/volume, manual flag set during an incident
+  - **Companion field**: `osmosis_unstable_reason` (enum, see below) drives the localised banner. The existing `tooltip_message` field is reused for curator free-text.
+
+- **`osmosis_unstable_reason`** (enum: `"ibc_client" | "source_chain_killed" | "market" | "manual"`). Closed-set reason for `osmosis_unstable`. Each value maps to a localised string in the frontend.
+  - **Owners**: `ibc_client` and `source_chain_killed` are owned by `check_ibc_clients.mjs`. `market` is owned by `check_market_health.mjs`. `manual` is the curator's escape hatch; automation never overwrites or clears it.
+
+- **`osmosis_disabled`** (boolean, default: `false`). Internal-deposit UX override. The native flow is skipped in favour of routing the user to an external provider (Skip, Squid, Composable, etc.). **Not** a kill switch; for that, use the halt flags below.
+  - **Frontend output**: `disabled: true`
+  - **Common reasons**: an asset that is only safely transferable through a partner UI (Composable PICA, Wormhole BTC, alloyed asset originators).
+
+- **`osmosis_halt_deposits`** (boolean, default: `false`). Kill switch for the **deposit** direction. The asset-page Deposit button is greyed; the bridge flow renders a "deposits halted" screen with no external-provider fallback. Withdrawals remain available unless `osmosis_halt_withdrawals` is also set.
+  - **Frontend output**: `haltDeposits: true`
+  - **Companion field**: `osmosis_deposit_halt_reason` drives the localised banner.
+
+- **`osmosis_deposit_halt_reason`** (enum: `"bridge_down" | "extended_unstable_market" | "planned_shutdown" | "source_chain_killed" | "manual"`).
+  - **Owners**: `bridge_down` and `source_chain_killed` are owned by `check_ibc_clients.mjs`. `extended_unstable_market` is owned by `check_extended_halts.mjs` (which sets the flag and clears it on the 1-day recovery branch). `check_market_health.mjs` may also clear an `extended_unstable_market` halt as part of its market-recovery flow, but never sets it. `planned_shutdown` is owned by `check_extended_halts.mjs`. `manual` is curator-only.
+
+- **`osmosis_halt_withdrawals`** (boolean, default: `false`). Kill switch for the **withdraw** direction.
+  - **Frontend output**: `haltWithdrawals: true`
+  - **Companion field**: `osmosis_withdrawal_halt_reason` (enum: `"bridge_down" | "source_chain_killed" | "manual"`).
+
+- **`planned_shutdown_date`** (string, ISO 8601 UTC, optional). Date when the asset is scheduled to be shut down. When the date is within 14 days, `check_extended_halts.mjs` pre-emptively sets `osmosis_halt_deposits=true` with reason `planned_shutdown`.
+
+**Tooltip override / curator lock.** The existing `tooltip_message` field doubles as the override signal for automation. If any asset has a non-empty `tooltip_message`, **no automated script will modify its halt or unstable flags** (the curator has taken ownership). Use this when you want to set a halt manually with bespoke context, or when you want to prevent the automated lifecycle from clearing a flag during recovery.
+
+**Reason-vocabulary contract.** Each automated script only modifies flags whose current reason value it owns (see "Owners" above). This means `check_ibc_clients` will never overwrite a `manual` halt or an `extended_unstable_market` halt that another script set. To release a manual override, clear `tooltip_message` and either set the reason back to one the relevant script owns, or remove the flag and let the script re-derive it on the next run.
 
 - **`transfer_methods`** (array) - Custom transfer configurations for assets requiring special handling.
   - Should be included whenever basic IBC transfer cannot carry out an interchain transfer
@@ -211,7 +233,7 @@ For complete schema definitions, see `zone_assets.schema.json`.
 ```
 **Result**: Visible only with "Show Unverified Assets" toggle, native IBC works.
 
-#### Scenario 3: Unreliable IBC - Needs External Interface
+#### Scenario 3: Asset with an unstable IBC channel (warning only)
 ```json
 {
   "chain_name": "genesisl1",
@@ -219,12 +241,13 @@ For complete schema definitions, see `zone_assets.schema.json`.
   "path": "transfer/channel-253/el1",
   "osmosis_verified": false,
   "osmosis_unstable": true,
+  "osmosis_unstable_reason": "ibc_client",
   "_comment": "GenesisL1 $L1"
 }
 ```
-**Result**: Warning indicator shown on asset. Add `osmosis_disabled: true` to also disable native IBC buttons.
+**Result**: Warning indicator (alert-circle icon) shown next to the asset symbol. Both deposit and withdraw flows still work; the frontend renders a localised banner explaining the cause. Typically auto-set by `check_ibc_clients.mjs`.
 
-**To enable native IBC**: Remove `osmosis_unstable` after confirming channels work reliably.
+**To enable native IBC fully**: `check_ibc_clients.mjs` clears `osmosis_unstable` automatically once both IBC clients are Active again. To force-clear, remove the flag manually.
 
 #### Scenario 4: Asset with Custom Transfer Method
 ```json
@@ -246,7 +269,7 @@ For complete schema definitions, see `zone_assets.schema.json`.
 ```
 **Result**: Shows both native IBC and Squid Router options.
 
-#### Scenario 5: Intentionally Disabled Transfers
+#### Scenario 5: Asset routed via external provider only (`osmosis_disabled`)
 ```json
 {
   "chain_name": "composable",
@@ -264,27 +287,73 @@ For complete schema definitions, see `zone_assets.schema.json`.
   "_comment": "Picasso $PICA - use custom interface only"
 }
 ```
-**Result**: Native IBC disabled, shows only Picasso App transfer method.
+**Result**: Native flow is skipped; user is routed straight to the Picasso App. **Both** deposit and withdraw still work, just via the external provider.
 
-### Decision Guide: Enabling Native IBC Transfers
+#### Scenario 6: Deposits halted, withdrawals still open
+```json
+{
+  "chain_name": "namada",
+  "base_denom": "unam",
+  "path": "transfer/channel-XXXX/unam",
+  "osmosis_verified": true,
+  "osmosis_halt_deposits": true,
+  "osmosis_deposit_halt_reason": "manual",
+  "tooltip_message": "Deposits paused pending Namada IBC v0.x release.",
+  "_comment": "Namada $NAM"
+}
+```
+**Result**: Deposit button greyed on every surface (asset page, portfolio, bridge). Bridge flow shows "Deposits halted" with the tooltip text. Withdrawals work normally. The `manual` reason + non-empty `tooltip_message` together lock the halt against any automation.
 
-**Question: Why isn't my asset showing native deposit/withdraw buttons?**
+#### Scenario 7: Asset halted in both directions (incident response)
+```json
+{
+  "chain_name": "examplehub",
+  "base_denom": "uex",
+  "path": "transfer/channel-XXXX/uex",
+  "osmosis_unstable": true,
+  "osmosis_unstable_reason": "manual",
+  "osmosis_halt_deposits": true,
+  "osmosis_deposit_halt_reason": "manual",
+  "osmosis_halt_withdrawals": true,
+  "osmosis_withdrawal_halt_reason": "manual",
+  "tooltip_message": "Exploit response, working with the team. Status: https://status.example.com",
+  "_comment": "Example $EX - halted"
+}
+```
+**Result**: All transfer flows blocked, banner explains the cause, automation leaves the asset alone until the curator clears the tooltip and reasons.
 
-Check your asset configuration for these flags:
+### Decision Guide: Choosing the right flag
 
-1. **`osmosis_disabled: true`** → This disables native IBC buttons
-   - **Solution**: Remove this flag if you want to enable native transfers
-   - Consider: Was this set for security/liquidity management? Verify it's safe to remove
+**Question: My asset's deposit/withdraw buttons are greyed (or missing). Why?**
 
-2. **`osmosis_unstable: true`** → This shows a warning indicator on the asset
-   - The asset may still have IBC buttons enabled unless `osmosis_disabled` is also set
-   - **Solution**: Remove this flag after confirming the IBC channel is active and reliable
+Check the asset entry in order:
 
-**Question: When should I use `osmosis_unstable` vs `osmosis_disabled`?**
+1. **`osmosis_halt_deposits: true`** or **`osmosis_halt_withdrawals: true`** → that direction is halted (kill switch).
+   - **Solution**: clear the flag and its `*_halt_reason`. If `tooltip_message` is set, clearing the reason isn't enough; also clear the tooltip, otherwise automation won't pick the asset back up.
+   - **Consider**: was this auto-set by `check_ibc_clients` / `check_extended_halts`? If so, the underlying cause needs to resolve first (bridge back up, market recovers) or `check_market_health` clears it on the next passing run.
 
-- **Use `osmosis_unstable`**: When the IBC channel has reliability problems (expired client, downtime, slow relayers) — shows a warning flag to users
-- **Use `osmosis_disabled`**: When you want to disable native IBC deposit/withdraw buttons, regardless of reliability
-- **Use both**: When you want to show a warning and disable the buttons
+2. **`osmosis_disabled: true`** → native flow is skipped; the user is sent to an external provider. The button is **not** greyed in this case; it still opens the bridge flow, but the flow renders the external-provider list rather than a native quote.
+   - **Solution**: remove the flag if a native path is now available.
+
+3. **`osmosis_unstable: true`** → warning indicator only. Buttons stay enabled. If they look greyed, check 1 first.
+
+**Question: Which flag should I use?**
+
+| Symptom | Flag(s) to set |
+|---|---|
+| Warn the user but allow transfers | `osmosis_unstable` + `osmosis_unstable_reason` |
+| Force the user to a partner UI for this asset | `osmosis_disabled` |
+| Block deposits, keep withdraws (e.g. broken inbound IBC, planned migration) | `osmosis_halt_deposits` + `osmosis_deposit_halt_reason` |
+| Block withdraws, keep deposits (rare) | `osmosis_halt_withdrawals` + `osmosis_withdrawal_halt_reason` |
+| Block both directions (incident response) | both halt flags + reasons |
+
+**Question: Will automation overwrite my manual changes?**
+
+No, as long as one of the following is true:
+- The reason is set to `"manual"`, or
+- `tooltip_message` is non-empty.
+
+Both serve as curator-lock signals. To hand the asset back to automation, clear the tooltip and either change the reason to one of the script-owned values or remove the flag entirely.
 
 ## Chains
 
@@ -440,12 +509,9 @@ The `Generate All Files` bundle workflow runs automatically and includes:
   - Creates minimal entries (chain_name + comment) for chains in `zone_assets.json` not yet in `zone_chains.json`
   - Makes it easy for maintainers to add custom RPC/REST endpoints later
   - All fields default to Chain Registry values unless explicitly overridden
-- Checks IBC client health for all IBC assets and automatically updates `osmosis_unstable` in `osmosis.zone_assets.json`
-  - Sources assets from the generated frontend assetlist (catches auto-detected assets with no zone_assets entry)
-  - Sets `osmosis_unstable: true` for assets whose Osmosis-side IBC client is Expired or Frozen; adds a minimal entry if none exists
-  - Clears `osmosis_unstable` only when **both** the Osmosis-side and counterparty-side clients are confirmed Active
-  - Removes auto-added minimal entries entirely when they recover (entries with no other meaningful fields)
-  - Runs before assetlist generation so the generated frontend output reflects correct flags in the same run
+- Runs the **bridge-state check** (`check_ibc_clients.mjs`): unified detection that drives both the IBC and killed-chain branches of the lifecycle (see "Asset lifecycle automation" below).
+- Runs the **market-health check** (`check_market_health.mjs`): independent unstable track driven by Numia liquidity/volume.
+- Runs the **extended-halts check** (`check_extended_halts.mjs`): 60-day deposit halt and planned-shutdown halt.
 - Validates RPC/REST endpoints for all chains (full validation, batched 10 at a time)
   - Tracks validation results in `state/state.json` for endpoint optimization
   - Reorders endpoints based on health (working backups promoted, failed endpoints deprioritized)
@@ -466,6 +532,76 @@ Individual generation workflows can be triggered manually via GitHub Actions:
 - `Localization` - Update translations
 
 **Note on Pool Pricing:** Pool-based pricing functionality (`getPools.mjs`) exists in the codebase but is currently disabled via the `getPools = false` flag in `generate_assetlist.mjs`. This code includes pool querying, asset pricing calculations, and routing logic. It was previously used to add pricing information to generated assetlists but is not currently active. The code remains available for future re-implementation if needed.
+
+### Asset lifecycle automation
+
+When an asset stops working, it moves through a single observable timeline anchored on `state.lastDowntimeDate`. Five automated scripts cooperate to drive that timeline, each with a well-defined scope and a non-overlapping set of "reason" enum values it owns.
+
+#### The four-state model
+
+| State | Frontend effect | Set by |
+|---|---|---|
+| `osmosis_unstable` (warning only) | Alert-circle icon + localised banner; both directions still work | `check_ibc_clients`, `check_market_health`, or curator |
+| `osmosis_disabled` (external-router) | Native flow skipped; user is routed to an external provider | Curator only |
+| `osmosis_halt_deposits` (kill switch) | Deposit button greyed everywhere; bridge flow blocked, no external fallback | `check_ibc_clients`, `check_extended_halts`, or curator |
+| `osmosis_halt_withdrawals` (kill switch) | Withdraw button greyed everywhere; bridge flow blocked, no external fallback | `check_ibc_clients` or curator |
+
+Each flag has a paired `*_reason` enum field. The frontend uses the reason to pick a localised banner string. The existing `tooltip_message` field is reused for curator free-text, and a non-empty `tooltip_message` locks the asset against all automation.
+
+#### Daily timeline
+
+```
+   no flag
+      │
+      │  bridge_down detected
+      │  (IBC Expired/Frozen on either side, OR source chain status="killed")
+      ▼
+   osmosis_unstable=true, halt_deposits=true, halt_withdrawals=true
+   reasons: ibc_client | source_chain_killed
+   state.lastDowntimeDate = <now>
+      │
+      ├──── bridge_up detected (both clients Active AND chain status="live")
+      │     ▼
+      │     halt_deposits=false, halt_withdrawals=false
+      │     osmosis_unstable stays
+      │     state.lastRecoveryDate = <now>
+      │        │
+      │        │   60 days since state.lastDowntimeDate AND market still failing
+      │        ▼
+      │        halt_deposits=true (reason: extended_unstable_market)
+      │        withdrawals stay open
+      │
+      │  90 days since state.lastDowntimeDate (regardless of intervening recovery)
+      ▼
+   PR opened proposing osmosis_verified=false
+   state.lastUnverifyProposedAt = <now> (30-day cooldown)
+   On merge: only osmosis_verified flips; unstable + state history kept as record.
+```
+
+A second, independent track exists for market-driven unstable. When a verified, non-disabled asset is post-grace (23+ days past listing) and fails the market check (`liquidity < $1k && volume_24h < $100`) for 7 consecutive daily runs, it is flagged with reason `market`. The same 60/90-day timeline applies. Recovery is single-day for the halt and 7-day for the full unstable clear; on full recovery, state history is wiped.
+
+#### Scripts in the daily cron (in order)
+
+1. **`check_ibc_clients.mjs`**, the unified bridge-state check. Detects IBC client status and source chain `status="killed"`. Owns reasons `ibc_client`, `source_chain_killed` (unstable) and `bridge_down`, `source_chain_killed` (halts). Implements the flap-vs-fresh-incident rule (within 30 days of recovery = continuation; beyond = fresh incident). Includes a "manual-flip safety net" that populates `state.lastDowntimeDate` if a curator manually sets `osmosis_unstable` without one.
+
+2. **`check_market_health.mjs`**, the market track. Owns reason `market` for unstable and is the **only** writer that fully recovers an asset from market-driven instability. Skipped for unverified, disabled, and preview assets, and for assets within the 23-day post-listing grace window. Alloyed assets are evaluated normally; constituents of an alloy inherit the alloy's volume and liquidity via `max(self, alloy)` so they are not falsely flagged when their standalone Numia row reads zero but the alloy carries real activity. Constituent membership is determined from SQS pool composition (positive balance in the alloyed transmuter pool).
+
+3. **`check_extended_halts.mjs`**, the 60-day rule and planned-shutdown rule. Owns reasons `extended_unstable_market` and `planned_shutdown` for deposit halts. Pre-emptively halts deposits 14 days before a `planned_shutdown_date`.
+
+#### Weekly cron
+
+**`check_unverify_candidates.mjs`** (Mondays at 16:00 UTC, via `propose_unverify.yml`). Collects every verified asset that has been continuously unstable for 90+ days and hasn't had an unverify PR opened in the last 30 days. Flips `osmosis_verified=false` for each, writes a markdown PR body, stamps `state.lastUnverifyProposedAt` for cooldown, and the workflow opens or updates a PR on a fixed branch (`auto-unverify/weekly-candidates`). The PR requires human approval.
+
+#### On-demand utility
+
+**`asset_status_report.mjs`** (read-only, `workflow_dispatch`-triggered). Produces a six-section markdown report covering unstable assets, halt status, disabled assets, verification-borderline assets, pending unverifies in cooldown, and detected invariant violations.
+
+#### Safety mechanisms
+
+- **`--dry-run` flag.** Every writer script accepts `--dry-run`, which emits a markdown report of intended mutations without writing any file. Always use this before enabling a fresh script in CI or after a chain-registry submodule bump that might flip many chains at once.
+- **Mutation cap.** No script will write changes touching more than **10 distinct source chains** in a single run. If exceeded, the script exits with code 2 and demands a `--force` flag. This catches mass-flips from upstream regressions.
+- **Reason-vocabulary contract.** Each reason enum value has exactly one owner script (or `manual` = the curator). No two scripts ever race on the same flag.
+- **Curator lock.** Any non-empty `tooltip_message` on a halted or unstable asset is treated as curator-owned and never overwritten by automation. To release the lock, clear the tooltip.
 
 ### Pull Request Workflow
 

--- a/RUNBOOKS.md
+++ b/RUNBOOKS.md
@@ -986,3 +986,54 @@ After emergency resolved:
    # Post in Discord if user-facing
    # Update status if posted outage notice
 ```
+
+---
+
+### RB006: Manually override an auto-set halt
+
+**Use when**: an automated halt (e.g. reason `bridge_down`) is in effect but you want to keep the asset halted with bespoke context, or override the cause description even though automation would otherwise clear the flag on recovery.
+
+#### Procedure
+
+Edit the zone_assets entry directly:
+
+```json
+{
+  "chain_name": "examplehub",
+  "base_denom": "uex",
+  "osmosis_halt_deposits": true,
+  "osmosis_deposit_halt_reason": "manual",
+  "tooltip_message": "Deposits paused pending the v0.5 chain upgrade scheduled 2026-06-10. Status: https://status.example.com"
+}
+```
+
+Two changes from an auto-set halt:
+
+1. The `*_halt_reason` is set to `manual`. Script-owned reasons get auto-cleared on recovery; `manual` does not.
+2. `tooltip_message` is non-empty. Any tooltip locks the asset against all automation.
+
+Commit and let the daily cron run. Verify the asset is now ignored by automation by checking the next workflow summary's "Manual halts currently in effect" section.
+
+#### Release the override
+
+Clear `tooltip_message` and set the reason back to a script-owned value (or just remove both flags entirely). The next daily run will re-derive the state.
+
+---
+
+### RB007: Weekly unverify PR, close vs merge
+
+**Use when**: the weekly `auto-unverify/weekly-candidates` PR is open and you need to decide what to do.
+
+#### Procedure
+
+The PR body lists each candidate with days unstable, reason, last downtime / recovery, halt status, liquidity, and volume. For each candidate:
+
+- **Merge if** the asset has been broken for 90+ days, the underlying issue isn't expected to resolve, and the market data confirms no real activity. Merge flips `osmosis_verified=false`; all history fields stay as record.
+- **Close (don't merge) if** the asset is recovering, has an active community working on the fix, or there's a strategic reason to keep it verified. Closing triggers a 30-day cooldown, so the asset won't be re-proposed until then.
+- **Edit the PR (remove rows) if** you want to unverify some but not all candidates. Use `git rebase` or commit a follow-up to the same branch, then merge.
+
+#### Notes
+
+- `osmosis_unstable` and the state history fields are preserved on unverify. This is intentional, so a later re-verification carries the prior incident record.
+- A re-verified asset that's still carrying stale dates should have them manually cleared at re-verify time.
+- The cooldown is per-asset, not per-PR. Closing the PR stamps `state.lastUnverifyProposedAt` for every candidate that was in the PR.

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -50,11 +50,45 @@
         },
         "osmosis_unstable": {
           "type": "boolean",
-          "description": "Whether the asset can reliably be transferred to or from Osmosis."
+          "description": "Whether the asset has experienced or is experiencing instability. Warning-only flag; does not gate transfers."
+        },
+        "osmosis_unstable_reason": {
+          "type": "string",
+          "enum": ["ibc_client", "source_chain_killed", "market", "manual"],
+          "description": "Closed-set reason for the unstable flag. Each has a localization key in the frontend. Curator-written context for any halt/unstable state lives in the existing `tooltip_message` field."
         },
         "osmosis_disabled": {
           "type": "boolean",
-          "description": "Whether the asset Deposit and Withdraw functions are disabled on Osmosis."
+          "description": "Whether the native Deposit/Withdraw flow should be skipped, routing the user to an external provider instead. UX router, not a kill switch."
+        },
+        "osmosis_halt_deposits": {
+          "type": "boolean",
+          "description": "Kill switch: deposits are halted. Asset-page Deposit button is greyed and the bridge flow blocks the deposit direction."
+        },
+        "osmosis_deposit_halt_reason": {
+          "type": "string",
+          "enum": [
+            "bridge_down",
+            "extended_unstable_market",
+            "planned_shutdown",
+            "source_chain_killed",
+            "manual"
+          ],
+          "description": "Closed-set reason for the deposit halt. Drives the localized banner. Curator-written context lives in the existing `tooltip_message` field."
+        },
+        "osmosis_halt_withdrawals": {
+          "type": "boolean",
+          "description": "Kill switch: withdrawals are halted."
+        },
+        "osmosis_withdrawal_halt_reason": {
+          "type": "string",
+          "enum": ["bridge_down", "source_chain_killed", "manual"],
+          "description": "Closed-set reason for the withdrawal halt. Curator-written context lives in the existing `tooltip_message` field."
+        },
+        "planned_shutdown_date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+          "description": "ISO UTC date when this asset is scheduled to be shut down. Used by check_extended_halts.mjs to pre-emptively halt deposits 14 days before the shutdown date."
         },
         "is_alloyed": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

Restores the **non-generated** portions of #3500, #3501, and #3502 that were rolled back in #3504, AND re-enables propagation of new lifecycle fields onto the generated frontend assetlist now that the frontend `Asset` type ships in [osmosis-frontend#4358](https://github.com/osmosis-labs/osmosis-frontend/pull/4358).

Also adds alloy-aware market-health evaluation so constituents of healthy alloys (USDT.eth.axl, ETH.axl, WBTC variants, etc.) are not falsely flagged as low-market when their standalone Numia volume reads zero but the alloy pool carries real activity.

Companion PR for the localisation dot-escape fix: #3505 (merged).

## What this brings back

**Lifecycle scripts:**
- `check_ibc_clients.mjs` (extensive rewrite: safety-net pass, reason backfill, read-only state lookup, source-chain-killed classification)
- `check_market_health.mjs` (with alloy-aware inheritance, see below)
- `check_extended_halts.mjs`, `check_unverify_candidates.mjs`, `asset_status_report.mjs` (new)
- `propose_unverify.yml` workflow (new)

**Workflow integration (`generate_all_files.yml`):**
- Invokes each lifecycle script in turn
- Captures `market-health.log` and `extended-halts.log` for the daily PR body
- Scrapes mutation counts into env vars
- Renders a quick-glance summary at the top of the PR with one row per category
- Mutation-cap banner moved above the detail sections

**Schema and docs:**
- `zone_assets.schema.json`: `tooltip_message`, `planned_shutdown_date`, halt/unstable reason enums
- `README.md` / `RUNBOOKS.md`: lifecycle field descriptions and operator scenarios

**Frontend propagation (re-enabled):**
- `generate_assetlist_functions.mjs`: `reformatFrontendAssetFromAssetData` emits the eight lifecycle keys (`unstableReason`, `haltDeposits`, `depositHaltReason`, `haltWithdrawals`, `withdrawalHaltReason`, `plannedShutdownDate`, `lastDowntimeDate`, `lastRecoveryDate`). Optional-field-drop arrays remove falsy values so they don't appear as null/false placeholders.
- `update_assetlist_state.mjs`: `syncStateFieldsToAssetlist` helper copies `lastDowntimeDate` and `lastRecoveryDate` from `state.json` onto the generated assetlist.

**Housekeeping:**
- `.gitignore`: `*.log` (untracks ephemeral lifecycle logs) and the `generated/reports/` directories

## Alloy-aware market health

`check_market_health.mjs` now queries SQS (`/pools?filter[type]=3`) and filters cosmwasm pools by the mainnet alloyed-transmuter code IDs (`814`, `867`, `996`) to build a constituent->alloy map. A constituent is any denom currently sitting with positive balance in an alloyed pool; whitelisted-but-empty constituents are deliberately excluded since they cannot inherit volume they are not contributing to.

For each non-alloyed asset being evaluated, the script compares `max(self.liquidity, alloy.liquidity)` and `max(self.volume24h, alloy.volume24h)` against the `LOW_*` thresholds. Constituents whose real trading happens through the alloy pool (e.g. `USDT.eth.axl`, `USDT.kava`, `ETH.axl`, `WBTC` variants) inherit the alloy's signal and are no longer flagged when their own Numia row reads zero.

**Alloys themselves are evaluated normally** (the previous `if (isAlloyed(asset)) continue;` skip was removed). A healthy alloy passes its check and protects its constituents via the max() rule. An unhealthy alloy fails its own check and is flagged like any other low-market asset.

SQS fetch degrades safely: on timeout or non-200, the constituent map stays empty, the per-asset loop falls back to self-only evaluation (the previous behaviour), and an error line goes to stderr. The script does not abort.

Verified via dry-run with current data:
- All 9 healthy alloys (BTC, ETH, DOGE, XRP, USDT, SOL, LINK, BNB, FET) pass.
- All 16 verified unhealthy alloys are flagged (3 of the 19 unhealthy alloys are skipped at the verified-only gate, by design).
- Constituents of healthy alloys (sampled USDT.eth.axl, USDT.kava, USDT.eth.pica, ETH.axl, WBTC, DOGE.int3) all pass.
- A variant not in any alloy pool (ETH.wh, zero balance in allETH) is correctly flagged when its own Numia row fails.

## What is NOT in this PR

- **Migration data**: `osmosis-1/osmosis.zone_assets.json` is unchanged. The 146 bridge_down halt clusters and 222 safety-net stamps from #3501 are not in this PR; they will be applied by running `check_ibc_clients.mjs --force` once after merge.
- **Generated artifacts**: `osmosis-1/generated/*` is unchanged. These regenerate automatically on the next cron.

## Frontend coordination

[osmosis-frontend#4358](https://github.com/osmosis-labs/osmosis-frontend/pull/4358) ships the `Asset` and `MinimalAsset` type additions for these eight fields. All fields are optional, so the frontend build is safe both before and after this PR lands. Once both PRs are merged, the next daily AUTO cron produces a frontend assetlist carrying lifecycle data and the UI renders halt banners, unstable warnings, and curator-override tooltips on the affected assets.

## Suggested rollout

1. Merge osmosis-frontend#4358 (frontend types ship; fields all optional so no UI change yet).
2. Merge this PR (lifecycle scripts + propagation + alloy-aware market health).
3. Run `node check_ibc_clients.mjs osmosis-1 --force --lcd https://osmosis-lcd.publicnode.com` for the initial migration. Populates 146 bridge_down clusters + 222 safety-net reason backfills across 13 chains.
4. Watch the next daily 15:00 UTC cron run to confirm the generated frontend assetlist now carries lifecycle fields, and that the frontend renders halts and unstable warnings on the affected assets.

## Verify

- [ ] `node -c` parses each of the four new and one rewritten `.mjs` files.
- [ ] Lifecycle scripts run end-to-end via `node check_ibc_clients.mjs osmosis-1 --dry-run --lcd https://osmosis-lcd.publicnode.com` and produce the expected dry-run report.
- [ ] `node check_market_health.mjs osmosis-1 --dry-run` reports zero false-positive flags on constituents of currently-healthy alloys.
- [ ] `osmosis-1/generated/frontend/assetlist.json` after a fresh `generate_assetlist.mjs` run carries `unstableReason`, `haltDeposits`, etc. on populated assets (will be visible after the post-merge `--force` migration).
- [ ] osmosis-frontend builds clean before and after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes automated workflows/scripts that can mutate `osmosis.zone_assets.json` and `state.json`, including automatically halting deposits/withdrawals and proposing unverifications, which can directly impact user transfer availability and asset visibility.
> 
> **Overview**
> Adds a new *asset lifecycle automation pipeline* to the daily `generate_all_files` workflow: runs the rewritten `check_ibc_clients` bridge-state check plus new `check_market_health` and `check_extended_halts` scripts, snapshots `zone_assets` for before/after diffing, and generates a PR body with a quick-glance lifecycle summary (including mutation-cap warnings, manual-halt visibility, and log excerpts).
> 
> Introduces new lifecycle scripts and workflows: a bi-weekly `propose_unverify` job that opens/updates a PR to flip `osmosis_verified=false` for 90+ day unstable assets (with cooldown tracking), plus utility scripts for market-driven instability, 60-day/planned-shutdown deposit halts, and an on-demand markdown `asset_status_report`.
> 
> Propagates lifecycle fields into the generated frontend assetlist by emitting `unstableReason`/halt fields and syncing `state` downtime/recovery dates, updates `zone_assets.schema.json` and docs to define new flags/reason enums and curator-lock semantics, and ignores generated logs/reports via `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb068c01913a9e04c9773111ecc03681c4bca675. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

