### PR TITLE
chore: TEMP hack lifecycle fields onto sample unstable assets

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -1774,7 +1774,12 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "manual",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "tooltipMessage": "Starname is undergoing scheduled maintenance until further notice. See https://twitter.com/starnameme for updates."
     },
     {
       "chainName": "emoney",
@@ -1828,7 +1833,9 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "market",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
     },
     {
       "chainName": "emoney",
@@ -1932,7 +1939,9 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "ibc_client",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
     },
     {
       "chainName": "impacthub",
@@ -2140,7 +2149,11 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "ibc_client",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down"
     },
     {
       "chainName": "panacea",
@@ -2406,7 +2419,12 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "ibc_client",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
+      "haltDeposits": true,
+      "depositHaltReason": "planned_shutdown",
+      "plannedShutdownDate": "2026-08-15T00:00:00.000Z"
     },
     {
       "chainName": "vidulum",
@@ -2452,7 +2470,10 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "market",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
+      "lastRecoveryDate": "2026-05-15T08:00:00.000Z"
     },
     {
       "chainName": "desmos",
@@ -2506,7 +2527,9 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "manual",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
     },
     {
       "chainName": "dig",
@@ -2697,7 +2720,13 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "source_chain_killed",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
+      "haltDeposits": true,
+      "depositHaltReason": "source_chain_killed",
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "source_chain_killed"
     },
     {
       "chainName": "umee",
@@ -5193,7 +5222,11 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "market",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
+      "haltDeposits": true,
+      "depositHaltReason": "extended_unstable_market"
     },
     {
       "chainName": "echelon",
@@ -5708,7 +5741,9 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "unstableReason": "source_chain_killed",
+      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
     },
     {
       "chainName": "lumenx",
@@ -15393,7 +15428,7 @@
         }
       ],
       "variantGroupKey": "ibc/176DD560277BB0BD676260BE02EBAB697725CA85144D8A2BF286C6B5323DB5FE",
-      "name": "Junø Apes",
+      "name": "Jun\u00c3\u00b8 Apes",
       "isAlloyed": false,
       "verified": false,
       "unstable": false,
@@ -28791,7 +28826,7 @@
       "transferMethods": [],
       "counterparty": [],
       "variantGroupKey": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/ba-ba",
-      "name": "von Baysen-Bażeński",
+      "name": "von Baysen-Ba\u00c5\u00bce\u00c5\u201eski",
       "isAlloyed": false,
       "verified": false,
       "unstable": false,


### PR DESCRIPTION
## ⚠️ TEMPORARY — to be reverted

Hacks `osmosis-1/generated/frontend/assetlist.json` directly to populate the new lifecycle fields on 10 already-unstable verified assets, so the [osmosis-frontend `jw-disablerevamp` branch](https://github.com/osmosis-labs/osmosis-frontend/tree/jw-disablerevamp) can render each halt and unstable scenario against real production data.

This PR will be reverted once the frontend disable-revamp landing has been signed off.

## While this is live

- **Production**: unaffected (already-built cached deploy).
- **Frontend `stage` / `main` builds**: will fail typecheck because their `Asset` type does not yet declare `unstableReason`, `haltDeposits`, `depositHaltReason`, `haltWithdrawals`, `withdrawalHaltReason`, `plannedShutdownDate`, `lastDowntimeDate`, `lastRecoveryDate`. Expected, do not panic-revert other branches.
- **Frontend `jw-disablerevamp`**: adds those fields to `Asset` and `MinimalAsset`, will continue to build.

## Sample matrix

| Symbol | Chain | `unstableReason` | `haltDeposits` reason | Notes |
|---|---|---|---|---|
| IOV | starname | `manual` | `manual` | Has `tooltipMessage` (curator-lock) |
| NGM | emoney | `market` | none | Unstable only |
| LIKE | likecoin | `ibc_client` | none | Unstable only |
| XKI | kichain | `ibc_client` | `bridge_down` | Deposits halted |
| LUM | lumnetwork | `ibc_client` | `planned_shutdown` | Has `plannedShutdownDate` (2026-08-15) |
| VDL.vdl | vidulum | `market` | none | Has `lastRecoveryDate` (recovered) |
| DSM | desmos | `manual` | none | Unstable only |
| DARC | konstellation | `source_chain_killed` | `source_chain_killed` | Both directions halted |
| TGD | tgrade | `market` | `extended_unstable_market` | Deposits halted |
| CRE | crescent | `source_chain_killed` | none | Unstable only |

Dates:
- `lastDowntimeDate`: 2026-02-20 (90 days ago) so the 60/90-day clock renders against a non-trivial duration.
- VDL's `lastRecoveryDate`: 2026-05-15 (5 days ago).
- LUM's `plannedShutdownDate`: 2026-08-15 (~3 months out).

## Cron interaction

The daily AUTO cron at 15:00 UTC will overwrite this file with the regenerated assetlist (which lacks these fields). That's fine: this hack is meant to be short-lived. If a second test cycle is needed after a cron run, re-apply by re-running the snippet in the commit body or this PR.

## Revert plan

1. Sign off on FE rendering on `jw-disablerevamp`.
2. Open the FE PR for review.
3. Merge a revert of this PR.
4. Next AUTO cron normalises everything back to production state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits a generated `assetlist.json` to add temporary metadata used by a frontend branch; risk is mainly downstream consumers/typechecks breaking due to new fields and a couple of name string encoding changes.
> 
> **Overview**
> Adds *temporary lifecycle/halt metadata* directly to `osmosis-1/generated/frontend/assetlist.json` for a handful of already-`unstable` verified assets (e.g., `unstableReason`, `lastDowntimeDate`, optional `lastRecoveryDate`/`plannedShutdownDate`, and deposit/withdrawal halt flags with reasons plus an optional `tooltipMessage`).
> 
> Also tweaks a couple of asset `name` strings due to escaped/unicode encoding and normalizes the file ending by adding a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fdec839f4811de7f6a446194863979ebcf26f8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->