### PR TITLE
Revert "chore: TEMP hack lifecycle fields onto sample unstable assets"

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -1774,12 +1774,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "manual",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
-      "haltDeposits": true,
-      "depositHaltReason": "manual",
-      "tooltipMessage": "Starname is undergoing scheduled maintenance until further notice. See https://twitter.com/starnameme for updates."
+      "preview": false
     },
     {
       "chainName": "emoney",
@@ -1833,9 +1828,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "market",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
+      "preview": false
     },
     {
       "chainName": "emoney",
@@ -1939,9 +1932,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "ibc_client",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
+      "preview": false
     },
     {
       "chainName": "impacthub",
@@ -2149,11 +2140,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "ibc_client",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
-      "haltDeposits": true,
-      "depositHaltReason": "bridge_down"
+      "preview": false
     },
     {
       "chainName": "panacea",
@@ -2419,12 +2406,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "ibc_client",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
-      "haltDeposits": true,
-      "depositHaltReason": "planned_shutdown",
-      "plannedShutdownDate": "2026-08-15T00:00:00.000Z"
+      "preview": false
     },
     {
       "chainName": "vidulum",
@@ -2470,10 +2452,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "market",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
-      "lastRecoveryDate": "2026-05-15T08:00:00.000Z"
+      "preview": false
     },
     {
       "chainName": "desmos",
@@ -2527,9 +2506,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "manual",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
+      "preview": false
     },
     {
       "chainName": "dig",
@@ -2720,13 +2697,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "source_chain_killed",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
-      "haltDeposits": true,
-      "depositHaltReason": "source_chain_killed",
-      "haltWithdrawals": true,
-      "withdrawalHaltReason": "source_chain_killed"
+      "preview": false
     },
     {
       "chainName": "umee",
@@ -5222,11 +5193,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "market",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z",
-      "haltDeposits": true,
-      "depositHaltReason": "extended_unstable_market"
+      "preview": false
     },
     {
       "chainName": "echelon",
@@ -5741,9 +5708,7 @@
       "verified": true,
       "unstable": true,
       "disabled": false,
-      "preview": false,
-      "unstableReason": "source_chain_killed",
-      "lastDowntimeDate": "2026-02-20T12:00:00.000Z"
+      "preview": false
     },
     {
       "chainName": "lumenx",
@@ -15428,7 +15393,7 @@
         }
       ],
       "variantGroupKey": "ibc/176DD560277BB0BD676260BE02EBAB697725CA85144D8A2BF286C6B5323DB5FE",
-      "name": "Jun\u00c3\u00b8 Apes",
+      "name": "Junø Apes",
       "isAlloyed": false,
       "verified": false,
       "unstable": false,
@@ -28826,7 +28791,7 @@
       "transferMethods": [],
       "counterparty": [],
       "variantGroupKey": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/ba-ba",
-      "name": "von Baysen-Ba\u00c5\u00bce\u00c5\u201eski",
+      "name": "von Baysen-Bażeński",
       "isAlloyed": false,
       "verified": false,
       "unstable": false,


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#3509

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates only generated `assetlist.json` metadata by removing temporary lifecycle/halts fields and fixing a couple of token name encodings; no logic changes.
> 
> **Overview**
> Reverts a temporary hack in `osmosis-1/generated/frontend/assetlist.json` by removing added lifecycle metadata on several unstable assets (e.g., `unstableReason`, downtime/recovery dates, deposit/withdrawal halt flags, planned shutdown info, and tooltip text).
> 
> Also corrects two asset `name` strings that were previously mis-encoded (e.g., `Junø Apes`, `von Baysen-Bażeński`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721237ef05056f8f34f867f4f28db6159522518e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->