### PR TITLE
fix(ibc-check): per-asset counterparty triple, clear stale cw20 flags

### DIFF
--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -253,8 +253,13 @@ function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByNa
   return endpoints;
 }
 
-async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByName, chainlistByName, deadEndpoints) {
+async function getCounterpartyClientStatus(chainName, channelId, port, zoneChainsByName, chainlistByName, deadEndpoints) {
   if (!chainName || !channelId) return 'unknown';
+  // Default to 'transfer' for plain bank-denom IBC. cw20 wrappers on Secret
+  // Network (and similar wasm-bound IBC variants) bind the counterparty
+  // channel to a contract-specific port like `wasm.secret1...`; the lookup
+  // must target that exact port or it will return nothing.
+  const counterpartyPort = port || 'transfer';
 
   const endpoints = getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName);
   if (endpoints === null) return 'killed';
@@ -265,7 +270,7 @@ async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByNam
 
     try {
       const channelData = await fetchJSONWithTimeout(
-        `${endpoint}/ibc/core/channel/v1/channels/${channelId}/ports/transfer`
+        `${endpoint}/ibc/core/channel/v1/channels/${channelId}/ports/${counterpartyPort}`
       );
       const connectionId = channelData.channel?.connection_hops?.[0];
       if (!connectionId) continue;
@@ -452,7 +457,13 @@ async function main() {
     if (asset.path) zoneByPath.set(asset.path, asset);
   }
 
-  // Group frontend IBC assets by channel.
+  // Group frontend IBC assets by Osmosis-side channel id, but record
+  // the counterparty (chainName, channelId, port) on each asset entry
+  // rather than once per channel. A single Osmosis channel can be shared
+  // by multiple asset variants whose counterparty side uses different
+  // ports (e.g. plain `transfer` for native denoms vs. `wasm.<contract>`
+  // for cw20 wrappers on Secret Network); collapsing them per-channel
+  // drops one variant on the floor.
   const channelMap = new Map();
   for (const asset of frontendData.assets ?? []) {
     const ibcMethod = asset.transferMethods?.find((m) => m.type === 'ibc');
@@ -460,11 +471,7 @@ async function main() {
 
     const channelId = ibcMethod.chain.channelId;
     if (!channelMap.has(channelId)) {
-      channelMap.set(channelId, {
-        assets: [],
-        counterpartyChainName: ibcMethod.counterparty?.chainName,
-        counterpartyChannelId: ibcMethod.counterparty?.channelId,
-      });
+      channelMap.set(channelId, { assets: [] });
     }
     channelMap.get(channelId).assets.push({
       chainName: asset.chainName,
@@ -473,6 +480,9 @@ async function main() {
       symbol: asset.symbol,
       channelId,
       ibcPath: ibcMethod.chain.path,
+      counterpartyChainName: ibcMethod.counterparty?.chainName,
+      counterpartyChannelId: ibcMethod.counterparty?.channelId,
+      counterpartyPort: ibcMethod.counterparty?.port,
     });
   }
 
@@ -522,38 +532,51 @@ async function main() {
     process.exit(3);
   }
 
-  // Phase 2: counterparty checks for channels we might clear
+  // Phase 2: counterparty checks for assets we might clear.
+  // Key by (counterpartyChainName, counterpartyChannelId, counterpartyPort)
+  // since one Osmosis channel can host multiple counterparty triples
+  // (e.g. plain transfer vs. wasm-port cw20 wrappers). The status of a
+  // given triple is shared across every asset that uses it.
+  const cpKey = (chainName, channelId, port) =>
+    `${chainName}|${channelId}|${port || 'transfer'}`;
+
   const cpCheckNeeded = new Map();
   for (const r of ibcResults) {
     if (r.error || r.status !== 'Active') continue;
     const cm = channelMap.get(r.channelId);
-    const hasUnstableAssets = cm.assets.some(
-      (fa) => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true
-    );
-    if (hasUnstableAssets && cm.counterpartyChainName && cm.counterpartyChannelId) {
-      cpCheckNeeded.set(r.channelId, cm);
+    for (const fa of cm.assets) {
+      if (zoneByPath.get(fa.ibcPath)?.osmosis_unstable !== true) continue;
+      if (!fa.counterpartyChainName || !fa.counterpartyChannelId) continue;
+      const key = cpKey(fa.counterpartyChainName, fa.counterpartyChannelId, fa.counterpartyPort);
+      if (cpCheckNeeded.has(key)) continue;
+      cpCheckNeeded.set(key, {
+        chainName: fa.counterpartyChainName,
+        channelId: fa.counterpartyChannelId,
+        port: fa.counterpartyPort,
+      });
     }
   }
 
   const cpStatuses = new Map();
   if (cpCheckNeeded.size > 0) {
-    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} channel(s)...\n`);
+    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} counterparty path(s)...\n`);
     const deadEndpoints = new Set();
     const cpResults = await processInBatches(
       [...cpCheckNeeded.entries()],
       CONCURRENCY,
-      async ([channelId, cm]) => {
+      async ([key, cp]) => {
         const status = await getCounterpartyClientStatus(
-          cm.counterpartyChainName,
-          cm.counterpartyChannelId,
+          cp.chainName,
+          cp.channelId,
+          cp.port,
           zoneChainsByName,
           chainlistByName,
           deadEndpoints
         );
-        return [channelId, status];
+        return [key, status];
       }
     );
-    for (const [channelId, status] of cpResults) cpStatuses.set(channelId, status);
+    for (const [key, status] of cpResults) cpStatuses.set(key, status);
   }
 
   // Phase 3: apply mutations (collected first, written later so dry-run can short-circuit)
@@ -574,10 +597,16 @@ async function main() {
     }
 
     const osmosisDown = r.status !== 'Active';
-    const cpStatus = cpStatuses.get(r.channelId); // undefined if no unstable assets
 
     for (const fa of cm.assets) {
-      // Per-asset evaluation, since source chain status is per-chain.
+      // Per-asset evaluation, since source chain status is per-chain
+      // and counterparty status is per-triple (chain, channel, port).
+      // Assets sharing the same Osmosis channel can resolve to different
+      // counterparty paths (e.g. cw20 wrappers vs. plain bank denoms).
+      const cpStatus = (fa.counterpartyChainName && fa.counterpartyChannelId)
+        ? cpStatuses.get(cpKey(fa.counterpartyChainName, fa.counterpartyChannelId, fa.counterpartyPort))
+        : undefined; // undefined when no counterparty check was needed for this asset
+
       const sourceStatus = getSourceChainStatus(fa.chainName);
       const chainKilled = sourceStatus === 'killed';
       const chainLive = sourceStatus === 'live';

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1549,9 +1549,7 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=alter"
         }
       ],
-      "_comment": "Alter $ALTER",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Alter $ALTER"
     },
     {
       "chain_name": "secretnetwork",
@@ -1565,9 +1563,7 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=butt"
         }
       ],
-      "_comment": "Button $BUTT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Button $BUTT"
     },
     {
       "chain_name": "secretnetwork",
@@ -1577,9 +1573,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Shade (old) $SHD.old",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Shade (old) $SHD.old"
     },
     {
       "chain_name": "secretnetwork",
@@ -1596,9 +1590,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "SIENNA $SIENNA",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "SIENNA $SIENNA"
     },
     {
       "chain_name": "secretnetwork",
@@ -1615,9 +1607,7 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "SCRT Staking Derivatives $stkd-SCRT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "SCRT Staking Derivatives $stkd-SCRT"
     },
     {
       "chain_name": "beezee",
@@ -1702,9 +1692,7 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=amber"
         }
       ],
-      "_comment": "Amber $AMBER",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Amber $AMBER"
     },
     {
       "chain_name": "onomy",
@@ -2176,9 +2164,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Silk $SILK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Silk $SILK"
     },
     {
       "chain_name": "juno",
@@ -2235,9 +2221,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Shade $SHD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Shade $SHD"
     },
     {
       "chain_name": "bluzelle",
@@ -3270,9 +3254,7 @@
       "categories": [
         "meme"
       ],
-      "_comment": "Puppy $PUPPY",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Puppy $PUPPY"
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
## Summary

- Fixes `check_ibc_clients.mjs` misclassification of cw20-wrapped IBC assets on Secret Network and Chihuahua as `safety_net | manual`.
- Clears `osmosis_unstable: true` from 9 cw20 entries that had been stuck on the manual-fallback branch (8 secretnetwork: ALTER, BUTT, SHD.old, SIENNA, stkd-SCRT, AMBER, SILK, SHD; 1 chihuahua: PUPPY).

## Root cause

An Osmosis channel can host more than one counterparty path. `channel-476` to Secret carries plain bank denoms (counterparty port `transfer`, channel `channel-1`) AND cw20 wrappers (counterparty port `wasm.secret1tqmms5awftpuhalcv5h5mg76fa0tkdz4jv9ex4`, channel `channel-44`). The old script:

1. Collapsed each Osmosis channel to one counterparty triple (whichever asset hit it first).
2. Hardcoded `ports/transfer` in `getCounterpartyClientStatus`.

So the wasm-port variant was invisible. The cw20 assets always had `osmosis_unstable: true` set but couldn't be confirmed as bridge_up; they fell through to the in-loop safety net which writes `osmosis_unstable_reason: \"manual\"` whenever the source chain is alive.

## Script change

- `getCounterpartyClientStatus` accepts a `port` parameter (defaults to `transfer`) and uses it in `/ibc/core/channel/v1/channels/{channelId}/ports/{port}`.
- The frontend-asset channel walk records `counterpartyChainName`, `counterpartyChannelId`, `counterpartyPort` per asset rather than per channel.
- Phase 2 counterparty checks and the per-asset mutation loop key `cpStatuses` by `(chain, channel, port)` via a `cpKey` helper.
- Dedupe is by triple in `cpCheckNeeded`, so multiple Osmosis channels sharing the same counterparty path still produce a single LCD fetch.

## Data change

9 cw20 entries in `osmosis-1/osmosis.zone_assets.json` lose `osmosis_unstable: true`. None had halt fields. Bridges are objectively up today; with the script fix in place these would resolve as bridge_up on the next run, but the clearing branch only fires when there's a halt field to clear, so the unstable flag would otherwise persist no-op forever.

## Test plan

- [x] `node check_ibc_clients.mjs osmosis-1 --dry-run` runs clean.
- [x] Dry-run report contains zero `safety_net | … | manual` rows (was 9: 8 secretnetwork cw20 + 1 chihuahua PUPPY).
- [x] No new false `bridge_down` rows for the 9 cw20 assets.
- [x] Counterparty fetch count drops from many to 2 (only remaining still-unstable triples).
- [x] Other channels' counterparty resolution unchanged.
- [ ] One full real run to confirm no surprise mutations.

## Out of scope, tracked separately

- `getClientStatusForChannel` (Osmosis-side LCD lookup) still hardcodes `ports/transfer`. Correct for every current Osmosis-side channel; same bug class returns if Osmosis ever hosts an Osmosis-side wasm-port channel.
- Flip `port` to required-no-default once all callers are updated.
- Liquidity prune review for ALTER / BUTT / SIENNA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the automation that flips `osmosis_unstable`/halt fields based on IBC client status; mistakes could incorrectly clear or set bridge-down indicators across assets sharing channels. Changes are localized to the utility script and a small set of asset entries.
> 
> **Overview**
> Fixes the IBC client check workflow to handle assets whose counterparty uses a non-`transfer` port (e.g. Secret cw20 `wasm.<contract>` ports) by passing the counterparty `port` into the LCD channel query and tracking counterparty status **per asset** rather than collapsing to a single counterparty per Osmosis channel.
> 
> Phase-2 counterparty lookups are now deduped by the `(chain, channel, port)` triple and the per-asset mutation logic consumes that triple-specific status, preventing false “unknown/manual” outcomes when multiple counterparty paths share one Osmosis channel.
> 
> Clears `osmosis_unstable` (and its manual reason) from 9 cw20 entries in `osmosis.zone_assets.json` that were previously stuck due to the incorrect counterparty lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55bbf1c10de95b941e941cdf3b7ed76ecd908139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->