### PR TITLE
Revert "fix(ibc-check): per-asset counterparty triple, clear stale cw20 flags"

### DIFF
--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -253,13 +253,8 @@ function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByNa
   return endpoints;
 }
 
-async function getCounterpartyClientStatus(chainName, channelId, port, zoneChainsByName, chainlistByName, deadEndpoints) {
+async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByName, chainlistByName, deadEndpoints) {
   if (!chainName || !channelId) return 'unknown';
-  // Default to 'transfer' for plain bank-denom IBC. cw20 wrappers on Secret
-  // Network (and similar wasm-bound IBC variants) bind the counterparty
-  // channel to a contract-specific port like `wasm.secret1...`; the lookup
-  // must target that exact port or it will return nothing.
-  const counterpartyPort = port || 'transfer';
 
   const endpoints = getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName);
   if (endpoints === null) return 'killed';
@@ -270,7 +265,7 @@ async function getCounterpartyClientStatus(chainName, channelId, port, zoneChain
 
     try {
       const channelData = await fetchJSONWithTimeout(
-        `${endpoint}/ibc/core/channel/v1/channels/${channelId}/ports/${counterpartyPort}`
+        `${endpoint}/ibc/core/channel/v1/channels/${channelId}/ports/transfer`
       );
       const connectionId = channelData.channel?.connection_hops?.[0];
       if (!connectionId) continue;
@@ -457,13 +452,7 @@ async function main() {
     if (asset.path) zoneByPath.set(asset.path, asset);
   }
 
-  // Group frontend IBC assets by Osmosis-side channel id, but record
-  // the counterparty (chainName, channelId, port) on each asset entry
-  // rather than once per channel. A single Osmosis channel can be shared
-  // by multiple asset variants whose counterparty side uses different
-  // ports (e.g. plain `transfer` for native denoms vs. `wasm.<contract>`
-  // for cw20 wrappers on Secret Network); collapsing them per-channel
-  // drops one variant on the floor.
+  // Group frontend IBC assets by channel.
   const channelMap = new Map();
   for (const asset of frontendData.assets ?? []) {
     const ibcMethod = asset.transferMethods?.find((m) => m.type === 'ibc');
@@ -471,7 +460,11 @@ async function main() {
 
     const channelId = ibcMethod.chain.channelId;
     if (!channelMap.has(channelId)) {
-      channelMap.set(channelId, { assets: [] });
+      channelMap.set(channelId, {
+        assets: [],
+        counterpartyChainName: ibcMethod.counterparty?.chainName,
+        counterpartyChannelId: ibcMethod.counterparty?.channelId,
+      });
     }
     channelMap.get(channelId).assets.push({
       chainName: asset.chainName,
@@ -480,9 +473,6 @@ async function main() {
       symbol: asset.symbol,
       channelId,
       ibcPath: ibcMethod.chain.path,
-      counterpartyChainName: ibcMethod.counterparty?.chainName,
-      counterpartyChannelId: ibcMethod.counterparty?.channelId,
-      counterpartyPort: ibcMethod.counterparty?.port,
     });
   }
 
@@ -532,51 +522,38 @@ async function main() {
     process.exit(3);
   }
 
-  // Phase 2: counterparty checks for assets we might clear.
-  // Key by (counterpartyChainName, counterpartyChannelId, counterpartyPort)
-  // since one Osmosis channel can host multiple counterparty triples
-  // (e.g. plain transfer vs. wasm-port cw20 wrappers). The status of a
-  // given triple is shared across every asset that uses it.
-  const cpKey = (chainName, channelId, port) =>
-    `${chainName}|${channelId}|${port || 'transfer'}`;
-
+  // Phase 2: counterparty checks for channels we might clear
   const cpCheckNeeded = new Map();
   for (const r of ibcResults) {
     if (r.error || r.status !== 'Active') continue;
     const cm = channelMap.get(r.channelId);
-    for (const fa of cm.assets) {
-      if (zoneByPath.get(fa.ibcPath)?.osmosis_unstable !== true) continue;
-      if (!fa.counterpartyChainName || !fa.counterpartyChannelId) continue;
-      const key = cpKey(fa.counterpartyChainName, fa.counterpartyChannelId, fa.counterpartyPort);
-      if (cpCheckNeeded.has(key)) continue;
-      cpCheckNeeded.set(key, {
-        chainName: fa.counterpartyChainName,
-        channelId: fa.counterpartyChannelId,
-        port: fa.counterpartyPort,
-      });
+    const hasUnstableAssets = cm.assets.some(
+      (fa) => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true
+    );
+    if (hasUnstableAssets && cm.counterpartyChainName && cm.counterpartyChannelId) {
+      cpCheckNeeded.set(r.channelId, cm);
     }
   }
 
   const cpStatuses = new Map();
   if (cpCheckNeeded.size > 0) {
-    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} counterparty path(s)...\n`);
+    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} channel(s)...\n`);
     const deadEndpoints = new Set();
     const cpResults = await processInBatches(
       [...cpCheckNeeded.entries()],
       CONCURRENCY,
-      async ([key, cp]) => {
+      async ([channelId, cm]) => {
         const status = await getCounterpartyClientStatus(
-          cp.chainName,
-          cp.channelId,
-          cp.port,
+          cm.counterpartyChainName,
+          cm.counterpartyChannelId,
           zoneChainsByName,
           chainlistByName,
           deadEndpoints
         );
-        return [key, status];
+        return [channelId, status];
       }
     );
-    for (const [key, status] of cpResults) cpStatuses.set(key, status);
+    for (const [channelId, status] of cpResults) cpStatuses.set(channelId, status);
   }
 
   // Phase 3: apply mutations (collected first, written later so dry-run can short-circuit)
@@ -597,16 +574,10 @@ async function main() {
     }
 
     const osmosisDown = r.status !== 'Active';
+    const cpStatus = cpStatuses.get(r.channelId); // undefined if no unstable assets
 
     for (const fa of cm.assets) {
-      // Per-asset evaluation, since source chain status is per-chain
-      // and counterparty status is per-triple (chain, channel, port).
-      // Assets sharing the same Osmosis channel can resolve to different
-      // counterparty paths (e.g. cw20 wrappers vs. plain bank denoms).
-      const cpStatus = (fa.counterpartyChainName && fa.counterpartyChannelId)
-        ? cpStatuses.get(cpKey(fa.counterpartyChainName, fa.counterpartyChannelId, fa.counterpartyPort))
-        : undefined; // undefined when no counterparty check was needed for this asset
-
+      // Per-asset evaluation, since source chain status is per-chain.
       const sourceStatus = getSourceChainStatus(fa.chainName);
       const chainKilled = sourceStatus === 'killed';
       const chainLive = sourceStatus === 'live';

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1549,7 +1549,9 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=alter"
         }
       ],
-      "_comment": "Alter $ALTER"
+      "_comment": "Alter $ALTER",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "secretnetwork",
@@ -1563,7 +1565,9 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=butt"
         }
       ],
-      "_comment": "Button $BUTT"
+      "_comment": "Button $BUTT",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "secretnetwork",
@@ -1573,7 +1577,9 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Shade (old) $SHD.old"
+      "_comment": "Shade (old) $SHD.old",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "secretnetwork",
@@ -1590,7 +1596,9 @@
       "categories": [
         "defi"
       ],
-      "_comment": "SIENNA $SIENNA"
+      "_comment": "SIENNA $SIENNA",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "secretnetwork",
@@ -1607,7 +1615,9 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "SCRT Staking Derivatives $stkd-SCRT"
+      "_comment": "SCRT Staking Derivatives $stkd-SCRT",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "beezee",
@@ -1692,7 +1702,9 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=amber"
         }
       ],
-      "_comment": "Amber $AMBER"
+      "_comment": "Amber $AMBER",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "onomy",
@@ -2164,7 +2176,9 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Silk $SILK"
+      "_comment": "Silk $SILK",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "juno",
@@ -2221,7 +2235,9 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Shade $SHD"
+      "_comment": "Shade $SHD",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "bluzelle",
@@ -3254,7 +3270,9 @@
       "categories": [
         "meme"
       ],
-      "_comment": "Puppy $PUPPY"
+      "_comment": "Puppy $PUPPY",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual"
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#3514

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bridge-state automation to assume a single counterparty per Osmosis channel and always query the `transfer` port, which could misclassify channels that use non-transfer ports (e.g., wasm-bound ICS20 variants) and lead to incorrect unstable/halt flag updates.
> 
> **Overview**
> Reverts the prior per-asset counterparty path handling in `check_ibc_clients.mjs` by grouping IBC assets strictly per Osmosis `channelId`, storing one counterparty `(chainName, channelId)` per channel, and always querying the counterparty endpoint with `ports/transfer` (dropping per-asset `counterparty.port` support).
> 
> Updates `osmosis.zone_assets.json` to mark several Secret Network CW20 assets (and `chihuahua`’s `PUPPY`) as `osmosis_unstable: true` with `osmosis_unstable_reason: "manual"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e661e5bb9002886e4612c8307617ef8ced511f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->