### PR TITLE
Revert "chore: first-pass lifecycle migration"

### DIFF
--- a/osmosis-1/generated/state/state.json
+++ b/osmosis-1/generated/state/state.json
@@ -118,18 +118,15 @@
     },
     {
       "base_denom": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
@@ -145,8 +142,7 @@
     },
     {
       "base_denom": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
@@ -166,23 +162,19 @@
     },
     {
       "base_denom": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
@@ -194,8 +186,7 @@
     },
     {
       "base_denom": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
@@ -207,8 +198,7 @@
     },
     {
       "base_denom": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
@@ -276,13 +266,11 @@
     },
     {
       "base_denom": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
@@ -298,19 +286,15 @@
     },
     {
       "base_denom": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z",
-      "lastRecoveryDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
@@ -354,8 +338,7 @@
     },
     {
       "base_denom": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
@@ -375,8 +358,7 @@
     },
     {
       "base_denom": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
@@ -384,8 +366,7 @@
     },
     {
       "base_denom": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
@@ -413,8 +394,7 @@
     },
     {
       "base_denom": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372",
@@ -446,8 +426,7 @@
     },
     {
       "base_denom": "ibc/EDD6F0D66BCD49C1084FB2C35353B4ACD7B9191117CE63671B61320548F7C89D",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/A76EB6ECF4E3E2D4A23C526FD1B48FDD42F171B206C9D2758EF778A7826ADD68",
@@ -455,13 +434,11 @@
     },
     {
       "base_denom": "ibc/CEE970BB3D26F4B907097B6B660489F13F3B0DA765B83CC7D9A0BC0CE220FA6F",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/8A025A1E70101E39DE0C0F153E582A30806D3DA16795F6D868A3AA247D2DEDF7",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/18FB5C09D9D2371F659D4846A956FA56225E377EE3C3652A2BF3542BF809159D",
@@ -469,13 +446,11 @@
     },
     {
       "base_denom": "ibc/0B3D528E74E3DEAADF8A68F393887AC7E06028904D02173561B0D27F6E751D0A",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/63CDD51098FD99E04E5F5610A3882CBE7614C441607BA6FCD7F3A3C1CD5325F8",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/10E5E5B06D78FFBB61FD9F89209DEE5FD4446ED0550CBB8E3747DA79E10D9DC6",
@@ -531,23 +506,19 @@
     },
     {
       "base_denom": "ibc/56D7C03B8F6A07AD322EEE1BEF3AE996E09D1C1E34C27CF37E0D4A0AC5972516",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/6727B2F071643B3841BD535ECDD4ED9CAE52ABDD0DCD07C3630811A7A37B215C",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/6B2B19D874851F631FF0AF82C38A20D4B82F438C7A22F41EDA33568345397244",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/1B708808D372E959CD4839C594960309283424C775F4A038AAEBE7F83A988477",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/23AB778D694C1ECFC59B91D8C399C115CC53B0BD1C61020D8E19519F002BDD85",
@@ -643,18 +614,15 @@
     },
     {
       "base_denom": "ibc/A1830DECC0B742F0B2044FF74BE727B5CF92C9A28A9235C3BACE4D24A23504FA",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/01D2F0C4739C871BFBEE7E786709E6904A55559DC1483DD92ED392EF12247862",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/B66CE615C600ED0A8B5AF425ECFE0D57BE2377587F66C45934A76886F34DC9B7",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/CFF40564FDA3E958D9904B8B479124987901168494655D9CC6B7C0EC0416020B",
@@ -686,8 +654,7 @@
     },
     {
       "base_denom": "ibc/6928AFA9EA721938FED13B051F9DBF1272B16393D20C49EA5E4901BB76D94A90",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "factory/osmo1g8qypve6l95xmhgc0fddaecerffymsl7kn9muw/squosmo",
@@ -711,8 +678,7 @@
     },
     {
       "base_denom": "ibc/E7905742CE2EA4EA5D592527DC89220C59B617DE803939FE7293805A64B484D7",
-      "legacyAsset": true,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "legacyAsset": true
     },
     {
       "base_denom": "ibc/E42006ED917C769EDE1B474650EEA6BFE3F97958912B9206DD7010A28D01D9D5",
@@ -808,8 +774,7 @@
     },
     {
       "base_denom": "ibc/178248C262DE2E141EE6287EE7AB0854F05F25B0A3F40C4B912FA1C7E51F466E",
-      "listingDate": "2024-03-19T19:08:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-03-19T19:08:00.000Z"
     },
     {
       "base_denom": "ibc/62118FB4D5FEDD5D2B18DC93648A745CD5E5B01D420E9B7A5FED5381CB13A7E8",
@@ -817,8 +782,7 @@
     },
     {
       "base_denom": "ibc/0835781EF3F3ADD053874323AB660C75B50B18B16733CAB783CA6BBD78244EDF",
-      "listingDate": "2024-03-03T22:27:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-03-03T22:27:00.000Z"
     },
     {
       "base_denom": "ibc/BB0AFE2AFBD6E883690DAE4B9168EAC2B306BCC9C9292DACBB4152BBB08DB25F",
@@ -830,8 +794,7 @@
     },
     {
       "base_denom": "ibc/C12C353A83CD1005FC38943410B894DBEC5F2ABC97FC12908F0FB03B970E8E1B",
-      "listingDate": "2024-03-13T15:44:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-03-13T15:44:00.000Z"
     },
     {
       "base_denom": "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
@@ -839,8 +802,7 @@
     },
     {
       "base_denom": "ibc/64D56DF9EC69BE554F49EBCE0199611062FF1137EF105E2F645C1997344F3834",
-      "listingDate": "2024-03-15T19:51:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-03-15T19:51:00.000Z"
     },
     {
       "base_denom": "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3",
@@ -860,8 +822,7 @@
     },
     {
       "base_denom": "ibc/3A0A392E610A8D477851ABFEA74F3D828F36C015AB8E93B0FBB7566A6D13C4D6",
-      "listingDate": "2024-04-03T16:09:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-04-03T16:09:00.000Z"
     },
     {
       "base_denom": "ibc/AC6EE43E608B5A7EEE460C960480BC1C3708010E32B2071C429DA259836E10C3",
@@ -869,8 +830,7 @@
     },
     {
       "base_denom": "ibc/FD506CCA1FC574F2A8175FB574C981E9F6351E194AA48AC219BD67FF934E2F33",
-      "listingDate": "2024-05-16T17:00:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-05-16T17:00:00.000Z"
     },
     {
       "base_denom": "ibc/094FB70C3006906F67F5D674073D2DAFAFB41537E7033098F5C752F211E7B6C2",
@@ -898,23 +858,19 @@
     },
     {
       "base_denom": "ibc/A23E590BA7E0D808706FB5085A449B3B9D6864AE4DDE7DAF936243CEBB2A3D43",
-      "listingDate": "2024-04-25T15:30:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-04-25T15:30:00.000Z"
     },
     {
       "base_denom": "ibc/5435437A8C9416B650DDA49C338B63CCFC6465123B715F6BAA9B1B2071E27913",
-      "listingDate": "2024-04-25T15:30:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-04-25T15:30:00.000Z"
     },
     {
       "base_denom": "ibc/0EFA07F312E05258A56AE1DD600E39B9151CF7A91C8A94EEBCF4F03ECFE5DD98",
-      "listingDate": "2024-04-25T15:30:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-04-25T15:30:00.000Z"
     },
     {
       "base_denom": "ibc/F17CCB4F07948CC2D8B72952C2D0A84F2B763962F698774BB121B872AE4611B5",
-      "listingDate": "2024-04-25T15:30:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-04-25T15:30:00.000Z"
     },
     {
       "base_denom": "factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA",
@@ -938,8 +894,7 @@
     },
     {
       "base_denom": "ibc/A8C568580D613F16F7E9075EA9FAD69FEBE0CC1F4AF46C60255FEC4459C166F1",
-      "listingDate": "2024-06-05T03:00:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-06-05T03:00:00.000Z"
     },
     {
       "base_denom": "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC",
@@ -995,8 +950,7 @@
     },
     {
       "base_denom": "ibc/3F8F00094F0F79D17750FF69C5F09B078084018570AAF4F1C92C86D3F73E6488",
-      "listingDate": "2024-08-07T17:30:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-08-07T17:30:00.000Z"
     },
     {
       "base_denom": "factory/osmo1nufyzqlm8qhu2w7lm0l4rrax0ec8rsk69mga4tel8eare7c7ljaqpk2lyg/alloyed/allOP",
@@ -1028,8 +982,7 @@
     },
     {
       "base_denom": "ibc/C91210281CEB708DC6E41A47FC9EC298F45712273DD58C682BEBAD00DCB59DC2",
-      "listingDate": "2024-08-12T23:00:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-08-12T23:00:00.000Z"
     },
     {
       "base_denom": "ibc/108604FDBE97DAEF128FD4ECFEB2A8AFC2D04A7162C97EAA2FD5BCB0869D0BBC",
@@ -1057,9 +1010,7 @@
     },
     {
       "base_denom": "ibc/905889A7F0B94F1CE1506D9BADF13AE9141E4CBDBCD565E1DFC7AE418B3E3E98",
-      "listingDate": "2024-08-30T00:33:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z",
-      "lastRecoveryDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-08-30T00:33:00.000Z"
     },
     {
       "base_denom": "factory/osmo12lnwf54yd30p6amzaged2atln8k0l32n7ncxf04ctg7u7ymnsy7qkqgsw4/alloyed/allTON",
@@ -1103,8 +1054,7 @@
     },
     {
       "base_denom": "ibc/3B95D63B520C283BCA86F8CD426D57584039463FD684A5CBA31D2780B86A1995",
-      "listingDate": "2024-11-18T20:00:00.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-11-18T20:00:00.000Z"
     },
     {
       "base_denom": "ibc/CD6412358F33B372A355CF22786D8C19477C15092B56BD56188679EED8556964",
@@ -1112,8 +1062,7 @@
     },
     {
       "base_denom": "ibc/1B454982D3746951510D3845145B83628D4ED380D95722C8077776C4689F973A",
-      "listingDate": "2024-11-20T12:49:15.000Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2024-11-20T12:49:15.000Z"
     },
     {
       "base_denom": "ibc/C1B4D4804EB8F95FFB75E6395A301F0AD6D7DDE5C3A45571B70E46A368DD353E",
@@ -1149,8 +1098,7 @@
     },
     {
       "base_denom": "ibc/50F886EFA15E1FF3D9226B177083A1EFF944176181C70B6131D74FE5AFB1F2C0",
-      "listingDate": "2025-02-20T19:58:18.010Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-02-20T19:58:18.010Z"
     },
     {
       "base_denom": "ibc/DC1DF96AB7F5109433C3D5FDADE83F8EC2D522B80FAB0593BC1A2781F36AD633",
@@ -1170,8 +1118,7 @@
     },
     {
       "base_denom": "ibc/8765FF0D37A7A85357ED28061EDEBC736743216DB06FE92231957CE158FB351E",
-      "listingDate": "2025-03-11T18:42:07.755Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-03-11T18:42:07.755Z"
     },
     {
       "base_denom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/t7s",
@@ -1183,8 +1130,7 @@
     },
     {
       "base_denom": "ibc/D37860EB1D2669F34B47A7BC48885853D5AB23642EF958CDEA35EB6074087064",
-      "listingDate": "2025-03-28T19:58:31.709Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-03-28T19:58:31.709Z"
     },
     {
       "base_denom": "factory/osmo1qdvwftqd8ml6t9w6dmj97m03ck5ghqqmd8y7cm/cult",
@@ -1208,8 +1154,7 @@
     },
     {
       "base_denom": "ibc/9D8D4CAE9D8F15B69E93969304AF3878D14BDED39FEAF0060566D6AC22288779",
-      "listingDate": "2025-04-29T10:47:24.166Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-04-29T10:47:24.166Z"
     },
     {
       "base_denom": "ibc/643EBFFC9D4533E93A5CF144FE786A6FB326F4C0C6224F7CB7563CC374EE56EE",
@@ -1221,8 +1166,7 @@
     },
     {
       "base_denom": "ibc/040D0BE35BED6A09D9418C29961FDA0EE0C3B0C71053B2E3FE38FBA7E50FFEF6",
-      "listingDate": "2025-05-20T15:33:05.874Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-05-20T15:33:05.874Z"
     },
     {
       "base_denom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/mtc",
@@ -1234,8 +1178,7 @@
     },
     {
       "base_denom": "ibc/86E7DAA73DD4AEA7319C77A81CF202A02BD094AE8550EEEAB06DF31749B6E05C",
-      "listingDate": "2025-05-28T16:38:39.356Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-05-28T16:38:39.356Z"
     },
     {
       "base_denom": "ibc/C7110DEC66869DAE9BE9C3C60F4B5313B16A2204AE020C3B0527DD6B322386A3",
@@ -1247,8 +1190,7 @@
     },
     {
       "base_denom": "ibc/46EB46DB30D3BBC6F404A9232C09785F36D40DA05C662A8E295712ECBAFF1609",
-      "listingDate": "2025-07-02T18:03:35.348Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-07-02T18:03:35.348Z"
     },
     {
       "base_denom": "ibc/869E01805EBBDDCAEA588666CD5149728B7DC7D69F30D92F77AD67F77CEB3FDA",
@@ -1292,8 +1234,7 @@
     },
     {
       "base_denom": "ibc/73C91DAE5E8AAC34C95BE8B969365449FFFC2D900A5FDEF40BA339EB34CE5752",
-      "listingDate": "2025-07-23T19:33:16.981Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-07-23T19:33:16.981Z"
     },
     {
       "base_denom": "ibc/0EF5630576C66968EF0787868CF09FD866FAD131BC148D24A148358A85F0EB62",
@@ -1325,13 +1266,11 @@
     },
     {
       "base_denom": "ibc/FBBC35295AA037DC0A77796B08DC3003EC918E18E75D61D675A0EEAC0643F36C",
-      "listingDate": "2025-10-29T11:39:21.204Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-10-29T11:39:21.204Z"
     },
     {
       "base_denom": "ibc/BE072C03DA544CF282499418E7BC64D38614879B3EE95F9AD91E6C37267D4836",
-      "listingDate": "2025-11-07T12:28:09.265Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2025-11-07T12:28:09.265Z"
     },
     {
       "base_denom": "ibc/2F4258D6E1E01B203D6CA83F2C7E4959615053A21EC2C2FC196F7911CAC832EF",
@@ -1423,8 +1362,7 @@
     },
     {
       "base_denom": "ibc/E132A35DC380C8D68E99F46BC7A5083602F171D00E3BE9471541FB1AA62D8BE2",
-      "listingDate": "2026-01-15T09:37:45.680Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2026-01-15T09:37:45.680Z"
     },
     {
       "base_denom": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
@@ -1436,1243 +1374,7 @@
     },
     {
       "base_denom": "ibc/31B7E66F7236A52FE7ED2E5418CEF92C71A72DA711B373309C69C21BE8032DF7",
-      "listingDate": "2026-03-06T15:21:19.532Z",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9BC783D73D46226BC948F34BC9136C081B89144E646DB5E4C1E8A6A4E777DC1B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1733402CBEA1D9D9D13DEA1EF1A76A116B51F5FF252A4DBBE6240DBFF8758EFC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/737BA149DE0967CA64C7A6FFCF5026EC7C6210F4BA1A3B1429E4FEBDEB4940F2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/686B4FE801A81ED9B46CC2E24FF3A7EA2E6A1E1A2A4D73BD7F2BC2866007AB0A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B9CBF51BD026FDB9F6D0623130E5242512CCE6147978C90A3B00C57F797AF752",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/61365041DAC5A57B92D60A3EBEB5143E209F86CECDBDD7326A6E7F8351352119",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F223D443CFBDFEDA198A63BE5633DC24ADE5B9F93822CF7BD641F99FEA2B56A7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/856C6F01E48EC9A89EFF35B2B75C3BC0CDF51C23AB094CCC6AE31B6D30C2A6ED",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1C657376F808E4E06B75EB18169B68B31042EAC8AE3D8FBAD0224F1170AFDF45",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/484650D35669EBFD1A7D9E57D0B557B92664C4AF2C92DBC20C317F1F06DCBC4B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/75D92821E64E9449B113A6CC156AE933DBD4B9BE9EE753B2550DE8DC71947E69",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5CF826D4A1C654B63F5025923AEBE56BD5710BD56E743FBDB9B338D0DD444077",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0F91EE8B98AAE3CF393D94CD7F89A10F8D7758C5EC707E721899DFE65C164C28",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4976049456D261659D0EC499CC9C2391D3C7D1128A0B9FB0BBF2842D1B2BC7BC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/DDF1CD4CDC14AE2D6A3060193624605FF12DEE71CF1F8C19EEF35E9447653493",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/42A9553A7770F3D7B62F3A82AF04E7719B4FD6EAF31BE5645092AAC4A6C2201D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/04FAC73DFF7F1DD59395948F2F043B0BBF978AD4533EE37E811340F501A08FFB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/3AF2E322D4B54BB97EEE24760ED25B725842A9B62C759402AB8AADD75915FD14",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/834D0AEF380E2A490E4209DFF2785B8DBB7703118C144AC373699525C65B4223",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/917C4B1E92EE2F959FC11ECFC435C4048F97E8B00F9444592706F4604F24BF25",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A37859A04007157B7FE3DC60BA32B7AC9CE7921988D32C087A52DFC98DF74C21",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/698A7B8E3CFC0E7831B3DA4BF2525907AF1277FC2D1ABBC21F1114CE9751C04A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/ADBDAED6F14E5BE1392CE79F29A59F362E53261A87D3ACF8244A88DA428A100E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/58E4261D2E21FE3A459C290A9F97F3DCD257B28F48AAE828298B38E048804829",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/3561B86D3E5B4D574B47BCD4AFDB84FC5B4DCD2E6E3F1FEF39AABE85137A365A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/CB430302A78522199562A80B9408F91264C89F659C123BF0BFDE1397D340C667",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/04DB563BCDD7DCBFAA277838BD141BA262DA8E7C2FEF825A4A324B7D588B351F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FDFCC8A906432FA7EFBA430062DA860883F5DDC77B8D64AFA2EE6CD5DC54B6A2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6A71FD886C62ECADA07ECFD24542C5E87C316A590737F5CE6FC37E3D258CD106",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/37DFAFDA529FF7D513B0DB23E9728DF9BF73122D38D46824C78BB7F91E6A736B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9A8CBC029002DC5170E715F93FBF35011FFC9796371F59B1F3C3094AE1B453A9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/078AD6F581E8115CDFBD8FFA29D8C71AFE250CE952AFF80040CBC64868D44AD3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/688E70EF567E5D4BA1CF4C54BAD758C288BC1A6C8B0B12979F911A2AE95E27EC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5B5BFCC8A9F0D554A4245117F7798E85BE25B6C73DBFA2D6F369BD9DD6CACC6D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/080CE38C1E49595F2199E88BE7281F93FAEEF3FE354EECED0640625E8311C9CF",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/39AAE0F5F918B731BEF1E02E9BAED33C242805F668B0A941AC509FB569FE51CB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BFFE212A23384C4EB055CF6F95A1F5EC1BE0F9BD286FAA66C3748F0444E67D63",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/257FF64F160106F6EE43CEE7C761DA64C1346221895373CC810FFA1BFAC5A7CD",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8D0FFEA4EDB04E3C1738C9599B66AE49683E0540FC4C1214AC84534C200D818B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D09BB89B2187EF13EF006B44510749B0F02FD0B34F8BB55C70D812A1FF6148C7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/63551E7BB24008F0AFC1CB051A423A5104F781F035F8B1A191264B7086A0A0F6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B83F9E20B4A07FA8846880000BD9D8985D89567A090F5E9390C64E81C39B4607",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F618D130A2B8203D169811658BD0361F18DC2453085965FA0E5AEB8018DD54EE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9A83BDF4C8C5FFDDE735533BC8CD4363714A6474AED1C2C492FB003BB77C7982",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0F9E9277B61A78CB31014D541ACA5BF6AB06DFC4524C4C836490B131DAAECD78",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/764F53CE03456AE392B5DA23935497E6428C33DC60A4B05FC03E10B635DB67E8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FD07CD381DAC06EB5159318F5069BADEB0C7C9692CB8AEDCB955130B20B92F62",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/3A1B6C687105F68F2F91964E9C2376BDC79F5C3DEC33F9F1F9166C18F1D6536F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/09FAF1E04435E14C68DE7AB0D03C521C92975C792DB12B2EA390BAA2E06B3F3D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C97473CD237EBA2F94FDFA6ABA5EC0E22FA140655D73D2A2754F03A347BBA40B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/46AC07DBFF1352EC94AF5BD4D23740D92D9803A6B41F6E213E77F3A1143FB963",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D59DB4C0B161B04CFD4B83E583AB557752EC7C56D4A170FF75A6D1CF1946F603",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/044B7B28AFE93CEC769CF529ADC626DA09EA0EFA3E0E3284D540E9E00E01E24A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E4C60B9F95BF54CC085A5E39F6057ABD4DF92793D330EB884A36530F7E6804DE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/EFC1776BEFB7842F2DC7BABD9A3050E188145C99007ECC5F3526FED45A68D5F5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/453B5B25834A5D4B8FE1E894E69D73F46424F28E8ED3D8E8CA654AEFF1EC5D3B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/ADFA3242D14E90EA479701A6CA341701FF5B88A3E969620AACABB3A0C50CA5CC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/631DB9935E8523BDCF76B55129F5238A14C809CCB3B43AECC157DC19702F3F9E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/629B5691DE993DCD07AA1B0587AD52A7FA4E8F28B77DE15BCBDF936CA6F76E6C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D28B585D6B67E2F1479BBA3E949C687289C94D33FFA0720E3A8CB0B244AD8BC6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2C43B074A5C7C3FB32EB8FA85239FCF887312BC960F373BC1EF1EE8517A0B996",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A7FDF1007E2D96C0D92896277039802F1EB5AAA28A644830483C425177064072",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/62F720A2B0AFE59D7377E86911A9EA2B1192DFA3C26C2329479376F3CBEBD311",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6CC792B72CAB4395B8192A8B2DFE35BA99172BD41BFF1F6A769E1522C2C58BBF",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BD80C1E9F86F41F0D591BD50ACD77BE83EEDA3DDB10C5FD8AB287CE0711C45DE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/60E8734240210E52792615AD5002457D11FD7FB85FE6FE11DC92268BB5AB63F4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/16B3CDBADC506456F3D71E22CE422BB990D7186D611B09744F39F47931B5C738",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/955E5E0BED298F85956121C3BD627CEB12B858A9EB7C1ED24B1515A658318CE4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1A3DE66CCE39FA151DA710B21E06C8FBC47178C1DCE7BB35D2A79466F754CD51",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B1DA72A9BF8F97F0575AB93681D476AFE640A0CD1FB44DD016BE156EEA8B8C7A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/78C9FC2412DA11C71FFDDBC3DE03584AF72A50EB5C572EEB31083ACC31AD706A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E4673C5CDB56B4225AB1625F3B478740AE9F11E1A6BEBC1B30F8A5080D6AFBD6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/71F741EEE3CE4AC4C537550AD401927BDC888FDED01DE5F66CAEDA46FFE67D57",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B8FD98E11799F3D76F184A6976CA25EDA8625AE5F05B1875ACF2D430A611DD99",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/01C449AE0CBD63FCC4D201AA8200E8BB7C10FD6CA53F80C9535F037B9A43C512",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1F3AB31A66CC0FBE149859D55D0D2D7167B851A113786438EA6E201033600C8E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8BE73A810E22F80E5E850531A688600D63AE7392E7C2770AE758CAA4FD921B7F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/54B2D9DC9602A1CE2A0329D51C6A1C7C4ADE71477186AEAAA549318C4513A453",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0D4113BDD4043C13A751E79A9EF099C7DFB2E5EA462343B139F52DA3BDD83F9B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6539288FEE1DDE376CB2A6B625BB57420F39414FCF79534B05090140ED020EEC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4E0EB62AF53F3E9BB58B1EBEF3D37D064AAFC6C0807AC0CCB62271A706F6DCC4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B89DE064B57F5026B63CFF50ED15A5EBA901A6B17D9600B9A4F86C32095BFEF4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/288ECF01A3786BF0AD0E5CE5A7BAA2DDA0D7E69BE06C91D6CD4524CC25FCDFBC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/52CBC5B9DA1B3C50E1D71C7B1F644CE8D6782E89AA7928EED409DB2DE6D066D8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/387550832FF1E03C51B5B0AAF12428E71EBE2160797FDC1EC40C4319E2887409",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/34E86DB41A10A2196D46B0B4630F176F6C9FA92AF183BCA6BA835C1172DE2D36",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/70BA39FF274D97FB5B51C9A1DF34880E8C1977A5F6D76ABE7A4F84D35AD06B74",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/17984B6DD060E366611DB96C98403A3684A0650778E495AD18F0F829844B69A3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/00CE99CC81F5D839621F34A34310A327D24861B9A56BCA4B4189A71EDDD58F6C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/69A55176BF0A688C0CB9A2CDB695CEBE5C8184CE9AC38E1774835BD96A59B6C7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C2EC862FE83DB6A765BE73BBF856CA0F5C131D3992DE43671EBAECF39511F9A5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/3425E3C2869BE09C84F0681FC354B7B478069271AC124AA4C3749902B0577D38",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A73AA8A97F41D95D00C2A76BA59713EDBDFD8C3E579593832D447C8542E30A0F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1FDDC52C591F30D97320F64EAC8FD58EF076FC5898941F4385B3B43C58F8A2CA",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/38FFF8A0D8D4E60D68D3571CAB8EA0FF47D2FFAB201D8DB0D2EECD8C50468CF7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9F0607DFB6A8DE15C010794774C2A08A739CF9F9211E7729D69E4E06A30D64FC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0439427A0B9F1685BC048403A61D365040A5AA1A23BB50A844921C1D90DA8FD2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D269DCE1A16F5334C13A333A6FDD495F22DF100D572D27A03827BD9C1B7F90D0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/661DE312BBDE78A305B570F96258D90415FB2D43E26689E80CA561F0C0EDC93B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4774BEC5D2E599DAB788D91DDF06379615CAC7842B47FFCD342B6B07A1DB37D8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8B0F0E843175FA8636105D6DD258780CAF55C229BD48FB4CBF87CA2DC9CBC6A6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6E69F8A74F0B88080CC391B32152537079A41401A3217B7C45D94CA8BCA3DE5E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/40F1CB094B33D5AD8987B556CB085D51630F39D703BC6B0CF073B4B37067FDC2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/ECFCD5CF8A9DAE40E34B4EF903C250EDB1112373498C93A92588911108763D2C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2BEC196FC8159D97497B8B5F0A9C256B471AD7C0C79220922227BEFC2874CC66",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/13DA3E148B744650A3CDBDA8DB961B3718083C4285F8D3BDFD31A6E0355CE898",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/CC3635C0737F9D69B8BD7A868DF93FF06C536DD1D7678ED972B9A358C95FBA4B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BBDCB376EC5E6854794C210FEDFEB20847B67A8E57EA94F845D16AFF88A1EEA3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/EC2A4146DBAAE6B06B745650EE9321A543C63402D5A4CD17C6152A056568F755",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/63EAE682B21E3C6F225461D5A21B84EC58DD4FB31210BFF67AEB2F34C184DD62",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BE0A20B179CF0EC2EE9C959A1412038B3770D797EDE44DA12DA6E543B1F50AF8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/73CEE0841A14710B86348BC4966DAAAB9EEBCE89D9F5D5D57BFC9BAFD5CE1C45",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8B7575FD02069D742D1866D51B16C84A9ADE9D0E0BA0CD53CE784FD123A37F7E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/78081C7DC880CFE1905F443A5B708DAA3E0FE3D2E696B43387D8CC8F5D810DED",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/985F312E97991CD8D9A822622EC645040766AB34300117F26D6ED0EB0545B657",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6290D0EB636CDA765DB34A0EB99E9F0BF1E210081816645ED9CACC54A73AABB9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/CED983DA7EF2E242E966D04F2BB328644DE58768B590A31A185EDC631E65B1FC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F31C0E41FD4EE1906D4CA47840E9BF917C3C52E3098AE895018B0302B58B0C22",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C9793EF38C52764AEB1743C1100A4CFF3EB1806790381D06079A145DF90ACC3F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BBD673A95765D7BC8C4080C9EBC3236C372513B79B3189DD9681B66EADD4E86A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0C9A1733521250F9F74FFE84799812C0CC1992207C2139EE28D5DCCEA13FCD88",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8DDEC9407527353400F36B5A90341D9C49C8C596B06BB59CCD358D0709F290C3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B3770556B373E492AEE53B05EBF322CA07BBE7C02BFEA670EEF9BBB6434377D3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/498C7E4A265DEB6E665BAB98008F44A780D065985F6A0C541E29F8B358C2F97A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9D469589B6972088B055C2CDF522BA94B470B0A6D8B2986A40175D3F70666F39",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B638D6F50AE1BCCBCCA9A6BC7DBBDBB7EBA6364882B5434033096981B9583D0C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/810619591B0DC153AA9F6F0BD4658F5B7727AC45666DF82B05DCEB0E99860DEC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/119AE70C773F15CD27490D8CA5CD58E422A719A423E14C1FFFD80045F93CC51E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/81608AC7D8D98446126D946A084EF18BDE44EF0F97B8A9A8E7504868044631A4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0A7EE1DD1A73C7E3ECFA9B62DC1FD3FA37209A082D823A7FE109A3546B2C9900",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/311B59F20D12FE6B96E057721B050852EEDC941357A5220DE188E8B43A15C500",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0B05519DE4B0DB3738EA4682E5220D1847C52701C13E175723332AB1ACE44DDD",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8098FA444F096C18BBC10CD7304583BE0672D07F69BCDBE46074DB45D43AEB8A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8A7A6FD98DC5332C6661DD4C1C6310183A4CD8E1910EE2E73163B2392EAD4BB8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E2AF33E5D9907359CB5DF9533B6D5D9EF757F86221106750EC23AE2B08BB2A5A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6BE37F2DD1EA6B5F3EE294A0D35BA3B42323100B664B6C525E3B642D056EABE2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C218C175146321A4DD12151610714496AEBEC9C3809FBE96B75093B8BF129821",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FDE0E4427A93D59006CF9F373B4E635F2CAA7789A2993E472833A77FF4CED947",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/686604325288CCABE0880790E88CE10304B25A59965A5B4FE4C58C862D84007B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0A3DDFB577AEB092443C4C9C0E025171EC4B826039D983A4B8244F3369BC8F5C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BF6687D844E1679FDA171D4F99FBCA51DBACB00EB599429E0F8F97A6498B8613",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FE09C698B28F4D840F8CB5BEB99825249D439AEF26E6717B64A7A89AD515E60D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/044E493E636DABF10B86EF3CD02C0C6658B4B16181B07BC980942A56B7E0CCAF",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A59707D2BF4F613362D7C014814D8F32DFC4F35D95559192CBCC645A1251A7C7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/036F5847D691122EBDA11B7BEE629E522E12D30D54AB834D6D39F74F27335CEE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D534C19E4916EBD35ABEDFB3ECE6FC19E0C5A4FAE42417FBC8961DC01511CC5A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F4515A441C63DB462841773FB9A47E00E662CDB82B1E2C13C7AB6CEBE3E46A8C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/40DFC290C384C3F52656EE7952A706B4A06F665165A4FCBB75927AAF85D19C62",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/68411017E581D8F49F359E6C5363173E48195FD0347498912E8DF937629A6EA3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/01EB83EB9C3774132DC14284B09C116A66AE0B389FF810AE6D32E52B6E17506C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/7039427EF61BB21E93347851BA33B30ACDD88AE06AAF942A586EADAB00B176A9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BB5C274D065F63D44AC79DF95E4D8DCC127058AB90222BE1EA1C6F8B7179AEE4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/26B57141A21AFAA8396791914987ECFCD5B7F020AE5747D0CB85D92FAAA79B1C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/60D39B9BF965AB94799F94906C1656133883A59DB01383446CE05F12862E93D6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A66550A245C5F83C2BBB983356D94180E564C9BD23FDD52417A928B60516E18D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B697B2E2F996F1AA8EB7FD699610ED74C94E20667C4497564559D1C606B8CEFB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/81628CA198871167855B7CA65C98F75AFECE6EC4A66ABDB4E31C771D0B452EFD",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B42CA5DD98B0FC5DBBEF3A2D05B5149918229BBFEF7301898227549C7FDB3C18",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C480CCF447C773445A736D2BE6D1A341D19AE6775442B285076C4C1FFC23C787",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/587EBDEB5CFF88FA16232B448C3ACFF30A7A03992F6BBC5DE3B62D56DE2F97AE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/70801C356A0EB938521635E26BC823A3F584F040E1667C7F96AB5FD2F588470D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F59F45BA91253FFD28F0962BF1C276552896C2DF4EB0301409BC9BD27C876A9E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/076D9B856EADEF89779E71126A3D12F05B5E38A5BAB065333457FB6EEA9CDB19",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/46EB7106C06254FB0753D989DF38750ED6D9D742EA493B1CCFE14EA39C040F7A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8F5A3C6E598A54578465B6EA27993E9CEE88A08CB44D8ED262968BEBCD27A9A3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/41548C812173671CBF300056C3F87C1457248C2E8233A4671CC35ED846562BE2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B420FFFAFFDEFAE409D562971FFF887F46776BECA903B81E1F8BC50D9F65FE76",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/759F8F2B165F061E302295D3D7A012440DE157A34690344594388F15CE4B12A6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2DCB24B7EF9AAF39A3D58930837CD35431A05FE7AE807886D8C11DFD47615E6F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1B638F1B5D8549E5A9B0079BF9F71D4B1B92D1067B4061FB85C8FDBA6D611EB0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/DDCDB4417DD225DA65E139EC8CF71B954A7981025B9D8FAEA9A0CD7538A109C1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/65B3A773757ED6FB103A1653150C625083415203E9BED783ACAB1A1D77385D25",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A04CA107774AC5362B86EC795AE4DBE1A417F5226BC732A1316F0C4306F13C7F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C1FF41CBD059DA05B8559B75A7054B2B73421293554056701CCBDEE99988AB6A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/550D909CEEAA496D11103535ACD6BFD0951187DDC5CC972E32A33F5BB7A46B3F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/58ECE947093989D0D38EAB6CF1187CD39109FE4A284195160B5580B4759AABBC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6228ED69C9CB9B1F67D6712F0BFBE48987B72096AA24FCC51572ED78E712A4B6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/985F276338DB2A9949323E848A691029136E369C2316803868A71416F0FF1110",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D1077079798E5FB206FFB362D58F906DEB3E22739DAD341F4E3CC3F58D55F38A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8A93A6107BEB28DBDF170E86742FF60E5B44C8216A7F8A0270CA6CD399209767",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D54858FA6021E642059751A22ADF948FBFFD25C49977AA4D3C3E1DD2BDE85903",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2FF8A13212E679700E43DB4A3D7DEEBB799F82C7AC484EC62D0CC9C70712FF7A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2F1734352BCD9544F244F710BFD93AA9443448A52E3B844066CE366BC7480CF0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/72AD7E08E13F06FA8335CC741D9F1E356D711E7600E943099B2C20231FEAC353",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5956CC1EE2087417431EAC723EDC762868F172485CA9A7ABF06EEC01BB5AA50F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4798AB5B9D8878C64FACCBD9BB05583D301DF8D84DCE31F71B6D39E296BD9AE8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0E18B0E689C80338F4BF2BB653DFEB42F55F47780D6D0160CE04403F6C8CE75D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/63D0470F087602AC2F962335EC7720A5A72B493AA4ED42D19450D8FCED66332F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B78BD5F935CD68B9ABCFB8501895F0244F951798FC7D8F62865FB90ECE0A677F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8FC0F59B86D1E83121039D5BA291E349A41FB84790626891DAB84EC1D6BC6190",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/68AD1271DF0CC0EB4662D47EF9EDE7B83E6A1FC60FB39665B785688F2DBC6212",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5645C4E694913D2F5EFF097E9A436896622F5196D5EDC3ABA491684FED8E4510",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/010DA8440215B218771AAF3BFEAC9E73D5A0AC4ABBDD052FC8852299875CC7C9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A72EE14210E657F40ECD34E3293C39A97B19BA9025389CD272AEB554B03679C1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/EBCED9F09712699FFA898C54B4B63CF2111775826D236BB923AA3132A8852000",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/24C63A198A26BB6DEFF8C8E4B75F1503F0B41ABAAC63AA4CF3AB849DA6D4A5F9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/438C6FE288373EF18842904D8D1F511811281DA8ABCA7F26FCCDC257AD1C0B7E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4A3912C620F4EF4C7A2B35B6F6A968A447D239A865D0FF5DA318B1098A15FF6B",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/79272BD3235917A54671D117744F16B19881FD848770B047C655BC439402E684",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0BA1F51EBF29A62AA39D781FE70E3111AAEC1764327DCFA143AA04C144DEFD61",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/EB098C17A6E6EC3BDC45729DF64E2A670F48706E49C287C8A4F6FB8445D421BB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9FB24B13C22ADC3CEFF4AB68FD06764DC395892769B543F0F76558B7495A6C83",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2624803ABAD8421F6AABB2B27E0C86DE16B8D838283E13C2D3E330B3F55E8136",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B25AF8A01B2D8E51A020FFD958BFD2138AB174A150B3BE59C659D4AB7629D26A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/7E022B7DF1C6239320E1CD2C4E1180A0DC93DF3C2D2333BF88F18297E49C8EE3",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/54487D97ED235CDA43B79FE2338D3B65935D81EE0D8EA064242134D73603D709",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/00AB944BC9AE7E9EEBE195282D4C32F052FC9A17A816F807CE8C57AAD9BB0E34",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BC25A27F8959A8C953A7208DAC2A0450E54356D279B4EBB192E5A5287148087E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BF7BB2AB3BDD80BD85E183FB047FDB27DF627C90CFB24778A0259BCA28B7A795",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BBF0972F80318E58F9C5B46ED310CB4C1B47585542347027F9A08E200D4721B5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/7CE29790D6ADBA5DD3C6118DDD9B2B30095CC552B6C84C0E3C67FC2CB5BAEB01",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/EEF8C7657CF1DB6E6BB7205093BB5B524F9A22FB00E05D6D4B9959BB5A6E5185",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/DCDA80F8A42E2D07310980558C4BE5EB76773C06F6CCAF6F852AA51096BEF688",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E1A2E414EE76E2D13FE25C202F74550C580B602DF8D5D623A01A9F6CEB8DA7C4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/AF32DD96993860F979BAF9A8B35D3A9887E63AE5D33FB8A16A81F10ED5779A94",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FFA4532FCC33B233CAC1318BEBF14C77813D301C6B25ACAF875F0CA37F11DE2C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/ECA4BA1A926B53FE9EE329D46676CE9E488936958E8D4EBEF86631C558F70BF7",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C193D4053B5CBA315F714B97B18A0E549CE4C0CC9F291ABE947C3F824FC4BAB1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/6F5574C187BE26B68BDB7EC11B2B020626131557BA94726ACA5751543C386CC1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8A6DDEC99830F58B59B4E2D92B3975476B517119D20B50C3D50D1472B6795694",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/862B6D1F538B6695B087BB69CABFAEF8CBBD68A56CBFAD638E7A58D40DE0E606",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9DBB1AE3451C1EA76D6CD5C407B20EBBE91A4A85C11F7557D704E6E36C5ECFB0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/81901B38AE554FE7A9BC549F7E6A2FE584A42F71581066D358F8FED70FDBD434",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/15746455402ECB0C6B3157C8ED7054654B634240B16FF8A1E1543A2D950003F6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F984A3251DBCC64303521B77DA3A764EC74BE62488C14D13D3E6FF98EDE9853A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/512DB86DDF581E5C087FA212B67277F98CA6CF5698B245C2139FD4C9820180F5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C4C4B03B6EEBEE4E5539CA0374AFEC9A03FDAAE7A04FD060943D449BE76F4519",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C32ECACFBFD8D4D069917F7E6DBC143C701A9EE3A66C225FDA8C593636AB731D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F85234C944405C80F619C8A41A2E61CAF098DA9EECFDE5C91AF761A6CF0EA755",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D6792A8D31266076B44BFE4FF55AB84856E03D52D4BA850AE8979A96E5773386",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/D5F6C69F88BE0707A260E07AFC3F564D7B06218F54040677593A36F556336978",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/DBFF8B4E1596285D5D85BD643289361F886CC8817A03FD99A3ED4AA1B4403399",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0E8F7D3B3E33F7704BD143859503DA0CCEC30073219AE61FA58D8F3721BAE978",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8BF6A461FAECF7E8A36CAE320A59A516B1BCED929AAC564DA74428B5EF98BCBD",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/3D2E98CAFBBFDC38185B7F90C2A43F81EAD7D59B05EAD724249D92F354F5D5FE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/78CA71CC7C7E3C779E39E132CDD27ECC5A983CBD0B1AD6B0A231CD0BFE58E5A4",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5E6A7AB5907400C6D3F8FF3DF3F67AE65FE5CD4EB0ABB8867C59ACA81D79645A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8547B5685FFCDC0F19A575D00951DBA6F00EC04B4A7A3A837E4DAB96C5763E7D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4469BAFC779FC985281939283FBF58392CEAB3553DB057C919D348391C8311DE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B74DADEFF1EAAD6F369FC8BB27F0E776A08D2EFF079797B2F80058E2FE5C23E5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A3D296760A21029AA03A32F4EC9D1935647B7659349A6467721E7B3FAD99F27F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/87FAABD443F9EC1CC09A587B750C7842F36F5509F17CF256A0F4F867CD848892",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5D0A4C0C1664AA3A5153914A33CE6D1A7263E8016E29576389C52B3C224B3AF2",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/67B7FDD98FC78C38A7F7C9968EDE8CD0B65C7D85992F6A9A861A8AA945FCD67C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9EC76A95DCC57A9ABFDDEC23E8EE901DB65897FC6C4828704C51DD93CB236E65",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/636DF2E7F94984C061DB3C8CF5BD3E5360065FED21C14C38186B68713C1FD280",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/17C54D2D90B6584613A3B1D97A622E5056CC03170309B524EB7E1A1383D309FB",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/08EB827EDDD71B1832E299B0ACFF161F72B19A00A166E367BC9ACA9E4A8F3E52",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/3C793E97322DF85D1B337E65EA10712C506E7A02F76F83DB1AC4AB4D99F7B11A",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/C540484A8F328D916FF61876E12DFC93492E9FAB8E8219244B2FAEA63647DF0D",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/93C85229E10B4EFC6C21638FE687303D382B7E5658E89CD2B13656393808D5D0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/4231A886A89CE5CFA6AE18AE437C4BED390B6D66C613129BEEB30EC62F06C673",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A1FAF407EF8DD888107FF6A41088904399B1E737D521DE49C06621C8BDC572D6",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FB84BB485258FB4398AF1DE3F21AB2AC51ACB2B03906BAD92B751A43A3578F81",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F74CD50CDBDFD5D5BB416928427012F8752EC9515126FEC6FE41ECF67592D790",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/554D4B36F6AE0B1E7AACC67EA9134DBD3ECCA8FE9B2678B7FC4429963E191A63",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/CA94E5B6B196FF8B5AA99C5D103F46D3BBB5D62E933B394489349FCB3B8E3ABE",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/90B9EC702B93F7BA51E961E845DFC1C6634262E1B782791BEC3163B28000E418",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FD850E9ECEB7B379AE3ABCB4D7369D9C2B37B23D418105682FFAAEF7412B3EC1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/F510C857E4DFB82766BA3256D61E9B7AF8B56411740C5863F3001C3D5EC5D945",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9F5E65D9AFD2B2DA5B9377E6722484FE579241832286CD4DC138F1610F992D5C",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/CD96D509B5BD856343A94CE82CB4AD38F41438AACC662DF0FB7DF4FE97B818E0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A3B38BDE64F5EF0675971A29D538A22EF33DB0FAD85F2F0B1F4A8EA8BA3D53E5",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/8B2F8C2B387062FBABC5FD894927275A9FE2D943745A0B2B00BEC83AB8371DB1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/090155A209DE7C256AE76E9A35A37DDB19F9D956A4063364FD8D8155E6E10FFC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/FBCF33DC9AC4989F8EC3EA6FC3986CDDCC6546CE4B2723CBA80B582D6F831FB8",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/1409DB6AC63E07C1FDE81A62619C285EB7CCF6213DCBE0BC3BE436338E27AE1F",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/CAA6F31FAD151445081A5D30401B89EB9F5DCE64D204E56468AD2035062B0640",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/A0F802310D3249FE01A3B0EB966ED330C6A09F24CE42766B7EA8C26A1E00E0B1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/AAFBAE8D78167243B324C1FF4E0D1E426A78010264C8315CBA57F98A44CF66DC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/BADE12981CD6690CE3D1B2419D30AE2C9EFD87E6DB02D320FAC3EF1D30517E6E",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/B7BDBA7D76ECF43520252879E6643C740F3917C728FFF4C0C8FD2E3E49780838",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0A37E6D85265C3CE9FBC475355B56B4E85A62F9F97773E9B4BBDCF33905D5823",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/415010FB5AA64F09C62BCB2A1386BD940644EB4A1828532CD18A08205EC40F86",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/0B10F783E5012100C142DA1C0D99A0E5B52EEBD882C1E4856378257566D04FA1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/5879773DFC4787E92157331C8ABEBCDC7F6FE9CB9DB50AABB9C8CCE5A7284C10",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/2381A3C97BE0FEB99534439EF644726A481C6445BD1062E8FC15A6E03A3492A9",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E00B52FA37C331F3527C177C307558FDF886DE7101983FE2FD1F10A8F76B91D0",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/16FCA8A24E88B7450B8F3D6774A8EC7220AD0B6A080C0FD0CDB824D2C98AACCC",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/615422D3409021B2DE968EA1D75B204D4B46F6ED794362D5727F889CE2BFCE17",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z",
-      "lastRecoveryDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/9253F17BA4C45BBCAC44A9DF23476C7011729A6944A9541B372575204A7C6886",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z",
-      "lastRecoveryDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
-      "base_denom": "ibc/E72E62E74112F379BB760D02515DA215408CCBF401CD4C9BC0A3DBD72A7076E1",
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z",
-      "lastRecoveryDate": "2026-05-22T09:57:52.115Z"
+      "listingDate": "2026-03-06T15:21:19.532Z"
     }
   ],
   "chains": [

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -370,12 +370,7 @@
         "social"
       ],
       "_comment": "Starname $IOV",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "emoney",
@@ -386,12 +381,7 @@
         "rwa"
       ],
       "_comment": "e-Money $NGM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "emoney",
@@ -402,12 +392,7 @@
         "stablecoin"
       ],
       "_comment": "e-Money EUR $EEUR",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "likecoin",
@@ -418,12 +403,7 @@
         "social"
       ],
       "_comment": "LikeCoin $LIKE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "impacthub",
@@ -455,12 +435,7 @@
       "path": "transfer/channel-77/uxki",
       "osmosis_verified": true,
       "_comment": "Ki $XKI",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "panacea",
@@ -505,12 +480,7 @@
       "path": "transfer/channel-115/ulum",
       "osmosis_verified": true,
       "_comment": "Lum Network $LUM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "vidulum",
@@ -518,12 +488,7 @@
       "path": "transfer/channel-124/uvdl",
       "osmosis_verified": true,
       "osmosis_unstable": true,
-      "_comment": "Vidulum (Vidulum) $VDL.vdl",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "Vidulum (Vidulum) $VDL.vdl"
     },
     {
       "chain_name": "desmos",
@@ -534,12 +499,7 @@
         "social"
       ],
       "_comment": "Desmos $DSM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "dig",
@@ -547,12 +507,7 @@
       "path": "transfer/channel-128/udig",
       "osmosis_verified": true,
       "osmosis_unstable": true,
-      "_comment": "Dig Chain $DIG",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "Dig Chain $DIG"
     },
     {
       "chain_name": "sommelier",
@@ -580,12 +535,7 @@
       "path": "transfer/channel-171/udarc",
       "osmosis_verified": true,
       "osmosis_unstable": true,
-      "_comment": "Konstellation $DARC",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Konstellation $DARC"
     },
     {
       "chain_name": "umee",
@@ -616,12 +566,7 @@
         "dweb"
       ],
       "_comment": "Decentr $DEC",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -657,12 +602,7 @@
       "categories": [
         "meme"
       ],
-      "_comment": "Cerberus $CRBRUS",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "Cerberus $CRBRUS"
     },
     {
       "chain_name": "fetchhub",
@@ -730,12 +670,7 @@
       "categories": [
         "oracles"
       ],
-      "_comment": "Microtick $TICK",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "Microtick $TICK"
     },
     {
       "chain_name": "sifchain",
@@ -746,12 +681,7 @@
         "defi"
       ],
       "_comment": "Sifchain $ROWAN",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "shentu",
@@ -903,12 +833,7 @@
       "path": "transfer/channel-236/uglx",
       "osmosis_verified": false,
       "_comment": "Galaxy $GLX",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -936,12 +861,7 @@
         "meme"
       ],
       "_comment": "MEME $MEME",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -970,12 +890,7 @@
       "path": "transfer/channel-221/uatolo",
       "osmosis_verified": false,
       "_comment": "Rizon $ATOLO",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "kava",
@@ -1158,12 +1073,7 @@
       "path": "transfer/channel-263/utgd",
       "osmosis_verified": true,
       "_comment": "Tgrade $TGD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "echelon",
@@ -1179,12 +1089,7 @@
         }
       ],
       "_comment": "Echelon $ECH",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "odin",
@@ -1195,12 +1100,7 @@
         "ai"
       ],
       "_comment": "Odin Protocol $ODIN",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "odin",
@@ -1208,12 +1108,7 @@
       "path": "transfer/channel-258/mGeo",
       "osmosis_verified": false,
       "osmosis_unstable": true,
-      "_comment": "GEO $GEO",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "GEO $GEO"
     },
     {
       "chain_name": "odin",
@@ -1221,12 +1116,7 @@
       "path": "transfer/channel-258/mO9W",
       "osmosis_verified": false,
       "osmosis_unstable": true,
-      "_comment": "O9W $O9W",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "O9W $O9W"
     },
     {
       "chain_name": "kichain",
@@ -1237,12 +1127,7 @@
         "symbol": "LVN.ki"
       },
       "_comment": "LVN $LVN.ki",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "axelar",
@@ -1292,12 +1177,7 @@
         "defi"
       ],
       "_comment": "Crescent $CRE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "lumenx",
@@ -1305,12 +1185,7 @@
       "path": "transfer/channel-286/ulumen",
       "osmosis_verified": false,
       "osmosis_unstable": true,
-      "_comment": "LumenX $LUMEN",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "LumenX $LUMEN"
     },
     {
       "chain_name": "oraichain",
@@ -1321,8 +1196,7 @@
         "ai"
       ],
       "_comment": "Oraichain $ORAI",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "cudos",
@@ -1333,12 +1207,7 @@
       "categories": [
         "dweb"
       ],
-      "_comment": "Cudos $CUDOS",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "Cudos $CUDOS"
     },
     {
       "chain_name": "kava",
@@ -1442,12 +1311,7 @@
       "path": "transfer/channel-355/arebus",
       "osmosis_verified": false,
       "osmosis_unstable": true,
-      "_comment": "Rebus $REBUS",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Rebus $REBUS"
     },
     {
       "chain_name": "teritori",
@@ -1489,12 +1353,7 @@
       "path": "transfer/channel-378/ulamb",
       "osmosis_verified": false,
       "_comment": "Lambda $LAMB",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "kujira",
@@ -1520,12 +1379,7 @@
       "path": "transfer/channel-382/nund",
       "osmosis_verified": true,
       "_comment": "Unification $FUND",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "jackal",
@@ -1550,8 +1404,7 @@
         }
       ],
       "_comment": "Alter $ALTER",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "secretnetwork",
@@ -1566,8 +1419,7 @@
         }
       ],
       "_comment": "Button $BUTT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "secretnetwork",
@@ -1578,8 +1430,7 @@
         "defi"
       ],
       "_comment": "Shade (old) $SHD.old",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "secretnetwork",
@@ -1597,8 +1448,7 @@
         "defi"
       ],
       "_comment": "SIENNA $SIENNA",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "secretnetwork",
@@ -1616,8 +1466,7 @@
         "liquid_staking"
       ],
       "_comment": "SCRT Staking Derivatives $stkd-SCRT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "beezee",
@@ -1639,12 +1488,7 @@
       "path": "transfer/channel-490/aacre",
       "osmosis_verified": false,
       "_comment": "Acrechain $ACRE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "comdex",
@@ -1663,12 +1507,7 @@
       "path": "transfer/channel-517/aimv",
       "osmosis_verified": false,
       "_comment": "Imversed $IMV",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "medasdigital",
@@ -1676,12 +1515,7 @@
       "path": "transfer/channel-87042/umedas",
       "osmosis_verified": true,
       "_comment": "Medas Digital Network $MEDAS",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -1703,8 +1537,7 @@
         }
       ],
       "_comment": "Amber $AMBER",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "onomy",
@@ -1715,12 +1548,7 @@
         "defi"
       ],
       "_comment": "Onomy $NOM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "persistence",
@@ -1738,12 +1566,7 @@
       "path": "transfer/channel-526/dys",
       "osmosis_verified": false,
       "_comment": "Dyson Protocol $DYS",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -1766,12 +1589,7 @@
         }
       ],
       "_comment": "Arable USD $arUSD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "planq",
@@ -1779,12 +1597,7 @@
       "path": "transfer/channel-492/aplanq",
       "osmosis_verified": true,
       "_comment": "Planq $PLQ",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "axelar",
@@ -1879,12 +1692,7 @@
       ],
       "osmosis_disabled": true,
       "_comment": "Mars Protocol (Mars Hub) $MARS.mars",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "acrechain",
@@ -1900,12 +1708,7 @@
         }
       ],
       "_comment": "Ciento Token $CNTO",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "stride",
@@ -1940,12 +1743,7 @@
       "path": "transfer/channel-641/uebl",
       "osmosis_verified": false,
       "_comment": "8ball $EBL",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "quicksilver",
@@ -2000,12 +1798,7 @@
       "path": "transfer/channel-648/arkh",
       "osmosis_verified": false,
       "osmosis_unstable": true,
-      "_comment": "Arkhadian $ARKH",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Arkhadian $ARKH"
     },
     {
       "chain_name": "quicksilver",
@@ -2037,12 +1830,7 @@
         "sail_initiative"
       ],
       "_comment": "Migaloo $WHALE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -2140,12 +1928,7 @@
         "nft_protocol"
       ],
       "_comment": "OmniFlix $FLIX",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -2177,8 +1960,7 @@
         "defi"
       ],
       "_comment": "Silk $SILK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -2236,8 +2018,7 @@
         "defi"
       ],
       "_comment": "Shade $SHD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "bluzelle",
@@ -2245,12 +2026,7 @@
       "path": "transfer/channel-763/ubnt",
       "osmosis_verified": true,
       "_comment": "Bluzelle $BLZ",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "axelar",
@@ -2497,12 +2273,7 @@
         "bridges"
       ],
       "_comment": "Picasso $PICA",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -2524,12 +2295,7 @@
         }
       ],
       "_comment": "Kusama $KSM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -2547,12 +2313,7 @@
         }
       ],
       "_comment": "Polkadot (Picasso via Picasso) (Picasso) $DOT.pica",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "quasar",
@@ -2564,12 +2325,7 @@
         "built_on_osmosis"
       ],
       "_comment": "Quasar $QSR.legacy",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "archway",
@@ -2986,12 +2742,7 @@
         "gaming"
       ],
       "_comment": "SGE $SGE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "stafihub",
@@ -3002,12 +2753,7 @@
         "liquid_staking"
       ],
       "_comment": "StaFi Hub $FIS",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "stafihub",
@@ -3018,12 +2764,7 @@
         "liquid_staking"
       ],
       "_comment": "rATOM $rATOM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "stargaze",
@@ -3106,12 +2847,7 @@
       "categories": [
         "dweb"
       ],
-      "_comment": "Nois $NOIS",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "Nois $NOIS"
     },
     {
       "chain_name": "osmosis",
@@ -3171,12 +2907,7 @@
       "path": "transfer/channel-880/uqwoyn",
       "osmosis_verified": false,
       "_comment": "Qwoyn $QWOYN",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "bostrom",
@@ -3213,12 +2944,7 @@
       "osmosis_verified": true,
       "osmosis_disabled": true,
       "_comment": "Source $SOURCE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "gateway",
@@ -3271,8 +2997,7 @@
         "meme"
       ],
       "_comment": "Puppy $PUPPY",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "neutron",
@@ -3303,12 +3028,7 @@
         "meme"
       ],
       "_comment": "ASH $ASH",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "migaloo",
@@ -3320,12 +3040,7 @@
         "sail_initiative"
       ],
       "_comment": "Racoon $RAC",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "migaloo",
@@ -3336,12 +3051,7 @@
         "meme"
       ],
       "_comment": "GUPPY $GUPPY",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "haqq",
@@ -3457,7 +3167,7 @@
       "base_denom": "cw20:juno1zkwveux7y6fmsr88atf3cyffx96p0c96qr8tgcsj7vfnhx7sal3s3zu3ps",
       "path": "transfer/channel-169/cw20:juno1zkwveux7y6fmsr88atf3cyffx96p0c96qr8tgcsj7vfnhx7sal3s3zu3ps",
       "osmosis_verified": false,
-      "_comment": "Jun\u00c3\u00b8 Apes $JAPE"
+      "_comment": "Junø Apes $JAPE"
     },
     {
       "chain_name": "chihuahua",
@@ -3674,12 +3384,7 @@
       "path": "transfer/channel-20100/nscr",
       "osmosis_verified": true,
       "_comment": "Scorum Network $SCR",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "chain4energy",
@@ -3705,12 +3410,7 @@
         "base_denom": "0x454b90716a9435e7161a9aea5cf00e0acbe565ae"
       },
       "_comment": "Source Token $SRCX",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "pylons",
@@ -3721,12 +3421,7 @@
         "nft_protocol"
       ],
       "_comment": "Pylons $ROCK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "gateway",
@@ -3780,12 +3475,7 @@
       ],
       "osmosis_verified": true,
       "_comment": "DOKI $DOKI",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -3805,12 +3495,7 @@
         "sail_initiative"
       ],
       "_comment": "SHARK $SHARK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "coreum",
@@ -3866,12 +3551,7 @@
       "osmosis_verified": false,
       "osmosis_unlisted": true,
       "_comment": "ConsciousDAO $CVN",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -3951,12 +3631,7 @@
       ],
       "osmosis_verified": true,
       "_comment": "Tinkernet $TNKR",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "gateway",
@@ -3989,12 +3664,7 @@
         "dweb"
       ],
       "_comment": "dHealth $DHP",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "furya",
@@ -4002,12 +3672,7 @@
       "path": "transfer/channel-74222/ufury",
       "osmosis_verified": false,
       "_comment": "furya $FURY",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "saga",
@@ -4049,12 +3714,7 @@
       "osmosis_verified": false,
       "osmosis_unlisted": true,
       "_comment": "Cifer $CIF",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "injective",
@@ -4143,12 +3803,7 @@
       "path": "transfer/channel-642/factory/migaloo1d0uma9qzcts4fzt7ml39xp44aut5k6qyjfzz4asalnecppppr3rsl52vvv/rstk",
       "osmosis_verified": false,
       "_comment": "RESTAKE $RSTK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -4173,12 +3828,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4194,12 +3844,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4215,12 +3860,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4236,12 +3876,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4257,12 +3892,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4278,12 +3908,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4299,12 +3924,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4320,12 +3940,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "bitsong",
@@ -4487,12 +4102,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4509,12 +4119,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4531,12 +4136,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4553,12 +4153,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4575,12 +4170,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4597,12 +4187,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4619,12 +4204,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4641,12 +4221,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -4690,12 +4265,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4713,12 +4283,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4736,12 +4301,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4759,12 +4319,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "composable",
@@ -4781,12 +4336,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -4840,12 +4390,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -5520,12 +5065,7 @@
         "bridges"
       ],
       "_comment": "Router Protocol $ROUTE",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -5634,12 +5174,7 @@
           "withdraw_url": "https://app.picasso.network/?from=OSMOSIS&to=SOLANA"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "haqq",
@@ -5751,8 +5286,7 @@
           "withdraw_url": "https://ton.thesis.io/"
         }
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -5777,12 +5311,7 @@
       "categories": [
         "liquid_staking"
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -5838,12 +5367,7 @@
       "path": "transfer/channel-81924/uandr",
       "osmosis_verified": false,
       "_comment": "Andromeda $ANDR",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -5942,12 +5466,7 @@
       ],
       "osmosis_verified": false,
       "_comment": "Kima Network $KIMA",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "stratos",
@@ -5997,12 +5516,7 @@
       "categories": [
         "defi"
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "int3face",
@@ -6307,12 +5821,7 @@
       "path": "transfer/channel-199/factory/omniflix1fwphj5p6qd8gtkehkzfgac38eur4uqzgz97uwvf6hsc0vjl004gqfj0xnv/ygata",
       "osmosis_verified": true,
       "_comment": "Yield GATA $YGATA",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "dungeon1",
@@ -6324,12 +5833,7 @@
         "symbol": "DGN.old"
       },
       "_comment": "Dragon Coin (old) $DGN.old",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "dungeon",
@@ -6350,12 +5854,7 @@
         "depin"
       ],
       "_comment": "Synternet $SYNT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -6502,12 +6001,7 @@
       "path": "transfer/channel-91942/uaaron",
       "osmosis_verified": false,
       "_comment": "Aaron Network $AARON",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "chihuahua",
@@ -6592,12 +6086,7 @@
         "stablecoin"
       ],
       "_comment": "kUSD $kUSD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "kopi",
@@ -6608,12 +6097,7 @@
         "defi"
       ],
       "_comment": "Kopi $XKP",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "quicksilver",
@@ -6717,12 +6201,7 @@
       "path": "transfer/channel-98081/sat",
       "osmosis_verified": true,
       "_comment": "Side Bitcoin $sBTC",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -6781,8 +6260,7 @@
       "categories": [
         "meme"
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "juno",
@@ -6810,12 +6288,7 @@
         "defi"
       ],
       "_comment": "Pryzm $PRYZM",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "stargaze",
@@ -6866,19 +6339,14 @@
       "categories": [
         "privacy"
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/ba-ba",
       "osmosis_verified": false,
       "listing_date_time_utc": "2025-03-28T06:38:05Z",
-      "_comment": "von Baysen-Ba\u00c5\u00bce\u00c5\u201eski $BABA",
+      "_comment": "von Baysen-Bażeński $BABA",
       "categories": [
         "meme"
       ]
@@ -7009,12 +6477,7 @@
         "liquid_staking"
       ],
       "_comment": "MilkyWay $MILK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "planq",
@@ -7022,12 +6485,7 @@
       "path": "transfer/channel-492/erc20/0xF630B96760B91f6FCbE8b3C24f2786AcA3D03648",
       "osmosis_verified": false,
       "_comment": "Anubis $ANUBI",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "planq",
@@ -7035,12 +6493,7 @@
       "path": "transfer/channel-492/erc20/0x8F4d86ABa1b47832C46f11e0fFD0F7aDa4498345",
       "osmosis_verified": false,
       "_comment": "Astonic $ATC",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "planq",
@@ -7048,12 +6501,7 @@
       "path": "transfer/channel-492/erc20/0xA2871B267a7d888F830251F6B4D9d3DFf184995a",
       "osmosis_verified": false,
       "_comment": "Astonic USD $aUSD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "planq",
@@ -7061,12 +6509,7 @@
       "path": "transfer/channel-492/erc20/0xd5be2932FEbD73019ba1d5d97DFC35E1Ab09E501",
       "osmosis_verified": false,
       "_comment": "Astonic EUR $aEUR",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "planq",
@@ -7074,12 +6517,7 @@
       "path": "transfer/channel-492/erc20/0x240642C6f69878A0b199065f25EDf82023BC59ce",
       "osmosis_verified": false,
       "_comment": "Astonic BRL $aBRL",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "cosmoshub",
@@ -7135,12 +6573,7 @@
         "liquid_staking"
       ],
       "_comment": "milkBABY $milkBABY",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -7206,12 +6639,7 @@
       "osmosis_verified": false,
       "osmosis_unlisted": true,
       "_comment": "OPHIR $OPHIR",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "cosmoshub",
@@ -7317,12 +6745,7 @@
         "symbol": "XRP.xrplevm"
       },
       "_comment": "Ripple (XRPL EVM) $XRP.xrplevm",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "taketitan",
@@ -7363,12 +6786,7 @@
       "path": "transfer/channel-104931/ahp",
       "osmosis_verified": false,
       "_comment": "Hippo Protocol $HP",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "int3face",
@@ -7485,12 +6903,7 @@
       "path": "transfer/channel-100418/umfx",
       "osmosis_verified": false,
       "_comment": "Manifest Token $MFX",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -7526,12 +6939,7 @@
         "defi"
       ],
       "_comment": "Intento $INTO",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "sunrise",
@@ -7665,12 +7073,7 @@
       "categories": [
         "social"
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "osmosis",
@@ -7693,12 +7096,7 @@
       "path": "transfer/channel-109096/uDRC",
       "osmosis_verified": true,
       "_comment": "Divine $DRC",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_unstable": true
     },
     {
       "chain_name": "initia",
@@ -7747,2832 +7145,1652 @@
       "base_denom": "echf",
       "path": "transfer/channel-37/echf",
       "osmosis_unstable": true,
-      "_comment": "e-Money CHF $ECHF",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "e-Money CHF $ECHF"
     },
     {
       "chain_name": "emoney",
       "base_denom": "enok",
       "path": "transfer/channel-37/enok",
       "osmosis_unstable": true,
-      "_comment": "e-Money NOK $ENOK",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "e-Money NOK $ENOK"
     },
     {
       "chain_name": "emoney",
       "base_denom": "edkk",
       "path": "transfer/channel-37/edkk",
       "osmosis_unstable": true,
-      "_comment": "e-Money DKK $EDKK",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "e-Money DKK $EDKK"
     },
     {
       "chain_name": "emoney",
       "base_denom": "esek",
       "path": "transfer/channel-37/esek",
       "osmosis_unstable": true,
-      "_comment": "e-Money SEK $ESEK",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "e-Money SEK $ESEK"
     },
     {
       "chain_name": "odin",
       "base_denom": "umyrk",
       "path": "transfer/channel-258/umyrk",
       "osmosis_unstable": true,
-      "_comment": "MYRK $MYRK",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "MYRK $MYRK"
     },
     {
       "chain_name": "planq",
       "base_denom": "erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09",
       "path": "transfer/channel-492/erc20/0x091F9A57A3F58d758b6572E9d41675918EAC7F09",
       "osmosis_unstable": true,
-      "_comment": "Source Token $SRCX.planq",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Source Token $SRCX.planq"
     },
     {
       "chain_name": "stafihub",
       "base_denom": "uriris",
       "path": "transfer/channel-5413/uriris",
       "osmosis_unstable": true,
-      "_comment": "rIRIS $rIRIS",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "rIRIS $rIRIS"
     },
     {
       "chain_name": "stafihub",
       "base_denom": "urhuahua",
       "path": "transfer/channel-5413/urhuahua",
       "osmosis_unstable": true,
-      "_comment": "rHUAHUA $rHUAHUA",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "rHUAHUA $rHUAHUA"
     },
     {
       "chain_name": "stafihub",
       "base_denom": "urswth",
       "path": "transfer/channel-5413/urswth",
       "osmosis_unstable": true,
-      "_comment": "rSWTH $rSWTH",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "rSWTH $rSWTH"
     },
     {
       "chain_name": "scorum",
       "base_denom": "gas",
       "path": "transfer/channel-20100/gas",
       "osmosis_unstable": true,
-      "_comment": "GAS $GAS",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "GAS $GAS"
     },
     {
       "chain_name": "lorenzo",
       "base_denom": "alrz",
       "path": "transfer/channel-79840/alrz",
       "osmosis_unstable": true,
-      "_comment": "Lorenzo Protocol $LRZ",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Lorenzo Protocol $LRZ"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uauuu",
       "path": "transfer/channel-75755/factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uauuu",
       "osmosis_unstable": true,
-      "_comment": "AUUU $AUUU",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "AUUU $AUUU"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "c:uatom",
       "path": "transfer/channel-75755/c:uatom",
       "osmosis_unstable": true,
-      "_comment": "cAtom $cATOM",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cAtom $cATOM"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "c:inj",
       "path": "transfer/channel-75755/c:inj",
       "osmosis_unstable": true,
-      "_comment": "cInj $cINJ",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cInj $cINJ"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "c:uosmo",
       "path": "transfer/channel-75755/c:uosmo",
       "osmosis_unstable": true,
-      "_comment": "cOsmo $cOSMO",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cOsmo $cOSMO"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "c:uluna",
       "path": "transfer/channel-75755/c:uluna",
       "osmosis_unstable": true,
-      "_comment": "cLuna $cLUNA",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cLuna $cLUNA"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "factory/pryzm1qg5ega6dykkxc307y25pecuufrjkxkaggkkxh7nad0vhyhtuhw3sk0s70x/cuauuu",
       "path": "transfer/channel-75755/factory/pryzm1qg5ega6dykkxc307y25pecuufrjkxkaggkkxh7nad0vhyhtuhw3sk0s70x/cuauuu",
       "osmosis_unstable": true,
-      "_comment": "cAuuu $cAUUU",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cAuuu $cAUUU"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "c:utia",
       "path": "transfer/channel-75755/c:utia",
       "osmosis_unstable": true,
-      "_comment": "cTia $cTIA",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cTia $cTIA"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "c:upryzm",
       "path": "transfer/channel-75755/c:upryzm",
       "osmosis_unstable": true,
-      "_comment": "cPryzm $cPRYZM",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "cPryzm $cPRYZM"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:30Sep2024",
       "path": "transfer/channel-75755/p:uatom:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pAtom (30Sep2024) $pATOM-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (30Sep2024) $pATOM-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:31Dec2024",
       "path": "transfer/channel-75755/p:uatom:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pAtom (31Dec2024) $pATOM-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (31Dec2024) $pATOM-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:31Mar2025",
       "path": "transfer/channel-75755/p:uatom:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pAtom (31Mar2025) $pATOM-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (31Mar2025) $pATOM-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:30Jun2025",
       "path": "transfer/channel-75755/p:uatom:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pAtom (30Jun2025) $pATOM-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (30Jun2025) $pATOM-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:30Sep2025",
       "path": "transfer/channel-75755/p:uatom:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pAtom (30Sep2025) $pATOM-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (30Sep2025) $pATOM-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:31Dec2025",
       "path": "transfer/channel-75755/p:uatom:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pAtom (31Dec2025) $pATOM-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (31Dec2025) $pATOM-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uatom:31Dec2026",
       "path": "transfer/channel-75755/p:uatom:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pAtom (31Dec2026) $pATOM-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAtom (31Dec2026) $pATOM-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:30Sep2024",
       "path": "transfer/channel-75755/p:uosmo:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (30Sep2024) $pOSMO-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (30Sep2024) $pOSMO-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:31Dec2024",
       "path": "transfer/channel-75755/p:uosmo:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (31Dec2024) $pOSMO-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (31Dec2024) $pOSMO-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:31Mar2025",
       "path": "transfer/channel-75755/p:uosmo:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (31Mar2025) $pOSMO-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (31Mar2025) $pOSMO-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:30Jun2025",
       "path": "transfer/channel-75755/p:uosmo:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (30Jun2025) $pOSMO-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (30Jun2025) $pOSMO-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:30Sep2025",
       "path": "transfer/channel-75755/p:uosmo:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (30Sep2025) $pOSMO-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (30Sep2025) $pOSMO-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:31Dec2025",
       "path": "transfer/channel-75755/p:uosmo:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (31Dec2025) $pOSMO-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (31Dec2025) $pOSMO-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uosmo:31Dec2026",
       "path": "transfer/channel-75755/p:uosmo:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pOsmo (31Dec2026) $pOSMO-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pOsmo (31Dec2026) $pOSMO-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:30Sep2024",
       "path": "transfer/channel-75755/p:inj:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pInj (30Sep2024) $pINJ-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (30Sep2024) $pINJ-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:31Dec2024",
       "path": "transfer/channel-75755/p:inj:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pInj (31Dec2024) $pINJ-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (31Dec2024) $pINJ-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:31Mar2025",
       "path": "transfer/channel-75755/p:inj:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pInj (31Mar2025) $pINJ-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (31Mar2025) $pINJ-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:30Jun2025",
       "path": "transfer/channel-75755/p:inj:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pInj (30Jun2025) $pINJ-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (30Jun2025) $pINJ-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:30Sep2025",
       "path": "transfer/channel-75755/p:inj:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pInj (30Sep2025) $pINJ-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (30Sep2025) $pINJ-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:31Dec2025",
       "path": "transfer/channel-75755/p:inj:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pInj (31Dec2025) $pINJ-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (31Dec2025) $pINJ-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:inj:31Dec2026",
       "path": "transfer/channel-75755/p:inj:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pInj (31Dec2026) $pINJ-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pInj (31Dec2026) $pINJ-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:30Sep2024",
       "path": "transfer/channel-75755/p:uluna:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pLuna (30Sep2024) $pLUNA-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (30Sep2024) $pLUNA-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:31Dec2024",
       "path": "transfer/channel-75755/p:uluna:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pLuna (31Dec2024) $pLUNA-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (31Dec2024) $pLUNA-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:31Mar2025",
       "path": "transfer/channel-75755/p:uluna:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pLuna (31Mar2025) $pLUNA-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (31Mar2025) $pLUNA-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:30Jun2025",
       "path": "transfer/channel-75755/p:uluna:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pLuna (30Jun2025) $pLUNA-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (30Jun2025) $pLUNA-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:30Sep2025",
       "path": "transfer/channel-75755/p:uluna:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pLuna (30Sep2025) $pLUNA-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (30Sep2025) $pLUNA-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:31Dec2025",
       "path": "transfer/channel-75755/p:uluna:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pLuna (31Dec2025) $pLUNA-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (31Dec2025) $pLUNA-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uluna:31Dec2026",
       "path": "transfer/channel-75755/p:uluna:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pLuna (31Dec2026) $pLUNA-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pLuna (31Dec2026) $pLUNA-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uauuu:30Sep2024",
       "path": "transfer/channel-75755/p:uauuu:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pAuuu (30Sep2024) $pAUUU-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAuuu (30Sep2024) $pAUUU-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uauuu:31Dec2024",
       "path": "transfer/channel-75755/p:uauuu:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pAuuu (31Dec2024) $pAUUU-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAuuu (31Dec2024) $pAUUU-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uauuu:30Jun2025",
       "path": "transfer/channel-75755/p:uauuu:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pAuuu (30Jun2025) $pAUUU-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAuuu (30Jun2025) $pAUUU-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uauuu:31Dec2025",
       "path": "transfer/channel-75755/p:uauuu:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pAuuu (31Dec2025) $pAUUU-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAuuu (31Dec2025) $pAUUU-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:uauuu:31Dec2026",
       "path": "transfer/channel-75755/p:uauuu:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pAuuu (31Dec2026) $pAUUU-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pAuuu (31Dec2026) $pAUUU-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stutia:30Sep2024",
       "path": "transfer/channel-75755/p:stutia:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pstTia (30Sep2024) $pstTIA-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstTia (30Sep2024) $pstTIA-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stutia:31Dec2024",
       "path": "transfer/channel-75755/p:stutia:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pstTia (31Dec2024) $pstTIA-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstTia (31Dec2024) $pstTIA-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stutia:31Mar2025",
       "path": "transfer/channel-75755/p:stutia:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pstTia (31Mar2025) $pstTIA-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstTia (31Mar2025) $pstTIA-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stutia:30Jun2025",
       "path": "transfer/channel-75755/p:stutia:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pstTia (30Jun2025) $pstTIA-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstTia (30Jun2025) $pstTIA-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stutia:31Dec2025",
       "path": "transfer/channel-75755/p:stutia:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pstTia (31Dec2025) $pstTIA-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstTia (31Dec2025) $pstTIA-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stutia:31Dec2026",
       "path": "transfer/channel-75755/p:stutia:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pstTia (31Dec2026) $pstTIA-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstTia (31Dec2026) $pstTIA-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stadydx:30Sep2024",
       "path": "transfer/channel-75755/p:stadydx:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "pstDydx (30Sep2024) $pstDYDX-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstDydx (30Sep2024) $pstDYDX-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stadydx:31Dec2024",
       "path": "transfer/channel-75755/p:stadydx:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pstDydx (31Dec2024) $pstDYDX-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstDydx (31Dec2024) $pstDYDX-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stadydx:31Mar2025",
       "path": "transfer/channel-75755/p:stadydx:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pstDydx (31Mar2025) $pstDYDX-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstDydx (31Mar2025) $pstDYDX-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stadydx:30Jun2025",
       "path": "transfer/channel-75755/p:stadydx:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pstDydx (30Jun2025) $pstDYDX-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstDydx (30Jun2025) $pstDYDX-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stadydx:31Dec2025",
       "path": "transfer/channel-75755/p:stadydx:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pstDydx (31Dec2025) $pstDYDX-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstDydx (31Dec2025) $pstDYDX-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:stadydx:31Dec2026",
       "path": "transfer/channel-75755/p:stadydx:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pstDydx (31Dec2026) $pstDYDX-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pstDydx (31Dec2026) $pstDYDX-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:udatom:31Dec2024",
       "path": "transfer/channel-75755/p:udatom:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pdAtom (31Dec2024) $pdATOM-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pdAtom (31Dec2024) $pdATOM-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:udatom:31Mar2025",
       "path": "transfer/channel-75755/p:udatom:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pdAtom (31Mar2025) $pdATOM-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pdAtom (31Mar2025) $pdATOM-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:udatom:30Jun2025",
       "path": "transfer/channel-75755/p:udatom:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pdAtom (30Jun2025) $pdATOM-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pdAtom (30Jun2025) $pdATOM-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:udatom:31Dec2025",
       "path": "transfer/channel-75755/p:udatom:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pdAtom (31Dec2025) $pdATOM-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pdAtom (31Dec2025) $pdATOM-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:udatom:31Dec2026",
       "path": "transfer/channel-75755/p:udatom:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pdAtom (31Dec2026) $pdATOM-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pdAtom (31Dec2026) $pdATOM-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:utia:31Dec2024",
       "path": "transfer/channel-75755/p:utia:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "pTia (31Dec2024) $pTIA-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pTia (31Dec2024) $pTIA-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:utia:31Mar2025",
       "path": "transfer/channel-75755/p:utia:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pTia (31Mar2025) $pTIA-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pTia (31Mar2025) $pTIA-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:utia:30Jun2025",
       "path": "transfer/channel-75755/p:utia:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pTia (30Jun2025) $pTIA-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pTia (30Jun2025) $pTIA-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:utia:30Sep2025",
       "path": "transfer/channel-75755/p:utia:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pTia (30Sep2025) $pTIA-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pTia (30Sep2025) $pTIA-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:utia:31Dec2025",
       "path": "transfer/channel-75755/p:utia:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pTia (31Dec2025) $pTIA-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pTia (31Dec2025) $pTIA-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:utia:31Dec2026",
       "path": "transfer/channel-75755/p:utia:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "pTia (31Dec2026) $pTIA-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pTia (31Dec2026) $pTIA-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ausdy:31Mar2025",
       "path": "transfer/channel-75755/p:ausdy:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pUsdy (31Mar2025) $pUSDY-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pUsdy (31Mar2025) $pUSDY-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ausdy:30Jun2025",
       "path": "transfer/channel-75755/p:ausdy:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pUsdy (30Jun2025) $pUSDY-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pUsdy (30Jun2025) $pUSDY-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ausdy:30Sep2025",
       "path": "transfer/channel-75755/p:ausdy:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pUsdy (30Sep2025) $pUSDY-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pUsdy (30Sep2025) $pUSDY-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ausdy:31Dec2025",
       "path": "transfer/channel-75755/p:ausdy:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pUsdy (31Dec2025) $pUSDY-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pUsdy (31Dec2025) $pUSDY-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ausdy:31Mar2026",
       "path": "transfer/channel-75755/p:ausdy:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "pUsdy (31Mar2026) $pUSDY-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pUsdy (31Mar2026) $pUSDY-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ausdy:30Jun2026",
       "path": "transfer/channel-75755/p:ausdy:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "pUsdy (30Jun2026) $pUSDY-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pUsdy (30Jun2026) $pUSDY-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:upryzm:31Mar2025",
       "path": "transfer/channel-75755/p:upryzm:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "pPryzm (31Mar2025) $pPRYZM-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pPryzm (31Mar2025) $pPRYZM-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:upryzm:30Jun2025",
       "path": "transfer/channel-75755/p:upryzm:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "pPryzm (30Jun2025) $pPRYZM-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pPryzm (30Jun2025) $pPRYZM-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:upryzm:30Sep2025",
       "path": "transfer/channel-75755/p:upryzm:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pPryzm (30Sep2025) $pPRYZM-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pPryzm (30Sep2025) $pPRYZM-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:upryzm:31Dec2025",
       "path": "transfer/channel-75755/p:upryzm:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pPryzm (31Dec2025) $pPRYZM-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pPryzm (31Dec2025) $pPRYZM-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:upryzm:31Mar2026",
       "path": "transfer/channel-75755/p:upryzm:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "pPryzm (31Mar2026) $pPRYZM-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pPryzm (31Mar2026) $pPRYZM-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:upryzm:30Jun2026",
       "path": "transfer/channel-75755/p:upryzm:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "pPryzm (30Jun2026) $pPRYZM-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pPryzm (30Jun2026) $pPRYZM-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:asusds:30Jun2025",
       "path": "transfer/channel-75755/p:asusds:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "psUsds (30Jun2025) $psUSDS-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "psUsds (30Jun2025) $psUSDS-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:asusds:30Sep2025",
       "path": "transfer/channel-75755/p:asusds:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "psUsds (30Sep2025) $psUSDS-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "psUsds (30Sep2025) $psUSDS-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:asusds:31Dec2025",
       "path": "transfer/channel-75755/p:asusds:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "psUsds (31Dec2025) $psUSDS-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "psUsds (31Dec2025) $psUSDS-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:asusds:31Mar2026",
       "path": "transfer/channel-75755/p:asusds:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "psUsds (31Mar2026) $psUSDS-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "psUsds (31Mar2026) $psUSDS-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:asusds:30Jun2026",
       "path": "transfer/channel-75755/p:asusds:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "psUsds (30Jun2026) $psUSDS-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "psUsds (30Jun2026) $psUSDS-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ambtc:30Sep2025",
       "path": "transfer/channel-75755/p:ambtc:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "pmBTC (30Sep2025) $pmBTC-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pmBTC (30Sep2025) $pmBTC-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ambtc:31Dec2025",
       "path": "transfer/channel-75755/p:ambtc:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "pmBTC (31Dec2025) $pmBTC-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pmBTC (31Dec2025) $pmBTC-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ambtc:31Mar2026",
       "path": "transfer/channel-75755/p:ambtc:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "pmBTC (31Mar2026) $pmBTC-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pmBTC (31Mar2026) $pmBTC-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "p:ambtc:30Jun2026",
       "path": "transfer/channel-75755/p:ambtc:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "pmBTC (30Jun2026) $pmBTC-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "pmBTC (30Jun2026) $pmBTC-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:30Sep2024",
       "path": "transfer/channel-75755/y:uatom:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "yAtom (30Sep2024) $yATOM-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (30Sep2024) $yATOM-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:31Dec2024",
       "path": "transfer/channel-75755/y:uatom:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "yAtom (31Dec2024) $yATOM-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (31Dec2024) $yATOM-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:31Mar2025",
       "path": "transfer/channel-75755/y:uatom:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yAtom (31Mar2025) $yATOM-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (31Mar2025) $yATOM-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:30Jun2025",
       "path": "transfer/channel-75755/y:uatom:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yAtom (30Jun2025) $yATOM-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (30Jun2025) $yATOM-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:30Sep2025",
       "path": "transfer/channel-75755/y:uatom:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yAtom (30Sep2025) $yATOM-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (30Sep2025) $yATOM-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:31Dec2025",
       "path": "transfer/channel-75755/y:uatom:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yAtom (31Dec2025) $yATOM-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (31Dec2025) $yATOM-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uatom:31Dec2026",
       "path": "transfer/channel-75755/y:uatom:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "yAtom (31Dec2026) $yATOM-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAtom (31Dec2026) $yATOM-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:30Sep2024",
       "path": "transfer/channel-75755/y:uosmo:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (30Sep2024) $yOSMO-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (30Sep2024) $yOSMO-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:31Dec2024",
       "path": "transfer/channel-75755/y:uosmo:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (31Dec2024) $yOSMO-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (31Dec2024) $yOSMO-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:31Mar2025",
       "path": "transfer/channel-75755/y:uosmo:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (31Mar2025) $yOSMO-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (31Mar2025) $yOSMO-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:30Jun2025",
       "path": "transfer/channel-75755/y:uosmo:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (30Jun2025) $yOSMO-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (30Jun2025) $yOSMO-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:30Sep2025",
       "path": "transfer/channel-75755/y:uosmo:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (30Sep2025) $yOSMO-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (30Sep2025) $yOSMO-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:31Dec2025",
       "path": "transfer/channel-75755/y:uosmo:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (31Dec2025) $yOSMO-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (31Dec2025) $yOSMO-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uosmo:31Dec2026",
       "path": "transfer/channel-75755/y:uosmo:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "yOsmo (31Dec2026) $yOSMO-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yOsmo (31Dec2026) $yOSMO-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:30Sep2024",
       "path": "transfer/channel-75755/y:inj:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "yInj (30Sep2024) $yINJ-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (30Sep2024) $yINJ-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:31Dec2024",
       "path": "transfer/channel-75755/y:inj:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "yInj (31Dec2024) $yINJ-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (31Dec2024) $yINJ-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:31Mar2025",
       "path": "transfer/channel-75755/y:inj:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yInj (31Mar2025) $yINJ-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (31Mar2025) $yINJ-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:30Jun2025",
       "path": "transfer/channel-75755/y:inj:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yInj (30Jun2025) $yINJ-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (30Jun2025) $yINJ-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:30Sep2025",
       "path": "transfer/channel-75755/y:inj:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yInj (30Sep2025) $yINJ-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (30Sep2025) $yINJ-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:31Dec2025",
       "path": "transfer/channel-75755/y:inj:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yInj (31Dec2025) $yINJ-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (31Dec2025) $yINJ-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:inj:31Dec2026",
       "path": "transfer/channel-75755/y:inj:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "yInj (31Dec2026) $yINJ-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yInj (31Dec2026) $yINJ-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:30Sep2024",
       "path": "transfer/channel-75755/y:uluna:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "yLuna (30Sep2024) $yLUNA-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (30Sep2024) $yLUNA-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:31Dec2024",
       "path": "transfer/channel-75755/y:uluna:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "yLuna (31Dec2024) $yLUNA-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (31Dec2024) $yLUNA-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:31Mar2025",
       "path": "transfer/channel-75755/y:uluna:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yLuna (31Mar2025) $yLUNA-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (31Mar2025) $yLUNA-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:30Jun2025",
       "path": "transfer/channel-75755/y:uluna:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yLuna (30Jun2025) $yLUNA-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (30Jun2025) $yLUNA-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:30Sep2025",
       "path": "transfer/channel-75755/y:uluna:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yLuna (30Sep2025) $yLUNA-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (30Sep2025) $yLUNA-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:31Dec2025",
       "path": "transfer/channel-75755/y:uluna:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yLuna (31Dec2025) $yLUNA-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (31Dec2025) $yLUNA-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uluna:31Dec2026",
       "path": "transfer/channel-75755/y:uluna:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "yLuna (31Dec2026) $yLUNA-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yLuna (31Dec2026) $yLUNA-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uauuu:30Sep2024",
       "path": "transfer/channel-75755/y:uauuu:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "yAuuu (30Sep2024) $yAUUU-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAuuu (30Sep2024) $yAUUU-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uauuu:31Dec2024",
       "path": "transfer/channel-75755/y:uauuu:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "yAuuu (31Dec2024) $yAUUU-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAuuu (31Dec2024) $yAUUU-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uauuu:30Jun2025",
       "path": "transfer/channel-75755/y:uauuu:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yAuuu (30Jun2025) $yAUUU-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAuuu (30Jun2025) $yAUUU-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uauuu:31Dec2025",
       "path": "transfer/channel-75755/y:uauuu:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yAuuu (31Dec2025) $yAUUU-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAuuu (31Dec2025) $yAUUU-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:uauuu:31Dec2026",
       "path": "transfer/channel-75755/y:uauuu:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "yAuuu (31Dec2026) $yAUUU-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yAuuu (31Dec2026) $yAUUU-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stutia:30Sep2024",
       "path": "transfer/channel-75755/y:stutia:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "ystTia (30Sep2024) $ystTIA-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystTia (30Sep2024) $ystTIA-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stutia:31Dec2024",
       "path": "transfer/channel-75755/y:stutia:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "ystTia (31Dec2024) $ystTIA-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystTia (31Dec2024) $ystTIA-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stutia:31Mar2025",
       "path": "transfer/channel-75755/y:stutia:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "ystTia (31Mar2025) $ystTIA-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystTia (31Mar2025) $ystTIA-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stutia:30Jun2025",
       "path": "transfer/channel-75755/y:stutia:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "ystTia (30Jun2025) $ystTIA-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystTia (30Jun2025) $ystTIA-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stutia:31Dec2025",
       "path": "transfer/channel-75755/y:stutia:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "ystTia (31Dec2025) $ystTIA-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystTia (31Dec2025) $ystTIA-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stutia:31Dec2026",
       "path": "transfer/channel-75755/y:stutia:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "ystTia (31Dec2026) $ystTIA-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystTia (31Dec2026) $ystTIA-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stadydx:30Sep2024",
       "path": "transfer/channel-75755/y:stadydx:30Sep2024",
       "osmosis_unstable": true,
-      "_comment": "ystDydx (30Sep2024) $ystDYDX-30Sep2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystDydx (30Sep2024) $ystDYDX-30Sep2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stadydx:31Dec2024",
       "path": "transfer/channel-75755/y:stadydx:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "ystDydx (31Dec2024) $ystDYDX-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystDydx (31Dec2024) $ystDYDX-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stadydx:31Mar2025",
       "path": "transfer/channel-75755/y:stadydx:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "ystDydx (31Mar2025) $ystDYDX-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystDydx (31Mar2025) $ystDYDX-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stadydx:30Jun2025",
       "path": "transfer/channel-75755/y:stadydx:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "ystDydx (30Jun2025) $ystDYDX-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystDydx (30Jun2025) $ystDYDX-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stadydx:31Dec2025",
       "path": "transfer/channel-75755/y:stadydx:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "ystDydx (31Dec2025) $ystDYDX-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystDydx (31Dec2025) $ystDYDX-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:stadydx:31Dec2026",
       "path": "transfer/channel-75755/y:stadydx:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "ystDydx (31Dec2026) $ystDYDX-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ystDydx (31Dec2026) $ystDYDX-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:udatom:31Dec2024",
       "path": "transfer/channel-75755/y:udatom:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "ydAtom (31Dec2024) $ydATOM-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ydAtom (31Dec2024) $ydATOM-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:udatom:31Mar2025",
       "path": "transfer/channel-75755/y:udatom:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "ydAtom (31Mar2025) $ydATOM-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ydAtom (31Mar2025) $ydATOM-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:udatom:30Jun2025",
       "path": "transfer/channel-75755/y:udatom:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "ydAtom (30Jun2025) $ydATOM-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ydAtom (30Jun2025) $ydATOM-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:udatom:31Dec2025",
       "path": "transfer/channel-75755/y:udatom:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "ydAtom (31Dec2025) $ydATOM-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ydAtom (31Dec2025) $ydATOM-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:udatom:31Dec2026",
       "path": "transfer/channel-75755/y:udatom:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "ydAtom (31Dec2026) $ydATOM-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ydAtom (31Dec2026) $ydATOM-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:utia:31Dec2024",
       "path": "transfer/channel-75755/y:utia:31Dec2024",
       "osmosis_unstable": true,
-      "_comment": "yTia (31Dec2024) $yTIA-31Dec2024",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yTia (31Dec2024) $yTIA-31Dec2024"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:utia:31Mar2025",
       "path": "transfer/channel-75755/y:utia:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yTia (31Mar2025) $yTIA-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yTia (31Mar2025) $yTIA-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:utia:30Jun2025",
       "path": "transfer/channel-75755/y:utia:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yTia (30Jun2025) $yTIA-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yTia (30Jun2025) $yTIA-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:utia:30Sep2025",
       "path": "transfer/channel-75755/y:utia:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yTia (30Sep2025) $yTIA-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yTia (30Sep2025) $yTIA-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:utia:31Dec2025",
       "path": "transfer/channel-75755/y:utia:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yTia (31Dec2025) $yTIA-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yTia (31Dec2025) $yTIA-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:utia:31Dec2026",
       "path": "transfer/channel-75755/y:utia:31Dec2026",
       "osmosis_unstable": true,
-      "_comment": "yTia (31Dec2026) $yTIA-31Dec2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yTia (31Dec2026) $yTIA-31Dec2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ausdy:31Mar2025",
       "path": "transfer/channel-75755/y:ausdy:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yUsdy (31Mar2025) $yUSDY-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yUsdy (31Mar2025) $yUSDY-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ausdy:30Jun2025",
       "path": "transfer/channel-75755/y:ausdy:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yUsdy (30Jun2025) $yUSDY-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yUsdy (30Jun2025) $yUSDY-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ausdy:30Sep2025",
       "path": "transfer/channel-75755/y:ausdy:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yUsdy (30Sep2025) $yUSDY-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yUsdy (30Sep2025) $yUSDY-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ausdy:31Dec2025",
       "path": "transfer/channel-75755/y:ausdy:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yUsdy (31Dec2025) $yUSDY-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yUsdy (31Dec2025) $yUSDY-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ausdy:31Mar2026",
       "path": "transfer/channel-75755/y:ausdy:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "yUsdy (31Mar2026) $yUSDY-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yUsdy (31Mar2026) $yUSDY-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ausdy:30Jun2026",
       "path": "transfer/channel-75755/y:ausdy:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "yUsdy (30Jun2026) $yUSDY-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yUsdy (30Jun2026) $yUSDY-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:upryzm:31Mar2025",
       "path": "transfer/channel-75755/y:upryzm:31Mar2025",
       "osmosis_unstable": true,
-      "_comment": "yPryzm (31Mar2025) $yPRYZM-31Mar2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yPryzm (31Mar2025) $yPRYZM-31Mar2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:upryzm:30Jun2025",
       "path": "transfer/channel-75755/y:upryzm:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "yPryzm (30Jun2025) $yPRYZM-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yPryzm (30Jun2025) $yPRYZM-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:upryzm:30Sep2025",
       "path": "transfer/channel-75755/y:upryzm:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "yPryzm (30Sep2025) $yPRYZM-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yPryzm (30Sep2025) $yPRYZM-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:upryzm:31Dec2025",
       "path": "transfer/channel-75755/y:upryzm:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "yPryzm (31Dec2025) $yPRYZM-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yPryzm (31Dec2025) $yPRYZM-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:upryzm:31Mar2026",
       "path": "transfer/channel-75755/y:upryzm:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "yPryzm (31Mar2026) $yPRYZM-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yPryzm (31Mar2026) $yPRYZM-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:upryzm:30Jun2026",
       "path": "transfer/channel-75755/y:upryzm:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "yPryzm (30Jun2026) $yPRYZM-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "yPryzm (30Jun2026) $yPRYZM-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:asusds:30Jun2025",
       "path": "transfer/channel-75755/y:asusds:30Jun2025",
       "osmosis_unstable": true,
-      "_comment": "ysUsds (30Jun2025) $ysUSDS-30Jun2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ysUsds (30Jun2025) $ysUSDS-30Jun2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:asusds:30Sep2025",
       "path": "transfer/channel-75755/y:asusds:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "ysUsds (30Sep2025) $ysUSDS-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ysUsds (30Sep2025) $ysUSDS-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:asusds:31Dec2025",
       "path": "transfer/channel-75755/y:asusds:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "ysUsds (31Dec2025) $ysUSDS-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ysUsds (31Dec2025) $ysUSDS-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:asusds:31Mar2026",
       "path": "transfer/channel-75755/y:asusds:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "ysUsds (31Mar2026) $ysUSDS-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ysUsds (31Mar2026) $ysUSDS-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:asusds:30Jun2026",
       "path": "transfer/channel-75755/y:asusds:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "ysUsds (30Jun2026) $ysUSDS-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ysUsds (30Jun2026) $ysUSDS-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ambtc:30Sep2025",
       "path": "transfer/channel-75755/y:ambtc:30Sep2025",
       "osmosis_unstable": true,
-      "_comment": "ymBTC (30Sep2025) $ymBTC-30Sep2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ymBTC (30Sep2025) $ymBTC-30Sep2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ambtc:31Dec2025",
       "path": "transfer/channel-75755/y:ambtc:31Dec2025",
       "osmosis_unstable": true,
-      "_comment": "ymBTC (31Dec2025) $ymBTC-31Dec2025",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ymBTC (31Dec2025) $ymBTC-31Dec2025"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ambtc:31Mar2026",
       "path": "transfer/channel-75755/y:ambtc:31Mar2026",
       "osmosis_unstable": true,
-      "_comment": "ymBTC (31Mar2026) $ymBTC-31Mar2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ymBTC (31Mar2026) $ymBTC-31Mar2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "y:ambtc:30Jun2026",
       "path": "transfer/channel-75755/y:ambtc:30Jun2026",
       "osmosis_unstable": true,
-      "_comment": "ymBTC (30Jun2026) $ymBTC-30Jun2026",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ymBTC (30Jun2026) $ymBTC-30Jun2026"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:6:uusdc.axl-uusdc",
       "path": "transfer/channel-75755/lp:6:uusdc.axl-uusdc",
       "osmosis_unstable": true,
-      "_comment": "USDC / USDC.axl LP $USDC-USDC.axl-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "USDC / USDC.axl LP $USDC-USDC.axl-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:0:uatom",
       "path": "transfer/channel-75755/lp:0:uatom",
       "osmosis_unstable": true,
-      "_comment": "ATOM Yield LP $ATOM-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ATOM Yield LP $ATOM-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:2:uatomypt-uatom",
       "path": "transfer/channel-75755/lp:2:uatomypt-uatom",
       "osmosis_unstable": true,
-      "_comment": "ATOM Boost LP $ATOM-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ATOM Boost LP $ATOM-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:3:uatom-uusdc",
       "path": "transfer/channel-75755/lp:3:uatom-uusdc",
       "osmosis_unstable": true,
-      "_comment": "ATOM / USDC LP $ATOM-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "ATOM / USDC LP $ATOM-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:1:inj",
       "path": "transfer/channel-75755/lp:1:inj",
       "osmosis_unstable": true,
-      "_comment": "INJ Yield LP $INJ-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "INJ Yield LP $INJ-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:4:injypt-inj",
       "path": "transfer/channel-75755/lp:4:injypt-inj",
       "osmosis_unstable": true,
-      "_comment": "INJ Boost LP $INJ-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "INJ Boost LP $INJ-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:5:inj-uusdc",
       "path": "transfer/channel-75755/lp:5:inj-uusdc",
       "osmosis_unstable": true,
-      "_comment": "INJ / USDC LP $INJ-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "INJ / USDC LP $INJ-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:10:uosmoypt-uosmo",
       "path": "transfer/channel-75755/lp:10:uosmoypt-uosmo",
       "osmosis_unstable": true,
-      "_comment": "OSMO Boost LP $OSMO-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "OSMO Boost LP $OSMO-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:11:uosmo-uusdc",
       "path": "transfer/channel-75755/lp:11:uosmo-uusdc",
       "osmosis_unstable": true,
-      "_comment": "OSMO / USDC LP $OSMO-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "OSMO / USDC LP $OSMO-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:9:uluna",
       "path": "transfer/channel-75755/lp:9:uluna",
       "osmosis_unstable": true,
-      "_comment": "LUNA Yield LP $LUNA-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "LUNA Yield LP $LUNA-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:12:ulunaypt-uluna",
       "path": "transfer/channel-75755/lp:12:ulunaypt-uluna",
       "osmosis_unstable": true,
-      "_comment": "LUNA Boost LP $LUNA-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "LUNA Boost LP $LUNA-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:13:uluna-uusdc",
       "path": "transfer/channel-75755/lp:13:uluna-uusdc",
       "osmosis_unstable": true,
-      "_comment": "LUNA / USDC LP $LUNA-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "LUNA / USDC LP $LUNA-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:14:uauuu",
       "path": "transfer/channel-75755/lp:14:uauuu",
       "osmosis_unstable": true,
-      "_comment": "AUUU Yield LP $AUUU-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "AUUU Yield LP $AUUU-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:17:uauuuypt-uauuu",
       "path": "transfer/channel-75755/lp:17:uauuuypt-uauuu",
       "osmosis_unstable": true,
-      "_comment": "AUUU Boost LP $AUUU-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "AUUU Boost LP $AUUU-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:7:uauuu-uusdc",
       "path": "transfer/channel-75755/lp:7:uauuu-uusdc",
       "osmosis_unstable": true,
-      "_comment": "AUUU / USDC LP $AUUU-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "AUUU / USDC LP $AUUU-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:15:stadydx",
       "path": "transfer/channel-75755/lp:15:stadydx",
       "osmosis_unstable": true,
-      "_comment": "stDYDX Yield LP $stDYDX-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "stDYDX Yield LP $stDYDX-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:18:stadydxypt-adydx",
       "path": "transfer/channel-75755/lp:18:stadydxypt-adydx",
       "osmosis_unstable": true,
-      "_comment": "stDYDX Boost LP $stDYDX-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "stDYDX Boost LP $stDYDX-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:19:adydx-uusdc",
       "path": "transfer/channel-75755/lp:19:adydx-uusdc",
       "osmosis_unstable": true,
-      "_comment": "DYDX / USDC LP $DYDX-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "DYDX / USDC LP $DYDX-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:16:stutia",
       "path": "transfer/channel-75755/lp:16:stutia",
       "osmosis_unstable": true,
-      "_comment": "stTIA Yield LP $stTIA-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "stTIA Yield LP $stTIA-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:20:stutiaypt-utia",
       "path": "transfer/channel-75755/lp:20:stutiaypt-utia",
       "osmosis_unstable": true,
-      "_comment": "stTIA Boost LP $stTIA-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "stTIA Boost LP $stTIA-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:24:utia",
       "path": "transfer/channel-75755/lp:24:utia",
       "osmosis_unstable": true,
-      "_comment": "TIA Yield LP $TIA-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "TIA Yield LP $TIA-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:25:utiaypt-utia",
       "path": "transfer/channel-75755/lp:25:utiaypt-utia",
       "osmosis_unstable": true,
-      "_comment": "TIA Boost LP $TIA-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "TIA Boost LP $TIA-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:21:utia-uusdc",
       "path": "transfer/channel-75755/lp:21:utia-uusdc",
       "osmosis_unstable": true,
-      "_comment": "TIA / USDC LP $TIA-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "TIA / USDC LP $TIA-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:22:udatom",
       "path": "transfer/channel-75755/lp:22:udatom",
       "osmosis_unstable": true,
-      "_comment": "dATOM Yield LP $dATOM-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "dATOM Yield LP $dATOM-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:23:udatomypt-uatom",
       "path": "transfer/channel-75755/lp:23:udatomypt-uatom",
       "osmosis_unstable": true,
-      "_comment": "dATOM Boost LP $dATOM-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "dATOM Boost LP $dATOM-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:31:ausdy",
       "path": "transfer/channel-75755/lp:31:ausdy",
       "osmosis_unstable": true,
-      "_comment": "USDY Yield LP $USDY-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "USDY Yield LP $USDY-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:32:ausdyypt-uusdc",
       "path": "transfer/channel-75755/lp:32:ausdyypt-uusdc",
       "osmosis_unstable": true,
-      "_comment": "USDY Boost LP $USDY-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "USDY Boost LP $USDY-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:33:upryzm",
       "path": "transfer/channel-75755/lp:33:upryzm",
       "osmosis_unstable": true,
-      "_comment": "PRYZM Yield LP $PRYZM-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "PRYZM Yield LP $PRYZM-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:34:upryzmypt-upryzm",
       "path": "transfer/channel-75755/lp:34:upryzmypt-upryzm",
       "osmosis_unstable": true,
-      "_comment": "PRYZM Base LP $PRYZM-BASE-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "PRYZM Base LP $PRYZM-BASE-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:35:upryzm-uusdc",
       "path": "transfer/channel-75755/lp:35:upryzm-uusdc",
       "osmosis_unstable": true,
-      "_comment": "PRYZM / USDC LP $PRYZM-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "PRYZM / USDC LP $PRYZM-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:36:asusds",
       "path": "transfer/channel-75755/lp:36:asusds",
       "osmosis_unstable": true,
-      "_comment": "sUSDS Yield LP $sUSDS-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "sUSDS Yield LP $sUSDS-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:37:asusdsypt-uusdc",
       "path": "transfer/channel-75755/lp:37:asusdsypt-uusdc",
       "osmosis_unstable": true,
-      "_comment": "sUSDS Boost LP $sUSDS-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "sUSDS Boost LP $sUSDS-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:38:ambtc",
       "path": "transfer/channel-75755/lp:38:ambtc",
       "osmosis_unstable": true,
-      "_comment": "mBTC Yield LP $mBTC-YIELD-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "mBTC Yield LP $mBTC-YIELD-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:39:ambtcypt-wsat",
       "path": "transfer/channel-75755/lp:39:ambtcypt-wsat",
       "osmosis_unstable": true,
-      "_comment": "mBTC Boost LP $mBTC-BOOST-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "mBTC Boost LP $mBTC-BOOST-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "lp:40:wsat-uusdc",
       "path": "transfer/channel-75755/lp:40:wsat-uusdc",
       "osmosis_unstable": true,
-      "_comment": "WBTC / USDC LP $WBTC-USDC-LP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "WBTC / USDC LP $WBTC-USDC-LP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/ustakedrop",
       "path": "transfer/channel-75755/factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/ustakedrop",
       "osmosis_unstable": true,
-      "_comment": "StakeDrop $STAKEDROP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "StakeDrop $STAKEDROP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uopdrop",
       "path": "transfer/channel-75755/factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uopdrop",
       "osmosis_unstable": true,
-      "_comment": "OpDrop $OPDROP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "OpDrop $OPDROP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uphotondrop",
       "path": "transfer/channel-75755/factory/pryzm1jnhcsa5ddjsjq2t97v6a82z542rduxvtw6wd9h/uphotondrop",
       "osmosis_unstable": true,
-      "_comment": "PhotonDrop $PHOTONDROP",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "PhotonDrop $PHOTONDROP"
     },
     {
       "chain_name": "pryzm",
       "base_denom": "factory/pryzm1fp7uhm334tssvzlg4mk0hsp0kezvcla0vzk22q/uscar",
       "path": "transfer/channel-75755/factory/pryzm1fp7uhm334tssvzlg4mk0hsp0kezvcla0vzk22q/uscar",
       "osmosis_unstable": true,
-      "_comment": "SCAR $SCAR",
-      "osmosis_unstable_reason": "source_chain_killed",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed"
+      "_comment": "SCAR $SCAR"
     },
     {
       "chain_name": "kopi",
       "base_denom": "uckusd",
       "path": "transfer/channel-97998/uckusd",
       "osmosis_unstable": true,
-      "_comment": "ckUSD $CKUSD",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "ckUSD $CKUSD"
     },
     {
       "chain_name": "kopi",
       "base_denom": "ucusdc",
       "path": "transfer/channel-97998/ucusdc",
       "osmosis_unstable": true,
-      "_comment": "cUSDC $CUSDC",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "cUSDC $CUSDC"
     },
     {
       "chain_name": "kopi",
       "base_denom": "ucusdtinj",
       "path": "transfer/channel-97998/ucusdtinj",
       "osmosis_unstable": true,
-      "_comment": "cUSDT.inj $cUSDT.inj",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "cUSDT.inj $cUSDT.inj"
     },
     {
       "chain_name": "kopi",
       "base_denom": "uasusdtinj",
       "path": "transfer/channel-97998/uasusdtinj",
       "osmosis_unstable": true,
-      "_comment": "asUSDT.inj $asUSDT.inj",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "asUSDT.inj $asUSDT.inj"
     },
     {
       "chain_name": "kopi",
       "base_denom": "uasusdc",
       "path": "transfer/channel-97998/uasusdc",
       "osmosis_unstable": true,
-      "_comment": "asUSDC $ASUSDC",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "asUSDC $ASUSDC"
     },
     {
       "chain_name": "sidechain",
       "base_denom": "uside",
       "path": "transfer/channel-98081/uside",
       "osmosis_unstable": true,
-      "_comment": "Side Chain $SIDE",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Side Chain $SIDE"
     },
     {
       "chain_name": "manifest",
       "base_denom": "upoa",
       "path": "transfer/channel-100418/upoa",
       "osmosis_unstable": true,
-      "_comment": "Manifest $POA",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Manifest $POA"
     },
     {
       "chain_name": "aura",
       "base_denom": "uaura",
       "path": "transfer/channel-11304/uaura",
       "osmosis_unstable": true,
-      "_comment": "Aura Network $AURA",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Aura Network $AURA"
     },
     {
       "chain_name": "fandomchain",
       "base_denom": "ufandomChain",
       "path": "transfer/channel-107392/ufandomChain",
       "osmosis_unstable": true,
-      "_comment": "fandomChain $FANDOMCHAIN",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "fandomChain $FANDOMCHAIN"
     },
     {
       "chain_name": "onex",
       "base_denom": "aonex",
       "path": "transfer/channel-74628/aonex",
       "osmosis_unstable": true,
-      "_comment": "ONEX $ONEX",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "ONEX $ONEX"
     },
     {
       "chain_name": "self",
       "base_denom": "uslf",
       "path": "transfer/channel-78292/uslf",
       "osmosis_unstable": true,
-      "_comment": "Self Chain $SLF",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Self Chain $SLF"
     },
     {
       "chain_name": "shareledger",
       "base_denom": "nshr",
       "path": "transfer/channel-647/nshr",
       "osmosis_unstable": true,
-      "_comment": "Shareledger $SHR",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Shareledger $SHR"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgshqdky4/ampWHALE",
       "path": "transfer/channel-642/factory/migaloo1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgshqdky4/ampWHALE",
       "osmosis_unstable": true,
-      "_comment": "ampWHALE $ampWHALE",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "ampWHALE $ampWHALE"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqdhts4u/boneWhale",
       "path": "transfer/channel-642/factory/migaloo1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqdhts4u/boneWhale",
       "osmosis_unstable": true,
-      "_comment": "BackBone Labs Liquid Staked WHALE $bWHALE",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "BackBone Labs Liquid Staked WHALE $bWHALE"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo18a9m9stu3dyvewwcq9qmp85euxqcvln5mefync/fable",
       "path": "transfer/channel-642/factory/migaloo18a9m9stu3dyvewwcq9qmp85euxqcvln5mefync/fable",
       "osmosis_unstable": true,
-      "_comment": "FABLE $FABLE",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "FABLE $FABLE"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1p3aj9f09d7c4jxhgue0hpdpw370j6gzc59nxxx6l8d0gc9f9rfwsdwetus/lsdSHARK",
       "path": "transfer/channel-642/factory/migaloo1p3aj9f09d7c4jxhgue0hpdpw370j6gzc59nxxx6l8d0gc9f9rfwsdwetus/lsdSHARK",
       "osmosis_unstable": true,
-      "_comment": "lsdSHARK $lsdSHARK",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "lsdSHARK $lsdSHARK"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1r9x8fz4alekzr78k42rpmr9unpa7egsldpqeynmwl2nfvzexue9sn8l5rg/gash",
       "path": "transfer/channel-642/factory/migaloo1r9x8fz4alekzr78k42rpmr9unpa7egsldpqeynmwl2nfvzexue9sn8l5rg/gash",
       "osmosis_unstable": true,
-      "_comment": "GASH $GASH",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "GASH $GASH"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/ugrac",
       "path": "transfer/channel-642/factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/ugrac",
       "osmosis_unstable": true,
-      "_comment": "Gaming RAC Token $GRAC",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Gaming RAC Token $GRAC"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1nsskhvvh0msm7d5ke2kfg24a8d4jecsnxd28s27h0uz5kf9ap60shlqmcl/ampGASH",
       "path": "transfer/channel-642/factory/migaloo1nsskhvvh0msm7d5ke2kfg24a8d4jecsnxd28s27h0uz5kf9ap60shlqmcl/ampGASH",
       "osmosis_unstable": true,
-      "_comment": "ampGASH $ampGASH",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "ampGASH $ampGASH"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1axtz4y7jyvdkkrflknv9dcut94xr5k8m6wete4rdrw4fuptk896su44x2z/uLP",
       "path": "transfer/channel-642/factory/migaloo1axtz4y7jyvdkkrflknv9dcut94xr5k8m6wete4rdrw4fuptk896su44x2z/uLP",
       "osmosis_unstable": true,
-      "_comment": "WHALE-wBTC WW LP $WHALE-wBTC-WW-LP",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "WHALE-wBTC WW LP $WHALE-wBTC-WW-LP"
     },
     {
       "chain_name": "migaloo",
       "base_denom": "factory/migaloo1zsptvkg5aeg4tjksgv7vp4x5s9p5euqrh9jl3sfdv48wtnrhftlszsvmu5/uwhalex",
       "path": "transfer/channel-642/factory/migaloo1zsptvkg5aeg4tjksgv7vp4x5s9p5euqrh9jl3sfdv48wtnrhftlszsvmu5/uwhalex",
       "osmosis_unstable": true,
-      "_comment": "WHALEX $WHALEX",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "WHALEX $WHALEX"
     },
     {
       "chain_name": "bluzelle",
       "base_denom": "uelt",
       "path": "transfer/channel-763/uelt",
       "osmosis_unstable": true,
-      "_comment": "ELT $ELT",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "ELT $ELT"
     },
     {
       "chain_name": "bluzelle",
       "base_denom": "ug4",
       "path": "transfer/channel-763/ug4",
       "osmosis_unstable": true,
-      "_comment": "G4 $G4",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "G4 $G4"
     },
     {
       "chain_name": "manifest",
       "base_denom": "factory/manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj/upwr",
       "path": "transfer/channel-100418/factory/manifest1afk9zr2hn2jsac63h4hm60vl9z3e5u69gndzf7c99cqge3vzwjzsfmy9qj/upwr",
       "osmosis_unstable": true,
-      "_comment": "Manifest Power Token $PWR",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Manifest Power Token $PWR"
     },
     {
       "chain_name": "lumen",
@@ -10586,28 +8804,21 @@
       "base_denom": "factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/extPEPE",
       "path": "transfer/channel-216/factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/extPEPE",
       "osmosis_unstable": true,
-      "_comment": "Pepe $PEPE.orai",
-      "osmosis_unstable_reason": "ibc_client"
+      "_comment": "Pepe $PEPE.orai"
     },
     {
       "chain_name": "oraichain",
       "base_denom": "factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/HMSTR",
       "path": "transfer/channel-216/factory/orai1wuvhex9xqs3r539mvc6mtm7n20fcj3qr2m0y9khx6n5vtlngfzes3k0rq9/HMSTR",
       "osmosis_unstable": true,
-      "_comment": "HMSTR $HMSTR",
-      "osmosis_unstable_reason": "ibc_client"
+      "_comment": "HMSTR $HMSTR"
     },
     {
       "chain_name": "crescent",
       "base_denom": "ubcre",
       "path": "transfer/channel-297/ubcre",
       "osmosis_unstable": true,
-      "_comment": "Bonded Crescent $bCRE",
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Bonded Crescent $bCRE"
     },
     {
       "chain_name": "cosmoshub",


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#3513

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a generated JSON artifact by removing downtime/recovery timestamp fields and dropping many downtime-only entries; no executable code paths change, with risk limited to downstream consumers expecting those fields.
> 
> **Overview**
> Reverts the previous lifecycle migration data in `osmosis-1/generated/state/state.json` by **removing** `lastDowntimeDate`/`lastRecoveryDate` fields from multiple asset entries and **dropping** a large trailing set of denom records that only contained downtime timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ddf0af69a7093f271e09ca00960de90934cc6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->