### PR TITLE
fix(ibc-check): per-asset counterparty triple, clear stale cw20 flags

### DIFF
--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -253,8 +253,13 @@ function getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByNa
   return endpoints;
 }
 
-async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByName, chainlistByName, deadEndpoints) {
+async function getCounterpartyClientStatus(chainName, channelId, port, zoneChainsByName, chainlistByName, deadEndpoints) {
   if (!chainName || !channelId) return 'unknown';
+  // Default to 'transfer' for plain bank-denom IBC. cw20 wrappers on Secret
+  // Network (and similar wasm-bound IBC variants) bind the counterparty
+  // channel to a contract-specific port like `wasm.secret1...`; the lookup
+  // must target that exact port or it will return nothing.
+  const counterpartyPort = port || 'transfer';
 
   const endpoints = getCounterpartyRestEndpoints(chainName, zoneChainsByName, chainlistByName);
   if (endpoints === null) return 'killed';
@@ -265,7 +270,7 @@ async function getCounterpartyClientStatus(chainName, channelId, zoneChainsByNam
 
     try {
       const channelData = await fetchJSONWithTimeout(
-        `${endpoint}/ibc/core/channel/v1/channels/${channelId}/ports/transfer`
+        `${endpoint}/ibc/core/channel/v1/channels/${channelId}/ports/${counterpartyPort}`
       );
       const connectionId = channelData.channel?.connection_hops?.[0];
       if (!connectionId) continue;
@@ -452,7 +457,13 @@ async function main() {
     if (asset.path) zoneByPath.set(asset.path, asset);
   }
 
-  // Group frontend IBC assets by channel.
+  // Group frontend IBC assets by Osmosis-side channel id, but record
+  // the counterparty (chainName, channelId, port) on each asset entry
+  // rather than once per channel. A single Osmosis channel can be shared
+  // by multiple asset variants whose counterparty side uses different
+  // ports (e.g. plain `transfer` for native denoms vs. `wasm.<contract>`
+  // for cw20 wrappers on Secret Network); collapsing them per-channel
+  // drops one variant on the floor.
   const channelMap = new Map();
   for (const asset of frontendData.assets ?? []) {
     const ibcMethod = asset.transferMethods?.find((m) => m.type === 'ibc');
@@ -460,11 +471,7 @@ async function main() {
 
     const channelId = ibcMethod.chain.channelId;
     if (!channelMap.has(channelId)) {
-      channelMap.set(channelId, {
-        assets: [],
-        counterpartyChainName: ibcMethod.counterparty?.chainName,
-        counterpartyChannelId: ibcMethod.counterparty?.channelId,
-      });
+      channelMap.set(channelId, { assets: [] });
     }
     channelMap.get(channelId).assets.push({
       chainName: asset.chainName,
@@ -473,6 +480,9 @@ async function main() {
       symbol: asset.symbol,
       channelId,
       ibcPath: ibcMethod.chain.path,
+      counterpartyChainName: ibcMethod.counterparty?.chainName,
+      counterpartyChannelId: ibcMethod.counterparty?.channelId,
+      counterpartyPort: ibcMethod.counterparty?.port,
     });
   }
 
@@ -522,38 +532,51 @@ async function main() {
     process.exit(3);
   }
 
-  // Phase 2: counterparty checks for channels we might clear
+  // Phase 2: counterparty checks for assets we might clear.
+  // Key by (counterpartyChainName, counterpartyChannelId, counterpartyPort)
+  // since one Osmosis channel can host multiple counterparty triples
+  // (e.g. plain transfer vs. wasm-port cw20 wrappers). The status of a
+  // given triple is shared across every asset that uses it.
+  const cpKey = (chainName, channelId, port) =>
+    `${chainName}|${channelId}|${port || 'transfer'}`;
+
   const cpCheckNeeded = new Map();
   for (const r of ibcResults) {
     if (r.error || r.status !== 'Active') continue;
     const cm = channelMap.get(r.channelId);
-    const hasUnstableAssets = cm.assets.some(
-      (fa) => zoneByPath.get(fa.ibcPath)?.osmosis_unstable === true
-    );
-    if (hasUnstableAssets && cm.counterpartyChainName && cm.counterpartyChannelId) {
-      cpCheckNeeded.set(r.channelId, cm);
+    for (const fa of cm.assets) {
+      if (zoneByPath.get(fa.ibcPath)?.osmosis_unstable !== true) continue;
+      if (!fa.counterpartyChainName || !fa.counterpartyChannelId) continue;
+      const key = cpKey(fa.counterpartyChainName, fa.counterpartyChannelId, fa.counterpartyPort);
+      if (cpCheckNeeded.has(key)) continue;
+      cpCheckNeeded.set(key, {
+        chainName: fa.counterpartyChainName,
+        channelId: fa.counterpartyChannelId,
+        port: fa.counterpartyPort,
+      });
     }
   }
 
   const cpStatuses = new Map();
   if (cpCheckNeeded.size > 0) {
-    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} channel(s)...\n`);
+    console.log(`Checking counterparty IBC client for ${cpCheckNeeded.size} counterparty path(s)...\n`);
     const deadEndpoints = new Set();
     const cpResults = await processInBatches(
       [...cpCheckNeeded.entries()],
       CONCURRENCY,
-      async ([channelId, cm]) => {
+      async ([key, cp]) => {
         const status = await getCounterpartyClientStatus(
-          cm.counterpartyChainName,
-          cm.counterpartyChannelId,
+          cp.chainName,
+          cp.channelId,
+          cp.port,
           zoneChainsByName,
           chainlistByName,
           deadEndpoints
         );
-        return [channelId, status];
+        return [key, status];
       }
     );
-    for (const [channelId, status] of cpResults) cpStatuses.set(channelId, status);
+    for (const [key, status] of cpResults) cpStatuses.set(key, status);
   }
 
   // Phase 3: apply mutations (collected first, written later so dry-run can short-circuit)
@@ -574,10 +597,16 @@ async function main() {
     }
 
     const osmosisDown = r.status !== 'Active';
-    const cpStatus = cpStatuses.get(r.channelId); // undefined if no unstable assets
 
     for (const fa of cm.assets) {
-      // Per-asset evaluation, since source chain status is per-chain.
+      // Per-asset evaluation, since source chain status is per-chain
+      // and counterparty status is per-triple (chain, channel, port).
+      // Assets sharing the same Osmosis channel can resolve to different
+      // counterparty paths (e.g. cw20 wrappers vs. plain bank denoms).
+      const cpStatus = (fa.counterpartyChainName && fa.counterpartyChannelId)
+        ? cpStatuses.get(cpKey(fa.counterpartyChainName, fa.counterpartyChannelId, fa.counterpartyPort))
+        : undefined; // undefined when no counterparty check was needed for this asset
+
       const sourceStatus = getSourceChainStatus(fa.chainName);
       const chainKilled = sourceStatus === 'killed';
       const chainLive = sourceStatus === 'live';

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1549,9 +1549,7 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=alter"
         }
       ],
-      "_comment": "Alter $ALTER",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Alter $ALTER"
     },
     {
       "chain_name": "secretnetwork",
@@ -1565,9 +1563,7 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=butt"
         }
       ],
-      "_comment": "Button $BUTT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Button $BUTT"
     },
     {
       "chain_name": "secretnetwork",
@@ -1577,9 +1573,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Shade (old) $SHD.old",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Shade (old) $SHD.old"
     },
     {
       "chain_name": "secretnetwork",
@@ -1596,9 +1590,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "SIENNA $SIENNA",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "SIENNA $SIENNA"
     },
     {
       "chain_name": "secretnetwork",
@@ -1615,9 +1607,7 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "SCRT Staking Derivatives $stkd-SCRT",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "SCRT Staking Derivatives $stkd-SCRT"
     },
     {
       "chain_name": "beezee",
@@ -1702,9 +1692,7 @@
           "deposit_url": "https://dash.scrt.network/ibc?chain=osmosis&mode=deposit&token=amber"
         }
       ],
-      "_comment": "Amber $AMBER",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Amber $AMBER"
     },
     {
       "chain_name": "onomy",
@@ -2176,9 +2164,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Silk $SILK",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Silk $SILK"
     },
     {
       "chain_name": "juno",
@@ -2235,9 +2221,7 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Shade $SHD",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Shade $SHD"
     },
     {
       "chain_name": "bluzelle",
@@ -3270,9 +3254,7 @@
       "categories": [
         "meme"
       ],
-      "_comment": "Puppy $PUPPY",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual"
+      "_comment": "Puppy $PUPPY"
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#3517

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the IBC bridge health check logic to key counterparty lookups per asset (including port), which can affect when assets are automatically marked unstable or cleared. Also mutates several existing `zone_assets` entries, so reviewers should verify the resulting flag state is correct for those assets.
> 
> **Overview**
> Fixes `check_ibc_clients.mjs` counterparty client checks to be **per asset** instead of per Osmosis channel by tracking a `(chain, channel, port)` triple and querying the exact counterparty `port` (defaulting to `transfer`) so wasm-bound IBC paths like Secret cw20 wrappers aren’t mis-evaluated or dropped.
> 
> Updates `osmosis.zone_assets.json` by removing previously manual `osmosis_unstable`/reason flags from several assets (notably Secret cw20 entries), leaving them to be managed by the automated bridge-state checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ac90dacf5da0546b829491ba1bdb0e86ce8b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->