### PR TITLE
fix(market-health): remove mutation cap from market-health check

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -67,15 +67,7 @@ jobs:
 
       - name: Check Market Health (independent unstable track)
         working-directory: ./.github/workflows/utility
-        run: |
-          set +e
-          node check_market_health.mjs osmosis-1 2>&1 | tee ../../../market-health.log
-          rc=${PIPESTATUS[0]}
-          if [ "$rc" -eq 2 ]; then
-            echo "MARKET_HEALTH_CAP_HIT=true" >> $GITHUB_ENV
-          elif [ "$rc" -ne 0 ]; then
-            exit $rc
-          fi
+        run: node check_market_health.mjs osmosis-1 2>&1 | tee ../../../market-health.log
 
       - name: Check Extended Halts (60d + planned shutdown)
         working-directory: ./.github/workflows/utility
@@ -316,7 +308,7 @@ jobs:
           # with code 2 (cap exceeded). The script's intended mutations were
           # not applied; an operator needs to inspect and decide whether to
           # re-run locally with --force.
-          if [ "$IBC_CAP_HIT" = "true" ] || [ "$MARKET_HEALTH_CAP_HIT" = "true" ] || [ "$EXTENDED_HALTS_CAP_HIT" = "true" ]; then
+          if [ "$IBC_CAP_HIT" = "true" ] || [ "$EXTENDED_HALTS_CAP_HIT" = "true" ]; then
             echo "## ⚠️ Mutation cap hit" >> workflow-summary.md
             echo "" >> workflow-summary.md
             echo "One or more lifecycle scripts exited with code 2 because their" >> workflow-summary.md
@@ -327,9 +319,6 @@ jobs:
             echo "" >> workflow-summary.md
             if [ "$IBC_CAP_HIT" = "true" ]; then
               echo "- 🛑 \`check_ibc_clients\` cap exceeded" >> workflow-summary.md
-            fi
-            if [ "$MARKET_HEALTH_CAP_HIT" = "true" ]; then
-              echo "- 🛑 \`check_market_health\` cap exceeded" >> workflow-summary.md
             fi
             if [ "$EXTENDED_HALTS_CAP_HIT" = "true" ]; then
               echo "- 🛑 \`check_extended_halts\` cap exceeded" >> workflow-summary.md

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -11,7 +11,7 @@
 //   Reason-vocabulary contract: this script owns reasons {market}.
 //
 // Usage:
-//   node check_market_health.mjs [<zone_name>] [--dry-run] [--force]
+//   node check_market_health.mjs [<zone_name>] [--dry-run]
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -36,11 +36,8 @@ const GRACE_MS = GRACE_DAYS * 24 * 60 * 60 * 1000;
 // Sentinel listing date used for assets without one (legacy assets).
 const LEGACY_LISTING_DATE = '2022-01-01T00:00:00.000Z';
 
-const MAX_CHAINS_PER_RUN = 10;
-
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
-const force = args.includes('--force');
 const positional = args.filter((a) => !a.startsWith('--'));
 const zoneBasePath = positional[0] || 'osmosis-1';
 
@@ -202,7 +199,6 @@ async function main() {
     // is owned by check_ibc_clients or manual.
   }
 
-  // ── Mutation cap (per source chain) ─────────────────────────────────────────
   // streak_increment / streak_reset / recovery_reset / market_missing are
   // informational; they don't write halt or unstable flags.
   const INFO_KINDS = new Set(['streak_increment', 'streak_reset', 'recovery_reset', 'market_missing']);
@@ -211,13 +207,6 @@ async function main() {
       .filter((m) => m.chain && !INFO_KINDS.has(m.kind))
       .map((m) => m.chain)
   );
-  if (affectedChains.size > MAX_CHAINS_PER_RUN && !force && !dryRun) {
-    console.error(
-      `\n⛔ Mutation cap exceeded: would touch ${affectedChains.size} chains ` +
-      `(threshold ${MAX_CHAINS_PER_RUN}). Re-run with --force or --dry-run.`
-    );
-    process.exit(2);
-  }
 
   if (dryRun) {
     fs.mkdirSync(reportsDir, { recursive: true });

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ A second, independent track exists for market-driven unstable. When a verified, 
 #### Safety mechanisms
 
 - **`--dry-run` flag.** Every writer script accepts `--dry-run`, which emits a markdown report of intended mutations without writing any file. Always use this before enabling a fresh script in CI or after a chain-registry submodule bump that might flip many chains at once.
-- **Mutation cap.** No script will write changes touching more than **10 distinct source chains** in a single run. If exceeded, the script exits with code 2 and demands a `--force` flag. This catches mass-flips from upstream regressions.
+- **Mutation cap.** `check_ibc_clients.mjs` and `check_extended_halts.mjs` will not write changes touching more than **10 distinct source chains** in a single run. If exceeded, the script exits with code 2 and demands a `--force` flag. This catches mass-flips from upstream regressions. `check_market_health.mjs` is exempt: market-wide liquidity/volume swings legitimately move many chains at once, so it always applies its full diff.
 - **Reason-vocabulary contract.** Each reason enum value has exactly one owner script (or `manual` = the curator). No two scripts ever race on the same flag.
 - **Curator lock.** Any non-empty `tooltip_message` on a halted or unstable asset is treated as curator-owned and never overwritten by automation. To release the lock, clear the tooltip.
 


### PR DESCRIPTION
## Summary

- Removes the 10-distinct-chain mutation cap from `check_market_health.mjs`. Market-wide liquidity/volume swings legitimately move many chains in a single run, and blocking that diff (exit code 2) was wrong for this script.
- The 7-run consecutive-failure streak gate (`REQUIRED_CONSECUTIVE_RUNS`) already protects against transient Numia glitches: a single bad fetch only increments a streak, and any passing run resets it. A flip only fires after 7 consecutive failing runs, which is a genuine market event, not noise.
- `check_ibc_clients.mjs` and `check_extended_halts.mjs` keep their cap unchanged.

## Changes

- `check_market_health.mjs`: drop `MAX_CHAINS_PER_RUN`, the `process.exit(2)` cap block, and the now-unused `--force` flag.
- `generate_all_files.yml`: simplify the "Check Market Health" step (no more `set +e` / code-2 soft-exception branch) and drop `MARKET_HEALTH_CAP_HIT` from the mutation-cap summary block.
- `README.md`: qualify the "Mutation cap" safety-mechanism bullet to name only the two scripts that retain it, and note market health is exempt.

## Test plan

- [x] `node --check check_market_health.mjs` passes
- [ ] CI regular run applies market-health diffs without aborting on >10 chains

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to market-health automation and CI wiring; IBC and extended-halts caps are unchanged, and the 7-run streak gate still limits transient Numia noise.
> 
> **Overview**
> Removes the **10 distinct source-chain mutation cap** from `check_market_health.mjs` so daily market-health updates are no longer blocked when many assets move at once. The script no longer exits with code **2** or supports **`--force`** for cap overrides; **`--dry-run`** is unchanged and still reports `distinct chains touched` for visibility.
> 
> **`generate_all_files.yml`** runs market health as a straight `node` step (no exit-code-2 soft handling or `MARKET_HEALTH_CAP_HIT`), and the workflow summary’s “mutation cap hit” section only covers **`check_ibc_clients`** and **`check_extended_halts`**.
> 
> **`README.md`** documents that the cap still applies to those two scripts and that market health is exempt because broad liquidity/volume moves are expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41fdcaed534a46ec7fabc01ffa42ffa83fba9aac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->