### PR TITLE
Mark Gravity Bridge assets unstable, halt deposits

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -332,7 +332,10 @@
       ],
       "_comment": "pSTAKE Finance $PSTAKE",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "akash",
@@ -823,7 +826,12 @@
           "withdraw_url": "https://bridge.blockscape.network/?from=osmosis&to=gravitybridge"
         }
       ],
-      "_comment": "Wrapped Bitcoin (Ethereum via Gravity Bridge) $WBTC.eth.grv"
+      "_comment": "Wrapped Bitcoin (Ethereum via Gravity Bridge) $WBTC.eth.grv",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -840,7 +848,10 @@
       ],
       "_comment": "Ethereum (Gravity Bridge) $ETH.grv",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -858,7 +869,12 @@
       "categories": [
         "stablecoin"
       ],
-      "_comment": "USDC (Ethereum via Gravity Bridge) $USDC.eth.grv"
+      "_comment": "USDC (Ethereum via Gravity Bridge) $USDC.eth.grv",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -876,7 +892,12 @@
       "categories": [
         "stablecoin"
       ],
-      "_comment": "Dai Stablecoin (Gravity Bridge) $DAI.grv"
+      "_comment": "Dai Stablecoin (Gravity Bridge) $DAI.grv",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -896,7 +917,10 @@
       ],
       "_comment": "Tether USD (Ethereum via Gravity Bridge) $USDT.eth.grv",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "juno",
@@ -4297,7 +4321,12 @@
       "categories": [
         "rwa"
       ],
-      "_comment": "Paxos Gold (Gravity Bridge) $PAXG.grv"
+      "_comment": "Paxos Gold (Gravity Bridge) $PAXG.grv",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
     },
     {
       "chain_name": "migaloo",


### PR DESCRIPTION
Update osmosis.zone_assets.json for Gravity Bridge-related tokens to reflect a compromised bridge. Multiple asset entries (e.g., pSTAKE, WBTC.eth.grv, ETH.grv, USDC.grv, DAI.grv, USDT.eth.grv, PAXG.grv, etc.) now include osmosis_unstable: true, osmosis_unstable_reason: "manual", osmosis_halt_deposits: true, osmosis_deposit_halt_reason: "bridge_down", and a tooltip_message indicating deposits are halted while the situation is assessed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only but directly controls whether users can deposit bridge-exposed assets; incorrect scope or missing assets could leave unsafe deposits open.
> 
> **Overview**
> **Gravity Bridge–routed assets** in `osmosis.zone_assets.json` are updated for an assumed bridge compromise: deposits are halted, assets are marked unstable with reason `manual` (replacing `market` where it applied), and a shared **tooltip** explains the situation.
> 
> Affected entries include **pSTAKE**, **WBTC/ETH/USDC/DAI/USDT** (and related) **`.grv`** tokens, and **PAXG**; several previously had no halt flags and now gain `osmosis_halt_deposits` with `osmosis_deposit_halt_reason: bridge_down`. This PR does **not** add withdrawal halts—only deposit halts and UI messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc49bfc041e3b3ef1ebf54dd42ad1455b7da5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->