### PR TITLE
fix(passage): override RPC/REST to polkachu (ecostake endpoints dead)

### DIFF
--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -829,12 +829,16 @@
     },
     {
       "chain_name": "passage",
-      "rpc": "https://rpc-passage.ecostake.com",
-      "rest": "https://rest-passage.ecostake.com",
+      "rpc": "https://passage-rpc.polkachu.com",
+      "rest": "https://passage-api.polkachu.com",
       "explorer_tx_url": "https://www.mintscan.io/passage/transactions/${txHash}",
       "keplr_features": [
         "ibc-go"
-      ]
+      ],
+      "override_properties": {
+        "force_rest": true,
+        "force_rpc": true
+      }
     },
     {
       "chain_name": "gateway",


### PR DESCRIPTION
## Summary

Passage (`passage-2`) bridge quotes on the Osmosis frontend (IBC and Skip) consistently time out. Root cause is the zone endpoint override: it points `rpc`/`rest` at **ecostake**, whose Passage endpoints are currently dead.

Because the zone `rpc`/`rest` values are placed **first** in the generated `chainlist.json`, this forces the worst endpoint into the primary position. The frontend's hedged query client tries the first endpoint immediately and staggers the rest, so gas estimation (sequential account → simulate → balances REST calls) only reaches a working endpoint several seconds in, exceeding the server-side 15s quote timeout.

This PR switches the override to **polkachu** and locks it with `force_rpc`/`force_rest`, matching the convention already used for cosmoshub, stride, cheqd, and panacea.

```diff
       "chain_name": "passage",
-      "rpc": "https://rpc-passage.ecostake.com",
-      "rest": "https://rest-passage.ecostake.com",
+      "rpc": "https://passage-rpc.polkachu.com",
+      "rest": "https://passage-api.polkachu.com",
       "explorer_tx_url": "https://www.mintscan.io/passage/transactions/${txHash}",
       "keplr_features": [
         "ibc-go"
-      ]
+      ],
+      "override_properties": {
+        "force_rest": true,
+        "force_rpc": true
+      }
```

## Endpoint health check (probed against a live `pasg1...` address)

Old override (`ecostake`):
- `https://rest-passage.ecostake.com` → HTTP `525`
- `https://rpc-passage.ecostake.com` → HTTP `525`

New override (`polkachu`):
- `https://passage-rpc.polkachu.com/status` → `200`, network `passage-2`, `catching_up=false`, height `19398371`
- `https://passage-api.polkachu.com/cosmos/auth/v1beta1/accounts/{addr}` → `200`
- `https://passage-api.polkachu.com/cosmos/bank/v1beta1/balances/{addr}` → `200`
- `https://passage-api.polkachu.com/cosmos/tx/v1beta1/simulate` → reachable (`400` on empty tx, as expected)
- `/cosmos/base/tendermint/v1beta1/syncing` → `{"syncing": false}`

## Test plan

- [ ] CI regenerates `osmosis-1/generated/frontend/chainlist.json` with polkachu first in Passage `apis.rpc`/`apis.rest`
- [ ] Verify a Passage → Osmosis IBC deposit quote returns within the timeout on the frontend
