### PR TITLE
fix(chainlist): stale demotion, zone-pin precedence, report QOL

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -496,24 +496,44 @@ jobs:
           if [ "$MANUAL_HALT_COUNT" -eq 0 ]; then
             echo "_None._" >> workflow-summary.md
           else
-            echo "| Chain | Base denom | Direction | Reason | Tooltip |" >> workflow-summary.md
-            echo "|-------|-----------|-----------|--------|---------|" >> workflow-summary.md
-            echo "$MANUAL_HALTS" | jq -r '
-              .[]
+            # Resolve Symbol and Route from the generated frontend assetlist,
+            # joined on chainName|sourceDenom. Route is the asset's listed origin
+            # chain, plus "via <hop>" when the asset reaches Osmosis through an
+            # intermediary cosmos chain (the first counterparty cosmos chain that
+            # is not the origin itself). So a native Gravity asset reads
+            # "gravitybridge", while a Persistence asset bridged in via Gravity
+            # reads "persistence via gravitybridge".
+            echo "| Symbol | Route | Base denom | Direction | Reason | Tooltip |" >> workflow-summary.md
+            echo "|--------|-------|-----------|-----------|--------|---------|" >> workflow-summary.md
+            echo "$MANUAL_HALTS" | jq -r --slurpfile fe osmosis-1/generated/frontend/assetlist.json '
+              ($fe[0].assets
+                | map({ key: (.chainName + "|" + .sourceDenom), value: . })
+                | from_entries) as $byOrigin
+              | .[]
               | . as $a
+              | ($byOrigin[$a.chain_name + "|" + $a.base_denom]) as $f
+              | ($f.symbol // $a._comment // $a.base_denom) as $sym
+              | (
+                  [ ($f.counterparty // [])[]
+                    | select(.chainType == "cosmos" and .chainName != $a.chain_name)
+                    | .chainName ] as $hops
+                  | if ($hops | length) > 0
+                    then $a.chain_name + " via " + $hops[0]
+                    else $a.chain_name end
+                ) as $route
               | [
                   (if .osmosis_halt_deposits == true then
-                     "| \(.chain_name) | \(.base_denom) | deposit | \(.osmosis_deposit_halt_reason // "") | \(.tooltip_message // "") |"
+                     "| \($sym) | \($route) | \(.base_denom) | deposit | \(.osmosis_deposit_halt_reason // "") | \(.tooltip_message // "") |"
                    else empty end),
                   (if .osmosis_halt_withdrawals == true then
-                     "| \(.chain_name) | \(.base_denom) | withdrawal | \(.osmosis_withdrawal_halt_reason // "") | \(.tooltip_message // "") |"
+                     "| \($sym) | \($route) | \(.base_denom) | withdrawal | \(.osmosis_withdrawal_halt_reason // "") | \(.tooltip_message // "") |"
                    else empty end)
                 ]
               # Fallback: an asset can be manually flagged unstable without
               # either direction halted. Emit one row so the asset is still
               # listed and the table never shows bare headers.
               | (if length == 0 then
-                   ["| \($a.chain_name) | \($a.base_denom) | none | \($a.osmosis_unstable_reason // "") | \($a.tooltip_message // "") |"]
+                   ["| \($sym) | \($route) | \($a.base_denom) | none | \($a.osmosis_unstable_reason // "") | \($a.tooltip_message // "") |"]
                  else . end)
               | .[]
             ' >> workflow-summary.md

--- a/.github/workflows/utility/endpoint_ordering.mjs
+++ b/.github/workflows/utility/endpoint_ordering.mjs
@@ -1,17 +1,32 @@
 /*
  * Pure endpoint-ordering helpers used by chainlist generation.
  *
- * These are kept dependency-free (no chain-registry, no filesystem) so they can
- * be unit-tested directly without triggering generation side effects. See
- * endpoint_ordering.test.mjs.
+ * These are kept dependency-free (no chain-registry, no filesystem) so the
+ * ordering logic is isolated from generation side effects and easy to reason
+ * about in one place.
  *
- * Background (MTN-101): the validator records, per chain, which endpoints passed
+ * Background: the validator records, per chain, which endpoints passed
  * connectivity and which failed and why. The generator uses that record to
  * (1) sink recorded-dead endpoints to the bottom of the published list and
  * (2) promote the validated working endpoint to first position. Both operations
  * key on the endpoint ADDRESS rather than a Chain Registry index, so they are
  * immune to the order mismatch between the validator's tested order and the
  * generator's published order.
+ *
+ * Demotion treats both connectivity failures and recorded-stale endpoints as
+ * dead (see getDeadEndpointAddresses). Two boundaries remain, driven by what the
+ * validator records:
+ *  - REST STALENESS IS NOT DETECTED. The validator only flags staleness on the
+ *    RPC /status result (latest_block_time too old); REST has no tip-freshness
+ *    check, so a reachable-but-stale REST endpoint is not marked stale and so
+ *    not demoted. Closing this needs a validator-side REST freshness probe.
+ *  - ONLY ENDPOINTS UP TO THE WINNER ARE RECORDED. The validator stops testing
+ *    at the first endpoint that passes, so allTestedEndpoints lists only the
+ *    endpoints tried before (and including) the winner. Endpoints that sort
+ *    after the winner are never recorded and therefore never demoted. This is
+ *    sufficient for the common case (dead zone pin tested first, healthy
+ *    backup wins) and is deliberate: probing every endpoint would multiply the
+ *    validator's runtime and the CI latency of generation.
  */
 
 // Error types the validator records for an endpoint that failed connectivity.
@@ -22,10 +37,15 @@ export const DEAD_ENDPOINT_ERROR_TYPES = new Set(['NETWORK_ERROR', 'TIMEOUT', 'H
  * Build the set of endpoint addresses (of a given type) that the validator
  * recorded as failing connectivity in this chain's last validation run.
  *
- * An endpoint is "dead" if its connectivity test did not pass AND at least one
- * of its test results carries a connectivity error type. We deliberately key on
- * the recorded error type rather than connectivityPassed alone, so that a
- * CORS-only failure (connectivity OK, CORS not enabled) is NOT treated as dead.
+ * An endpoint is "dead" if its connectivity test did not pass AND either:
+ *   - at least one test result carries a connectivity error type, OR
+ *   - at least one test result is flagged stale (reachable but chain tip too old;
+ *     the validator marks RPC /status results stale when latest_block_time is
+ *     more than an hour behind, and already rejects stale endpoints during
+ *     selection via `success && !stale`).
+ * We deliberately key on the recorded error type / stale flag rather than
+ * connectivityPassed alone, so that a CORS-only failure (connectivity OK, CORS
+ * not enabled) is NOT treated as dead.
  *
  * @param {Object} validationRecord - per-chain record from state.json
  * @param {string} nodeType - 'rpc' or 'rest'
@@ -37,10 +57,12 @@ export function getDeadEndpointAddresses(validationRecord, nodeType) {
   for (const ep of tested) {
     if (ep.type !== nodeType) continue;
     if (ep.connectivityPassed) continue;
-    const hasConnectivityError = (ep.testResults || []).some(
+    const results = ep.testResults || [];
+    const hasConnectivityError = results.some(
       r => r.errorType && DEAD_ENDPOINT_ERROR_TYPES.has(r.errorType)
     );
-    if (hasConnectivityError && ep.address) {
+    const isStale = results.some(r => r.stale === true);
+    if ((hasConnectivityError || isStale) && ep.address) {
       dead.add(ep.address);
     }
   }
@@ -77,8 +99,8 @@ export function deprioritizeDeadEndpoints(addresses, deadAddresses) {
 /**
  * Apply validation-driven reordering to a single node type's endpoint list:
  * first deprioritize recorded-dead endpoints, then promote the validated
- * working address to first position. Mirrors the logic inlined in
- * generate_chainlist.mjs and is the unit under regression test.
+ * working address to first position. This is the single entry point used by
+ * generate_chainlist.mjs.
  *
  * @param {string[]} addresses - ordered endpoint addresses (zone pin first, then sorted registry)
  * @param {Object} validationRecord - per-chain record from state.json

--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -513,8 +513,8 @@ async function getSuggestionChainProperties(minimalChain, zoneChain = {}) {
   //   2. Promote: lift the validated working endpoint to first position.
   // Both steps key on the endpoint ADDRESS, not on a Chain Registry index, so
   // they are immune to the order mismatch between the validator's tested order
-  // and the generator's published order (see MTN-101). Promotion runs after
-  // deprioritization so the validated winner ends up at slot 0.
+  // and the generator's published order. Promotion runs after deprioritization
+  // so the validated winner ends up at slot 0.
   const validationState = getValidationState('osmosis-1');
   const validationRecord = getValidationRecord(validationState, chain_name);
 

--- a/.github/workflows/utility/validateEndpoints.mjs
+++ b/.github/workflows/utility/validateEndpoints.mjs
@@ -1343,6 +1343,79 @@ function generateValidationReport(chainName) {
     zone.zoneChainlistFileName
   )?.chains || [];
 
+  // Get zone assets so we can report whether a connectivity-failed chain's
+  // assets are already covered (flagged unstable / deposits halted) by another
+  // mechanism (manual, ibc_client, market, etc.). A chain that fails all
+  // endpoints but is NOT yet covered is the actionable case: deposits may still
+  // be open against an unreachable chain. This is surfaced for human follow-up;
+  // it does not auto-mutate zone_assets.
+  const zoneAssets = zone.readFromFile(
+    chainName,
+    zone.noDir,
+    zone.zoneAssetsFileName
+  )?.assets || [];
+
+  // Summarize halt coverage per chain: how many of its assets are unstable and
+  // how many have deposits halted. An asset is attributed to a chain if either
+  // its listed chain_name OR its canonical.chain_name matches, so a token routed
+  // via the failed chain but listed under an intermediary (e.g. milkINIT listed
+  // under initia with canonical.chain_name "moo") still counts toward that
+  // chain's coverage. Counted once per chain even if both keys point at it.
+  const haltCoverageByChain = {};
+  const bumpCoverage = (c, asset) => {
+    if (!haltCoverageByChain[c]) {
+      haltCoverageByChain[c] = {
+        total: 0, unstable: 0, depositsHalted: 0, disabled: 0, haltedBothDirections: 0
+      };
+    }
+    haltCoverageByChain[c].total += 1;
+    if (asset.osmosis_unstable) { haltCoverageByChain[c].unstable += 1; }
+    if (asset.osmosis_halt_deposits) { haltCoverageByChain[c].depositsHalted += 1; }
+    // A disabled asset is hidden from the frontend entirely, so it is not a live
+    // deposit risk even without an unstable/halt flag. Counts as covered.
+    if (asset.osmosis_disabled) { haltCoverageByChain[c].disabled += 1; }
+    if (asset.osmosis_halt_deposits && asset.osmosis_halt_withdrawals) {
+      haltCoverageByChain[c].haltedBothDirections += 1;
+    }
+  };
+  zoneAssets.forEach(asset => {
+    const chains = new Set();
+    if (asset.chain_name) { chains.add(asset.chain_name); }
+    if (asset.canonical?.chain_name) { chains.add(asset.canonical.chain_name); }
+    chains.forEach(c => bumpCoverage(c, asset));
+  });
+
+  // Render a short coverage label for a chain's assets. An asset counts as
+  // "covered" only if it is deposit-halted or flagged unstable. osmosis_disabled
+  // is NOT coverage: per the schema it skips the native flow and routes the user
+  // to an external provider (a UX router, not a kill switch), and disabled assets
+  // are still emitted to the frontend with transfer methods, so deposits remain
+  // possible. We surface a disabled sub-count for context but it never marks a
+  // chain covered. The actionable case is a connectivity-failing chain with one
+  // or more assets that are neither deposit-halted nor unstable.
+  const getHaltCoverageLabel = (chain_name) => {
+    const cov = haltCoverageByChain[chain_name];
+    if (!cov || cov.total === 0) { return '— no listed assets'; }
+    const disabledNote = cov.disabled > 0 ? `, ${cov.disabled}/${cov.total} disabled` : '';
+    if (cov.depositsHalted >= cov.total) { return `🛑 deposits halted (${cov.depositsHalted}/${cov.total})`; }
+    if (cov.unstable >= cov.total) { return `⚠️ unstable (${cov.unstable}/${cov.total})`; }
+    if (cov.depositsHalted > 0 || cov.unstable > 0) {
+      return `🟠 partial (${cov.unstable}/${cov.total} unstable, ${cov.depositsHalted}/${cov.total} dep-halted${disabledNote})`;
+    }
+    return `❗ not covered (0/${cov.total}${disabledNote})`;
+  };
+
+  // A chain whose every listed asset has BOTH deposits and withdrawals halted is
+  // already at end of life from the user's perspective: there is nothing to do
+  // with it in either direction, so endpoint health is moot. Such chains are
+  // dropped from the connectivity-failures table to keep it focused on chains
+  // where reachability still matters. (This only affects the report; it does
+  // not delete anything from zone_assets.)
+  const isFullyHaltedBothDirections = (chain_name) => {
+    const cov = haltCoverageByChain[chain_name];
+    return !!cov && cov.total > 0 && cov.haltedBothDirections >= cov.total;
+  };
+
   const forcedEndpointChains = {};
   zoneChains.forEach(chain => {
     if (chain.override_properties?.force_rpc || chain.override_properties?.force_rest) {
@@ -1367,6 +1440,10 @@ function generateValidationReport(chainName) {
 
     // Skip killed chains
     if (killedChainNames.includes(chain.chain_name)) return false;
+
+    // Skip chains already fully halted both directions (end of life): endpoint
+    // reachability is irrelevant when nothing can be deposited or withdrawn.
+    if (isFullyHaltedBothDirections(chain.chain_name)) return false;
 
     // Only include chains where at least one endpoint type completely failed
     const rpcTests = chain.validationResults?.filter(r => r.test.includes('RPC')) || [];
@@ -1488,9 +1565,12 @@ function generateValidationReport(chainName) {
     report += `### ✅ All Chains Validated Successfully\n\n`;
   } else if (failedChains.length > 0) {
     report += `### ❌ Connectivity Failures\n\n`;
-    report += `The following chains have endpoints that failed connectivity tests (not just CORS):\n\n`;
-    report += `| Chain Name | Last Validation | Days Ago | RPC Status | REST Status |\n`;
-    report += `|------------|----------------|----------|------------|-------------|\n`;
+    report += `The following chains have endpoints that failed connectivity tests (not just CORS). `;
+    report += `The Halt Coverage column shows whether the chain's listed assets are already flagged `;
+    report += `unstable / deposit-halted by another mechanism; a chain that is "not covered" but failing `;
+    report += `connectivity is a candidate for halting deposits.\n\n`;
+    report += `| Chain Name | Last Validation | Days Ago | RPC Status | REST Status | Halt Coverage |\n`;
+    report += `|------------|----------------|----------|------------|-------------|---------------|\n`;
 
     failedChains.forEach(chain => {
       const validationDate = new Date(chain.validationDate);
@@ -1504,8 +1584,9 @@ function generateValidationReport(chainName) {
 
       const rpcStatus = rpcAllFailed ? '❌ All Failed' : '⚠️ Partial';
       const restStatus = restAllFailed ? '❌ All Failed' : '⚠️ Partial';
+      const haltCoverage = getHaltCoverageLabel(chain.chain_name);
 
-      report += `| ${chain.chain_name} | ${validationDate.toISOString().split('T')[0]} | ${daysSince} | ${rpcStatus} | ${restStatus} |\n`;
+      report += `| ${chain.chain_name} | ${validationDate.toISOString().split('T')[0]} | ${daysSince} | ${rpcStatus} | ${restStatus} | ${haltCoverage} |\n`;
     });
     report += `\n`;
   }

--- a/.github/workflows/utility/validateEndpoints.mjs
+++ b/.github/workflows/utility/validateEndpoints.mjs
@@ -759,14 +759,34 @@ async function validateCounterpartyChain(counterpartyChain, chainName = "osmosis
   const rpcTestTypes = [RPC_CORS, RPC_WSS, RPC_ENDPOINTS];
   const restTestTypes = [REST_CORS, REST_ENDPOINTS];
 
+  // Move the zone-pinned endpoint to the front of an already provider-sorted
+  // list, so the validator tests it first. This mirrors the generator, which
+  // places the zone pin in slot 0 BEFORE applying provider sorting to the rest.
+  // Without this, sortEndpointsByProvider re-sorts the pin like any other
+  // endpoint and floats a team endpoint above it, so the validator would select
+  // (and the generator would then promote) the team endpoint over the pin,
+  // contradicting pin-takes-precedence. Pin order: pin > team > preferred > rest.
+  // Mutates `sorted` in place (the only caller passes a fresh sort result).
+  const pinZoneEndpointFirst = (sorted, pinnedAddress) => {
+    if (!pinnedAddress) return sorted;
+    const idx = sorted.findIndex(ep => ep.address === pinnedAddress);
+    if (idx <= 0) return sorted; // not present, or already first
+    const [pinned] = sorted.splice(idx, 1);
+    sorted.unshift(pinned);
+    return sorted;
+  };
+
   // Get all RPC endpoints with original indices
   const rpcEndpoints = (counterpartyChain?.apis?.rpc || []).map((ep, idx) => ({
     ...ep,
     originalIndex: idx
   }));
 
-  // Sort by provider preference (Team > Keplr/Polkachu > Others)
-  const sortedRpcEndpoints = sortEndpointsByProvider(rpcEndpoints, counterpartyChain.chain_name);
+  // Sort by provider preference (Team > Keplr/Polkachu > Others), then pin first.
+  const sortedRpcEndpoints = pinZoneEndpointFirst(
+    sortEndpointsByProvider(rpcEndpoints, counterpartyChain.chain_name),
+    zoneChain?.rpc
+  );
 
   // Get endpoint counts
   const rpcCount = sortedRpcEndpoints.length;
@@ -846,8 +866,11 @@ async function validateCounterpartyChain(counterpartyChain, chainName = "osmosis
     originalIndex: idx
   }));
 
-  // Sort by provider preference (Team > Keplr/Polkachu > Others)
-  const sortedRestEndpoints = sortEndpointsByProvider(restEndpoints, counterpartyChain.chain_name);
+  // Sort by provider preference (Team > Keplr/Polkachu > Others), then pin first.
+  const sortedRestEndpoints = pinZoneEndpointFirst(
+    sortEndpointsByProvider(restEndpoints, counterpartyChain.chain_name),
+    zoneChain?.rest
+  );
 
   // Find working REST endpoint (test in preferred order)
   let restResults = null;


### PR DESCRIPTION
Follow-ups to the merged endpoint auto-demotion work. Three commits.

## 1. Demote reachable-but-stale endpoints

`getDeadEndpointAddresses` now treats a recorded-stale endpoint (chain tip more than an hour old) as dead alongside the connectivity error types, so a stale node no longer leads the published list. The validator already rejected stale endpoints during selection but the signal was not carried into demotion. Also documents the two remaining scope boundaries (REST staleness is not detected validator-side; only endpoints up to the winner are recorded, by design to bound validator runtime).

## 2. Validator must respect zone-pin precedence

The generator places the zone pin at slot 0 before provider-sorting the registry tail (pin > team > preferred > rest), but the validator was provider-sorting the whole list including the pin, floating a team endpoint above it. The validator then selected team over the pin, and (with the old index gate) this caused Osmosis to oscillate every run between the keplr zone pin and the `rpc.osmosis.zone` team endpoint. `pinZoneEndpointFirst` now moves the zone pin to the front of the sorted list before testing, so the validator tests the pin first and selects it when healthy; team/preferred win only when the pin is dead. Slot 0 is now stable regardless of the chainlist's starting order.

## 3. Report QOL: manual halts and connectivity failures

**Manual halts table:** add a Symbol column and replace Chain with Route. Route is the listed origin chain, plus "via <hop>" when the asset reaches Osmosis through an intermediary cosmos chain. A native Gravity asset reads "gravitybridge"; a Persistence asset bridged in via Gravity reads "persistence via gravitybridge". Joined from the generated frontend assetlist on chainName|sourceDenom.

**Connectivity Failures table:** add a Halt Coverage column showing whether each failed chain's assets are already covered (deposit-halted or unstable). Disabled is shown as an informational sub-count but does NOT count as coverage, because disabled assets still route to an external provider and retain transfer methods, so deposits remain possible. Assets are attributed to a chain by both chain_name and canonical.chain_name, so a token routed via a failed chain but listed under an intermediary (e.g. milkINIT under initia, canonical moo) is counted. A connectivity-failing chain that is "not covered" is the actionable case.

Also: chains where every listed asset has both deposits and withdrawals halted are dropped from the failures table. They are already at end of life, so endpoint reachability is moot and they were noise. This is a report-only filter; nothing is deleted from zone_assets.

## Notes for reviewers

- Reviewed by the assetlists reviewer agent across two passes. The pin-precedence commit was approved; a row-template misplacement and an over-broad "disabled counts as covered" call in the report commit were caught and fixed before this PR.
- No automated tests (the draft suite for the ordering helpers was scrapped earlier on request); behavior was verified by local generation runs and direct data checks.
- State-file lag: the ordering changes read state.json, last written under the old logic, so the visible effect lands on the first post-merge full validation run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which RPC/REST URLs are tested first and published in the frontend chainlist; mis-ordering could affect wallet connectivity until the next validation run, but scope is operational endpoint selection and reporting only.
> 
> **Overview**
> This PR tightens **endpoint validation and published chainlist ordering** so zone pins and stale nodes behave consistently, and makes **CI reports** easier to act on.
> 
> **Stale RPC demotion:** `getDeadEndpointAddresses` now treats validator-recorded **stale** RPC results (reachable but tip &gt;1h old) as “dead” alongside connectivity errors, so those addresses sink in the generated chainlist instead of staying near the top. Comments document remaining limits (no REST staleness probe; only endpoints tested up to the first winner are recorded).
> 
> **Zone-pin precedence in validation:** After provider sorting, the validator moves the zone-configured RPC/REST pin to the **front** of the test order (`pinZoneEndpointFirst`), matching the generator’s pin-first ordering. That stops team/preferred endpoints from winning over the pin and avoids oscillating primary endpoints between runs.
> 
> **Report QOL:** The workflow **manual halts** table adds **Symbol** and **Route** (origin chain, optional `via` hop from the frontend assetlist). The validation **Connectivity Failures** table adds **Halt Coverage** (unstable / deposit-halted vs not covered, with `canonical.chain_name` attribution) and drops chains whose listed assets are fully halted both ways (report-only noise reduction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc6cf28e327a4369a9a02f295d97d4f1f2751ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->