### PR TITLE
fix(chainlist): deprioritize malformed endpoint addresses

### DIFF
--- a/.github/workflows/utility/endpoint_ordering.mjs
+++ b/.github/workflows/utility/endpoint_ordering.mjs
@@ -34,6 +34,26 @@
 export const DEAD_ENDPOINT_ERROR_TYPES = new Set(['NETWORK_ERROR', 'TIMEOUT', 'HTTP_ERROR']);
 
 /**
+ * Whether an endpoint address is a usable absolute http(s) URL. A client cannot
+ * call a scheme-less address (e.g. "lcd.nolus.network") or a non-http(s) scheme,
+ * so such an address must never lead the published list even if it sorts first
+ * by Chain Registry order or provider preference. These come from malformed
+ * upstream Chain Registry entries.
+ *
+ * @param {string} address
+ * @returns {boolean} true if the address parses as an http(s) URL
+ */
+export function isUsableEndpointUrl(address) {
+  if (!address) { return false; }
+  try {
+    const url = new URL(address);
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build the set of endpoint addresses (of a given type) that the validator
  * recorded as failing connectivity in this chain's last validation run.
  *
@@ -98,9 +118,14 @@ export function deprioritizeDeadEndpoints(addresses, deadAddresses) {
 
 /**
  * Apply validation-driven reordering to a single node type's endpoint list:
- * first deprioritize recorded-dead endpoints, then promote the validated
- * working address to first position. This is the single entry point used by
- * generate_chainlist.mjs.
+ * first deprioritize recorded-dead and malformed endpoints, then promote the
+ * validated working address to first position. This is the single entry point
+ * used by generate_chainlist.mjs.
+ *
+ * Malformed addresses (scheme-less / non-http(s), from bad upstream Chain
+ * Registry entries) are sunk alongside recorded-dead endpoints: a client cannot
+ * call them, so they must never lead the list. They are demoted, not removed,
+ * matching the dead-endpoint behavior, in case the upstream entry is fixed.
  *
  * @param {string[]} addresses - ordered endpoint addresses (zone pin first, then sorted registry)
  * @param {Object} validationRecord - per-chain record from state.json
@@ -110,13 +135,43 @@ export function deprioritizeDeadEndpoints(addresses, deadAddresses) {
  */
 export function applyValidationOrdering(addresses, validationRecord, nodeType, validatedAddress) {
   const dead = getDeadEndpointAddresses(validationRecord, nodeType);
-  const { ordered, deprioritizedCount } = deprioritizeDeadEndpoints(addresses, dead);
+  const { ordered } = deprioritizeDeadEndpoints(addresses, dead);
   let result = ordered;
   let promoted = false;
-  if (validatedAddress && result.includes(validatedAddress) && result[0] !== validatedAddress) {
+  if (
+    validatedAddress &&
+    isUsableEndpointUrl(validatedAddress) &&
+    result.includes(validatedAddress) &&
+    result[0] !== validatedAddress
+  ) {
     result = result.filter(a => a !== validatedAddress);
     result.unshift(validatedAddress);
     promoted = true;
   }
-  return { ordered: result, deprioritizedCount, promoted };
+  // Finally, push malformed addresses (scheme-less / non-http(s)) strictly to
+  // the very bottom, below even dead-but-valid endpoints. A client cannot call
+  // them at all, whereas a dead-but-valid endpoint may recover, so malformed is
+  // the worst tier. Demoted, never removed. Stable within the malformed group.
+  const malformed = result.filter(a => !isUsableEndpointUrl(a));
+  const malformedSunk = malformed.length > 0 && malformed.length < result.length;
+  if (malformedSunk) {
+    const usable = result.filter(a => isUsableEndpointUrl(a));
+    result = [...usable, ...malformed];
+  }
+  // Report distinct addresses that were sunk below a healthy endpoint, counting
+  // an address that is both dead and malformed only once. When no healthy
+  // endpoint exists (all-dead or all-malformed), the guards leave order
+  // unchanged and nothing was sunk, so report 0.
+  const sunk = new Set();
+  const healthyExists = result.some(a => !dead.has(a) && isUsableEndpointUrl(a));
+  if (healthyExists) {
+    for (const a of addresses) {
+      if (dead.has(a) || !isUsableEndpointUrl(a)) { sunk.add(a); }
+    }
+  }
+  return {
+    ordered: result,
+    deprioritizedCount: sunk.size,
+    promoted
+  };
 }

--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -529,7 +529,7 @@ async function getSuggestionChainProperties(minimalChain, zoneChain = {}) {
       const r = applyValidationOrdering(allRpcEndpoints, validationRecord, 'rpc', rpcAddress);
       allRpcEndpoints = r.ordered;
       if (r.deprioritizedCount > 0) {
-        console.log(`Deprioritized ${r.deprioritizedCount} dead RPC endpoint(s) for ${chain_name}`);
+        console.log(`Deprioritized ${r.deprioritizedCount} dead or malformed RPC endpoint(s) for ${chain_name}`);
       }
       if (r.promoted) {
         console.log(`Promoted validated RPC for ${chain_name}: ${rpcAddress}`);
@@ -541,7 +541,7 @@ async function getSuggestionChainProperties(minimalChain, zoneChain = {}) {
       const r = applyValidationOrdering(allRestEndpoints, validationRecord, 'rest', restAddress);
       allRestEndpoints = r.ordered;
       if (r.deprioritizedCount > 0) {
-        console.log(`Deprioritized ${r.deprioritizedCount} dead REST endpoint(s) for ${chain_name}`);
+        console.log(`Deprioritized ${r.deprioritizedCount} dead or malformed REST endpoint(s) for ${chain_name}`);
       }
       if (r.promoted) {
         console.log(`Promoted validated REST for ${chain_name}: ${restAddress}`);


### PR DESCRIPTION
## Problem

A scheme-less or non-http(s) endpoint address can lead a published RPC/REST list, leaving the first entry unusable while a working endpoint sits lower. This surfaced on Nolus: `lcd.nolus.network` (scheme-less, a malformed upstream Chain Registry entry) was the first REST entry, ahead of an endpoint that actually passed validation. A client trying the first URL fails before reaching the working one.

A scheme-less address fails `new URL()`, so it was neither team-matched nor promoted — it simply sat at its Chain Registry index (0) and stayed first. Only four such addresses exist repo-wide: nolus and andromeda, rpc and rest.

## Change

`applyValidationOrdering` (in `endpoint_ordering.mjs`) now sinks any address that does not parse as an http(s) URL to the strict bottom of the published list, below even dead-but-valid endpoints (a dead endpoint may recover; a malformed one is uncallable, so it is the worst tier). Malformed entries are demoted, never removed, matching the existing dead-endpoint behavior and so the entry recovers automatically if the upstream registry is fixed.

- `isUsableEndpointUrl(address)` — true only for a parseable http(s) URL. Verified against real registry shapes: ports (`:443`) and paths (`/nolus`) pass; scheme-less, `host:port`, and non-http(s) schemes are rejected.
- The promotion step is guarded so a malformed address can never be promoted to slot 0.
- Guarded so an all-malformed list is left unchanged (no churn), mirroring the all-fail guard for dead endpoints.
- `deprioritizedCount` counts distinct sunk addresses (an address that is both recorded-dead and malformed is counted once), and the generator's log label now reads "dead or malformed".

## Verification

Local generation: clean (exit 0). All four malformed addresses now land last in their lists, still present (not removed), and a valid `https://` endpoint leads each. Nolus REST now leads with the liveraven endpoint that passed connectivity. Edge cases (all-malformed, empty, mixed, dead-and-malformed-same-address) checked directly.

## Notes for reviewers

- Reviewed by the assetlists reviewer agent: verdict correct and mergeable, no blockers. Two non-blocking log-only nits (count double-count, "dead" label) were raised and are fixed in this PR.
- No automated tests (the draft suite for the ordering helpers was scrapped earlier on request). `isUsableEndpointUrl` and the partition are pure and exported, so they are the first candidates if the suite returns.
- Follow-up to the merged endpoint auto-demotion work; the generated chainlist.json is intentionally not committed (CI regenerates).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only endpoint ordering logic with no auth or runtime app changes; behavior improves client-first URL choice with conservative all-malformed guards.
> 
> **Overview**
> Published RPC/REST lists can no longer be led by **scheme-less or non-http(s)** Chain Registry addresses (e.g. `lcd.nolus.network`), which clients cannot call even when they sort first.
> 
> **`endpoint_ordering.mjs`** adds **`isUsableEndpointUrl`** (parseable `http:`/`https:` only). **`applyValidationOrdering`** now sinks malformed addresses to the **strict bottom** (below recorded-dead but still-valid URLs), blocks promoting a malformed validated address to slot 0, leaves all-malformed lists unchanged, and recomputes **`deprioritizedCount`** as distinct dead-or-malformed addresses sunk when at least one healthy usable URL exists.
> 
> **`generate_chainlist.mjs`** log lines now say **"dead or malformed"** instead of **"dead"** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad15a84cafbcc92e5fc175b5717914ef380f50b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->