### PR TITLE
chore(evmos): mark Evmos assets source_chain_killed, add tooltip

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -254,11 +254,12 @@
       ],
       "_comment": "Evmos $EVMOS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Evmos chain has been permanently shut down by governance and is no longer producing blocks. Deposits and withdrawals are disabled. Source: https://x.com/Disperze_/status/2054625049429127192"
     },
     {
       "chain_name": "kava",
@@ -3063,11 +3064,12 @@
       ],
       "_comment": "Neokingdom DAO $NEOK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Evmos chain has been permanently shut down by governance and is no longer producing blocks. Deposits and withdrawals are disabled. Source: https://x.com/Disperze_/status/2054625049429127192"
     },
     {
       "chain_name": "realio",
@@ -3832,11 +3834,12 @@
       ],
       "_comment": "Teledisko DAO - Legacy $BERLIN-legacy",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Evmos chain has been permanently shut down by governance and is no longer producing blocks. Deposits and withdrawals are disabled. Source: https://x.com/Disperze_/status/2054625049429127192"
     },
     {
       "chain_name": "scorum",
@@ -4278,11 +4281,12 @@
       ],
       "_comment": "Crowdpunk DAO $CROWDP",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Evmos chain has been permanently shut down by governance and is no longer producing blocks. Deposits and withdrawals are disabled. Source: https://x.com/Disperze_/status/2054625049429127192"
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
## What

Corrects the halt/unstable reasons on the four Evmos-origin assets and adds a curator tooltip.

The **"Evmos Shutdown"** governance proposal passed (~2026-05-15) and the chain permanently halted block production at **block height 37,318,000** (~2026-05-18). The explorer, RPCs, and official site are all down.

The four Evmos-chain assets (EVMOS, NEOK, BERLIN-legacy, CROWDP) were already flagged `osmosis_unstable` with deposits and withdrawals halted, but the reasons read `ibc_client` / `bridge_down`, which describe a transient relayer outage rather than a permanent chain death.

## Changes

For each of the four assets in `osmosis-1/osmosis.zone_assets.json`:

- `osmosis_unstable_reason`: `ibc_client` -> `source_chain_killed`
- `osmosis_deposit_halt_reason`: `bridge_down` -> `source_chain_killed`
- `osmosis_withdrawal_halt_reason`: `bridge_down` -> `source_chain_killed`
- added `tooltip_message` explaining the shutdown, with the source link

`source_chain_killed` is the schema-defined value for exactly this case and is already in use elsewhere in the file (Terra Classic, etc.).

## Not included

- **stEVMOS** (Stride-staked EVMOS) is left on `market`. It lives on Stride (channel-326), which is alive, so the IBC path still functions; the existing unstable flag already warns users.
- Derived `generated/` outputs are left to the generation pipeline.

## Source

https://x.com/Disperze_/status/2054625049429127192

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON metadata-only updates to existing halted assets; no runtime, auth, or transfer logic changes.
> 
> **Overview**
> Updates **four Evmos-origin assets** (`EVMOS`, `NEOK`, `BERLIN-legacy`, `CROWDP`) in `osmosis.zone_assets.json` so halt/unstable metadata reflects a **permanent chain shutdown** instead of a transient bridge/IBC issue.
> 
> For each asset, **`osmosis_unstable_reason`**, **`osmosis_deposit_halt_reason`**, and **`osmosis_withdrawal_halt_reason`** change from `ibc_client` / `bridge_down` to **`source_chain_killed`** (same pattern as other dead-source chains in the file). A shared **`tooltip_message`** is added explaining that Evmos no longer produces blocks and that deposits/withdrawals stay disabled, with a source link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86269a8ed9a753a0a4547072722977d994c89343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->