### PR TITLE
feat(stargaze): planned shutdown 2026-06-15, auto-halt deposits

### DIFF
--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -8,7 +8,9 @@
 //       "extended_unstable_market".
 //
 //     • planned_shutdown_date within 14 days → halt_deposits with reason
-//       "planned_shutdown".
+//       "planned_shutdown". This set path does NOT honour the tooltip_message
+//       curator lock: a planned shutdown is a hard external deadline, so the
+//       halt fires even when a curator has written an explanatory tooltip.
 //
 //   Reason-vocabulary contract: this script owns reasons
 //   {extended_unstable_market, planned_shutdown}. Clearing rules:
@@ -17,7 +19,13 @@
 //       the market-recovery flow; both are safe because they're guarded by
 //       the same reason check.)
 //     • planned_shutdown: cleared when planned_shutdown_date is absent or
-//       > 14 days in the future.
+//       > 14 days in the future, AND no curator tooltip_message is present.
+//       (Once a curator documents the shutdown with a tooltip, the halt is
+//       theirs to clear; the cron will not auto-clear it.)
+//
+//   Notify-only: withdrawals are never auto-halted. The summary and dry-run
+//   report list upcoming planned shutdowns and any past-date shutdowns whose
+//   withdrawals are still open, so a curator can act.
 //
 // Usage:
 //   node check_extended_halts.mjs [<zone_name>] [--dry-run] [--force]
@@ -98,6 +106,10 @@ async function main() {
   const nowIso = new Date().toISOString();
   const nowMs = new Date(nowIso).getTime();
   const mutations = [];
+  // Notify-only signals (no mutation): planned shutdowns a curator may need to
+  // act on. "upcoming" = date within the halt window; "past_due" = date has
+  // passed but withdrawals are still open (chain likely down, funds may strand).
+  const notifications = [];
 
   for (const ev of evaluations) {
     const { coinMinimalDenom, chainName, symbol, zoneAsset } = ev;
@@ -159,13 +171,14 @@ async function main() {
     }
 
     // ── Trigger B: planned shutdown approaching ─────────────────────────────
-    // Curator lock honoured: non-empty tooltip_message blocks the set path,
-    // matching the contract used elsewhere.
+    // Curator lock is intentionally NOT honoured on this set path: a planned
+    // shutdown is a hard external deadline, so the deposit halt must fire even
+    // when a curator has written a tooltip_message explaining the shutdown.
+    // The lock is still honoured on Trigger A and on the clearing path below.
     const plannedDate = zoneAsset.planned_shutdown_date;
     if (
       plannedDate &&
-      zoneAsset.osmosis_halt_deposits !== true &&
-      !zoneAsset.tooltip_message
+      zoneAsset.osmosis_halt_deposits !== true
     ) {
       const untilMs = new Date(plannedDate).getTime() - nowMs;
       if (untilMs >= 0 && untilMs <= SHUTDOWN_WINDOW_MS) {
@@ -196,6 +209,27 @@ async function main() {
           kind: 'planned_shutdown_cleared',
           asset: symbol,
           chain: chainName,
+        });
+      }
+    }
+
+    // ── Notify-only: planned-shutdown awareness ─────────────────────────────
+    // Surface shutdowns for curator attention without mutating withdrawals.
+    if (plannedDate) {
+      const untilMs = new Date(plannedDate).getTime() - nowMs;
+      if (untilMs < 0 && zoneAsset.osmosis_halt_withdrawals !== true) {
+        notifications.push({
+          kind: 'past_due_withdrawals_open',
+          asset: symbol,
+          chain: chainName,
+          shutdown: plannedDate,
+        });
+      } else if (untilMs >= 0 && untilMs <= SHUTDOWN_WINDOW_MS) {
+        notifications.push({
+          kind: 'upcoming_planned_shutdown',
+          asset: symbol,
+          chain: chainName,
+          shutdown: plannedDate,
         });
       }
     }
@@ -230,6 +264,20 @@ async function main() {
         `| ${m.kind} | ${m.asset ?? '-'} | ${m.chain ?? '-'} | ${m.days ?? m.shutdown ?? '-'} |`
       );
     }
+    if (notifications.length > 0) {
+      lines.push(
+        ``,
+        `## Planned-shutdown notifications (no withdrawal action taken)`,
+        ``,
+        `| Kind | Asset | Chain | Shutdown |`,
+        `|------|-------|-------|----------|`
+      );
+      for (const n of notifications) {
+        lines.push(
+          `| ${n.kind} | ${n.asset ?? '-'} | ${n.chain ?? '-'} | ${n.shutdown ?? '-'} |`
+        );
+      }
+    }
     fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
     console.log(`\n📝 Dry-run report: ${reportPath}`);
     return;
@@ -249,6 +297,18 @@ async function main() {
   console.log('='.repeat(70));
   for (const [k, v] of Object.entries(byKind)) {
     console.log(`  ${k.padEnd(28)}: ${v}`);
+  }
+
+  if (notifications.length > 0) {
+    console.log('\n' + '-'.repeat(70));
+    console.log('  PLANNED-SHUTDOWN NOTIFICATIONS (no withdrawal action taken)');
+    console.log('-'.repeat(70));
+    for (const n of notifications) {
+      const flag = n.kind === 'past_due_withdrawals_open' ? '⚠️ ' : '   ';
+      console.log(
+        `  ${flag}${n.kind.padEnd(26)} ${(n.asset ?? '-').padEnd(16)} ${n.chain ?? '-'} (${n.shutdown})`
+      );
+    }
   }
 }
 

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -296,7 +296,9 @@
       "categories": [
         "nft_protocol"
       ],
-      "_comment": "Stargaze $STARS"
+      "_comment": "Stargaze $STARS",
+      "planned_shutdown_date": "2026-06-15T00:00:00Z",
+      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "chihuahua",
@@ -3162,7 +3164,9 @@
       "osmosis_verified": true,
       "_comment": "Stardust STRDST $STRDST",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "planned_shutdown_date": "2026-06-15T00:00:00Z",
+      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "doravota",
@@ -3267,7 +3271,9 @@
       "base_denom": "factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/uBRNCH",
       "path": "transfer/channel-75/factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/uBRNCH",
       "osmosis_verified": false,
-      "_comment": "Branch $BRNCH"
+      "_comment": "Branch $BRNCH",
+      "planned_shutdown_date": "2026-06-15T00:00:00Z",
+      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "neutron",
@@ -3622,7 +3628,9 @@
       "base_denom": "factory/stars1xx5976njvxpl9n4v8huvff6cudhx7yuu8e7rt4/usneaky",
       "path": "transfer/channel-75/factory/stars1xx5976njvxpl9n4v8huvff6cudhx7yuu8e7rt4/usneaky",
       "osmosis_verified": false,
-      "_comment": "Sneaky Productions $SNEAKY"
+      "_comment": "Sneaky Productions $SNEAKY",
+      "planned_shutdown_date": "2026-06-15T00:00:00Z",
+      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "osmosis",
@@ -7093,7 +7101,9 @@
       "base_denom": "factory/stars1rru5m2wh3fylpheqh8h5g968jwhe7rctkfm7u0gwk7ka4vx3q5tqukjl4z/hood",
       "path": "transfer/channel-75/factory/stars1rru5m2wh3fylpheqh8h5g968jwhe7rctkfm7u0gwk7ka4vx3q5tqukjl4z/hood",
       "osmosis_verified": false,
-      "_comment": "HOOD $HOOD"
+      "_comment": "HOOD $HOOD",
+      "planned_shutdown_date": "2026-06-15T00:00:00Z",
+      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## What

Stargaze is winding down its standalone chain on **2026-06-15** as the project migrates to the Cosmos Hub ("Stargaze 2.0"). Transfers over `channel-75` stop working at the shutdown, so deposits need to be disabled ahead of the date. This is a migration, not a chain death (unlike Evmos), so the messaging points users to the migration tooling rather than declaring the asset dead.

## Data changes (`osmosis-1/osmosis.zone_assets.json`)

For all five Stargaze-origin assets (STARS, STRDST, BRNCH, SNEAKY, HOOD):

- `planned_shutdown_date`: `2026-06-15T00:00:00Z`
- `tooltip_message`: explains the Cosmos Hub migration and links the auto-migration tool

No manual `osmosis_halt_deposits` is set. The daily `check_extended_halts` cron sets it automatically once the date is within the 14-day window (already true as of opening this PR).

## Script changes (`check_extended_halts.mjs`)

1. **Planned-shutdown set path no longer honours the `tooltip_message` curator lock.** Previously, any tooltip blocked the planned-shutdown auto-halt, which meant we could not both explain the shutdown to users and rely on the automation to disable deposits. A planned shutdown is a hard external deadline, so the halt must fire regardless of a tooltip. The lock still applies to the market/extended trigger and to the planned-shutdown clearing path (once a curator documents a shutdown with a tooltip, the cron will not auto-clear the halt).

2. **Notify-only reporting.** Withdrawals are never auto-halted. The summary and dry-run report now list:
   - `upcoming_planned_shutdown`: assets with a shutdown date inside the window
   - `past_due_withdrawals_open`: assets whose shutdown date has passed but withdrawals are still open (funds may strand)

   This surfaces shutdowns in the `[AUTO]` PR description for a curator to act on, without the script touching withdrawals.

## Verification

Local `--dry-run` against `osmosis-1`:

```
Mutations: 5
| planned_shutdown_set | STARS  | stargaze | 2026-06-15T00:00:00Z |
| planned_shutdown_set | STRDST | stargaze | 2026-06-15T00:00:00Z |
| planned_shutdown_set | BRNCH  | stargaze | 2026-06-15T00:00:00Z |
| planned_shutdown_set | SNEAKY | stargaze | 2026-06-15T00:00:00Z |
| planned_shutdown_set | HOOD   | stargaze | 2026-06-15T00:00:00Z |

## Planned-shutdown notifications (no withdrawal action taken)
| upcoming_planned_shutdown | STARS  | stargaze | 2026-06-15T00:00:00Z |
| upcoming_planned_shutdown | STRDST | stargaze | 2026-06-15T00:00:00Z |
| upcoming_planned_shutdown | BRNCH  | stargaze | 2026-06-15T00:00:00Z |
| upcoming_planned_shutdown | SNEAKY | stargaze | 2026-06-15T00:00:00Z |
| upcoming_planned_shutdown | HOOD   | stargaze | 2026-06-15T00:00:00Z |
```

All five assets halt despite their tooltips (the old code would have skipped all five), with matching notifications and no withdrawal mutations.

## Notes / open questions

- **Withdrawals left open** by design, so holders can still move assets before the 15th. The new `past_due_withdrawals_open` notification will flag them after the date if a curator still needs to halt withdrawals manually.
- The `2026-06-15` date is per the Foundation's internal information on the standalone-chain halt; public sources confirm the migration direction (Cosmos Hub forum proposal, auto-migration tool) but I could not pin the exact halt date to a public link.
- Derived `generated/` outputs left to the pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production halt automation and zone asset metadata for user-facing deposits; incorrect dates or lock behavior could block or fail to clear IBC deposits for multiple Stargaze assets.
> 
> **Overview**
> Prepares **Stargaze** IBC assets for the **2026-06-15** standalone-chain shutdown by annotating five zone assets with `planned_shutdown_date` and a migration **tooltip**, relying on the daily cron to set deposit halts inside the 14-day window.
> 
> **`check_extended_halts.mjs`** changes automation policy and reporting: the **planned-shutdown deposit halt** now applies even when a curator tooltip is present (tooltips still block extended-unstable set/clear and block **auto-clear** of `planned_shutdown` halts). The script adds **notify-only** dry-run/summary rows for upcoming shutdowns and for **past-due** shutdowns with withdrawals still open—**withdrawals are never auto-halted**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bbaa4a80b2a55b6d9d8d8574274119e8f720267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->