### PR TITLE
fix(chainlist): guard non-iterable versions in suggestion features

### DIFF
--- a/.github/workflows/utility/chain_registry.mjs
+++ b/.github/workflows/utility/chain_registry.mjs
@@ -169,8 +169,13 @@ export function populateChainDirectories() {
 
 export function getFileProperty(chainName, file, property) {
   const chainDirectory = chainNameToDirectoryMap.get(chainName);
-  if(chainDirectory) {
-    const filePath = path.join(chainDirectory,fileToFileNameMap.get(file));
+  const fileName = fileToFileNameMap.get(file);
+  // fileToFileNameMap only knows "chain" and "assetlist". An unknown file type
+  // (e.g. a caller asking for "versions") would otherwise reach
+  // path.join(dir, undefined), which throws on Node >=22 and is fragile on 20.
+  // Return undefined cleanly so callers get the same "absent" result.
+  if(chainDirectory && fileName) {
+    const filePath = path.join(chainDirectory, fileName);
     const FILE_EXISTS = fs.existsSync(filePath);
     if(FILE_EXISTS) {
       return readJsonFile(filePath)[property];

--- a/.github/workflows/utility/generate_chainlist.mjs
+++ b/.github/workflows/utility/generate_chainlist.mjs
@@ -242,8 +242,13 @@ function getChainSuggestionFeatures(chain, zoneChain) {
 
   const recommended_version = chain_reg.getFileProperty(chain.chain_name, "chain", "codebase")?.recommended_version;
   if (recommended_version) {
+    // getFileProperty only resolves the "chain"/"assetlist" files, so a
+    // "versions" lookup returns undefined; some chains also simply have no
+    // versions.json or no top-level versions array. Guard against a non-array
+    // here so a chain with codebase.recommended_version set doesn't crash the
+    // whole chainlist generation with "versions is not iterable".
     const versions = chain_reg.getFileProperty(chain.chain_name, "versions", "versions");
-    for (const version of versions) {
+    for (const version of (Array.isArray(versions) ? versions : [])) {
       if (version.recommended_version === recommended_version) {
 
         //ibc-go


### PR DESCRIPTION
## What

Fixes the `[AUTO] Generate All Files` run failing with:

```
TypeError: versions is not iterable
    at getChainSuggestionFeatures (generate_chainlist.mjs:246)
```

## Root cause

`getChainSuggestionFeatures` reads a chain's versions via `getFileProperty(chain, "versions", "versions")` and iterates the result with `for (const version of versions)`. For a chain whose `chain.json` sets `codebase.recommended_version` but whose `versions` lookup returns a non-array (no `versions.json`, or no top-level `versions` array), `versions` is `undefined` and the `for...of` throws, aborting the whole chainlist generation. It surfaced now because the daily chain-registry submodule pull changed the registry data hitting this branch.

Note: `generate_chainlist.mjs` imports `chain_reg` from the chain-registry **submodule's** utility (`../../../chain-registry/.github/workflows/utility/chain_registry.mjs`), so the local `./chain_registry.mjs` is not in this code path.

## Fix

- **`generate_chainlist.mjs`** (the actual fix): only iterate when `versions` is an array — `for (const version of (Array.isArray(versions) ? versions : []))`. Behavior-preserving: the versions-derived keplr feature flags were already a no-op whenever the lookup returned non-array, so guarding changes no output, it just stops the crash.
- **`chain_registry.mjs`** (defensive, unrelated to this crash): `getFileProperty` now returns `undefined` for an unknown file type instead of calling `path.join(dir, undefined)` (throws on Node >=22, fragile on 20). This module is only consumed by `report_dead_chains.mjs` in this repo, not by the chainlist generator, so it does not affect the crash; included as a small hardening of the helper my report script uses.

## Testing

- `node --check` clean on both files.
- Ran `generate_chainlist.mjs` end to end locally against the submodule import path: exit 0 (previously crashed), 189 chains generated.
- Confirmed feature derivation unchanged: the 154 chains with `features` get them from the `override_properties` / `keplr_features` path, not the versions path.
