### PR TITLE
chore(assets): mark onomy, onex, milkyway, dhealth, emoney source_chain_killed

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -403,11 +403,12 @@
       ],
       "_comment": "e-Money $NGM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The e-Money project has been discontinued and its chain is no longer maintained; the e-Money stablecoins were cancelled and the GitHub organisation archived. Deposits and withdrawals are disabled. Source: https://github.com/e-money"
     },
     {
       "chain_name": "emoney",
@@ -419,11 +420,12 @@
       ],
       "_comment": "e-Money EUR $EEUR",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The e-Money project has been discontinued and its chain is no longer maintained; the e-Money stablecoins were cancelled and the GitHub organisation archived. Deposits and withdrawals are disabled. Source: https://github.com/e-money"
     },
     {
       "chain_name": "likecoin",
@@ -1771,11 +1773,12 @@
       ],
       "_comment": "Onomy $NOM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Onomy chain has been permanently shut down. The team announced an indefinite sunset of operations and validators were instructed to stop producing blocks. Deposits and withdrawals are disabled. Source: https://x.com/OnomyProtocol/status/1921962201138483461"
     },
     {
       "chain_name": "persistence",
@@ -4179,11 +4182,12 @@
       ],
       "_comment": "dHealth $DHP",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The dHealth Cosmos chain has been sunset by governance and the project has migrated fully to Solana. The migration bridge closed on 2026-04-11. Deposits and withdrawals are disabled. Source: https://www.dhealth.com/post/bridge-open-migrate-to-solana-native-dhp"
     },
     {
       "chain_name": "furya",
@@ -7309,11 +7313,12 @@
       ],
       "_comment": "MilkyWay $MILK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The MilkyWay chain has been permanently wound down and shut down by the team. A final upgrade returned assets to their origin chains. Deposits and withdrawals are disabled. Source: https://x.com/milky_way_zone/status/2011770175566332325"
     },
     {
       "chain_name": "planq",
@@ -7439,11 +7444,12 @@
       ],
       "_comment": "milkBABY $milkBABY",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The MilkyWay chain has been permanently wound down and shut down by the team. A final upgrade returned assets to their origin chains. Deposits and withdrawals are disabled. Source: https://x.com/milky_way_zone/status/2011770175566332325"
     },
     {
       "chain_name": "osmosis",
@@ -8073,11 +8079,12 @@
       "path": "transfer/channel-37/echf",
       "osmosis_unstable": true,
       "_comment": "e-Money CHF $ECHF",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The e-Money project has been discontinued and its chain is no longer maintained; the e-Money stablecoins were cancelled and the GitHub organisation archived. Deposits and withdrawals are disabled. Source: https://github.com/e-money"
     },
     {
       "chain_name": "emoney",
@@ -8085,11 +8092,12 @@
       "path": "transfer/channel-37/enok",
       "osmosis_unstable": true,
       "_comment": "e-Money NOK $ENOK",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The e-Money project has been discontinued and its chain is no longer maintained; the e-Money stablecoins were cancelled and the GitHub organisation archived. Deposits and withdrawals are disabled. Source: https://github.com/e-money"
     },
     {
       "chain_name": "emoney",
@@ -8097,11 +8105,12 @@
       "path": "transfer/channel-37/edkk",
       "osmosis_unstable": true,
       "_comment": "e-Money DKK $EDKK",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The e-Money project has been discontinued and its chain is no longer maintained; the e-Money stablecoins were cancelled and the GitHub organisation archived. Deposits and withdrawals are disabled. Source: https://github.com/e-money"
     },
     {
       "chain_name": "emoney",
@@ -8109,11 +8118,12 @@
       "path": "transfer/channel-37/esek",
       "osmosis_unstable": true,
       "_comment": "e-Money SEK $ESEK",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The e-Money project has been discontinued and its chain is no longer maintained; the e-Money stablecoins were cancelled and the GitHub organisation archived. Deposits and withdrawals are disabled. Source: https://github.com/e-money"
     },
     {
       "chain_name": "odin",
@@ -10725,11 +10735,12 @@
       "path": "transfer/channel-74628/aonex",
       "osmosis_unstable": true,
       "_comment": "ONEX $ONEX",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "ONEX ran as an Onomy consumer chain and shut down together with Onomy, whose operations were permanently sunset. Deposits and withdrawals are disabled. Source: https://x.com/OnomyProtocol/status/1921962201138483461"
     },
     {
       "chain_name": "self",


### PR DESCRIPTION
## What

Marks the Osmosis-listed assets from five permanently shut-down source chains as `source_chain_killed`, with a per-chain `tooltip_message` citing the shutdown source. Mirrors the prior Evmos change. Verified in MTN-104.

For each of the 11 affected assets, all three reason fields move from `ibc_client` / `bridge_down` to `source_chain_killed`, and a `tooltip_message` is added.

| Chain | Assets | Source |
|-------|--------|--------|
| onomy | NOM | Official: indefinite sunset of operations, validators told to stop — https://x.com/OnomyProtocol/status/1921962201138483461 |
| onex | ONEX | Onomy consumer chain, died with Onomy (same source) |
| milkyway | MILK, milkBABY | Official "Wind-Down and Permanent Shutdown" — https://x.com/milky_way_zone/status/2011770175566332325 |
| dhealth | DHP | Governance sunset, full migration to Solana, bridge closed 2026-04-11 — https://www.dhealth.com/post/bridge-open-migrate-to-solana-native-dhp |
| emoney | NGM, EEUR, ECHF, ENOK, EDKK, ESEK | Project discontinued, GitHub org archived, stablecoins cancelled — https://github.com/e-money |

## Why

These chains have stopped producing blocks. The assets were previously flagged `ibc_client` / `bridge_down`, which describe a recoverable relayer outage rather than a permanent chain shutdown. `source_chain_killed` is the accurate reason and the tooltip tells users why deposits/withdrawals are disabled.

## Behaviour change

Deposits and withdrawals were already halted for these assets; this changes the displayed reason and adds an explanatory tooltip. Once flagged, the dead-chain report (PR #3548) stops surfacing these chains as candidates.

## Notes

- Evmos was already flagged `source_chain_killed` in a prior change and is not touched here.
- Data-only change to `osmosis-1/osmosis.zone_assets.json` (11 assets). No generated files; the daily pipeline regenerates those.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only metadata in a JSON asset list; no runtime logic, auth, or IBC behavior changes beyond displayed reasons and tooltips.
> 
> **Overview**
> Updates **`osmosis-1/osmosis.zone_assets.json`** so **11 IBC assets** from permanently shut-down chains (**e-Money**, **Onomy**, **ONEX**, **MilkyWay**, **dHealth**) use **`source_chain_killed`** instead of **`ibc_client`** / **`bridge_down`** for unstable and deposit/withdrawal halt reasons, matching the existing **Evmos** pattern.
> 
> Each affected entry gains a **`tooltip_message`** explaining the shutdown and why deposits/withdrawals stay disabled, with an official source link. **Deposit/withdrawal halts were already on**; this mainly changes **UI copy/reason codes** and keeps these chains out of dead-chain candidate reporting. Also adds a proper **newline at end of file**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf6ab0787d99f528bc303b1dd87d257dcdd08e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->