### PR TITLE
chore(assets): mark milkINIT source_chain_killed

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8067,7 +8067,14 @@
         "liquid_staking",
         "defi"
       ],
-      "_comment": "milkINIT $milkINIT"
+      "_comment": "milkINIT $milkINIT",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "milkINIT is a MilkyWay liquid-staking token, and the MilkyWay chain has been permanently wound down and shut down by the team. A final upgrade returned assets to their origin chains. Deposits and withdrawals are disabled. Source: https://x.com/milky_way_zone/status/2011770175566332325"
     },
     {
       "chain_name": "gnodi",


### PR DESCRIPTION
## What

Marks **milkINIT** (`initia` / canonical `moo`) as `source_chain_killed` with a tooltip, completing the MilkyWay shutdown cleanup. MilkyWay (MILK, milkBABY) was marked killed in #3551; milkINIT is a MilkyWay liquid-staking token routed via Initia, so its source chain is dead the same way.

All three reason fields set to `source_chain_killed`; tooltip cites the official MilkyWay "Wind-Down and Permanent Shutdown" post (https://x.com/milky_way_zone/status/2011770175566332325).

The existing `osmosis_disabled` flag is left untouched (it only marks the non-native Skip transfer flow, not a halt).

## Effect

This makes `moo` a fully-killed chain (its only Osmosis-listed asset), so it now also drops out of endpoint validation and the connectivity report once #3552 lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON metadata entry following an established killed-chain pattern; no application logic or security-sensitive code changes.
> 
> **Overview**
> **milkINIT** in `osmosis.zone_assets.json` is updated to match other wind-down assets: it is marked **unstable** and **deposit/withdrawal halts** are enabled, all with `source_chain_killed` reasons, plus a user-facing **tooltip** explaining MilkyWay’s permanent shutdown and linking the official announcement.
> 
> Existing **`osmosis_disabled`** on the Skip transfer flow is unchanged. Once related tooling ships, treating **`moo`** as fully killed (this is its only listed Osmosis asset) should remove it from endpoint validation and connectivity reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe5773bda95229a145b912876c07867513bc8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->