### PR TITLE
chore(int3): halt deposits and flag int3 assets unstable

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6293,7 +6293,12 @@
           "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=dogecoin&fromToken=DOGE.int3"
         }
       ],
-      "_comment": "Dogecoin (Int3) $DOGE.int3"
+      "_comment": "Dogecoin (Int3) $DOGE.int3",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "int3face",
@@ -6308,7 +6313,12 @@
           "withdraw_url": "https://app.int3face.zone/bridge"
         }
       ],
-      "_comment": "Bitcoin (Int3) $BTC.int3"
+      "_comment": "Bitcoin (Int3) $BTC.int3",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "int3face",
@@ -6325,7 +6335,10 @@
       ],
       "_comment": "Bitcoin Cash (Int3) $BCH.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "int3face",
@@ -6342,7 +6355,10 @@
       ],
       "_comment": "Litecoin (Int3) $LTC.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "axelar",
@@ -6745,7 +6761,10 @@
       },
       "_comment": "Toncoin (Int3) $TON.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "fetchhub",
@@ -7498,7 +7517,12 @@
           "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=solana&fromToken=SOL.int3"
         }
       ],
-      "_comment": "Solana (Int3) $SOL.int3"
+      "_comment": "Solana (Int3) $SOL.int3",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "atomone",
@@ -7520,7 +7544,12 @@
           "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=xrpl&fromToken=XRP.int3"
         }
       ],
-      "_comment": "Ripple (xrpl via Int3) $XRP.xrpl.int3"
+      "_comment": "Ripple (xrpl via Int3) $XRP.xrpl.int3",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "migaloo",
@@ -7715,7 +7744,10 @@
       ],
       "_comment": "Pudgy Penguins (Int3) $PENGU.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "int3face",
@@ -7735,7 +7767,10 @@
       ],
       "_comment": "Official Trump (Int3) $TRUMP.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "qfs",
@@ -7915,7 +7950,10 @@
       ],
       "_comment": "Zcash (Int3) $ZEC.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
     },
     {
       "chain_name": "osmosis",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6517,7 +6517,10 @@
       },
       "_comment": "Litecoin $LTC",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
     },
     {
       "chain_name": "osmosis",
@@ -6530,7 +6533,10 @@
       },
       "_comment": "Bitcoin Cash $BCH",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
     },
     {
       "chain_name": "mantrachain",
@@ -7816,7 +7822,10 @@
       ],
       "_comment": "Official Trump $TRUMP",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
     },
     {
       "chain_name": "osmosis",
@@ -7839,7 +7848,10 @@
       },
       "_comment": "Pudgy Penguins $PENGU",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
     },
     {
       "chain_name": "neutron",
@@ -7976,7 +7988,10 @@
       },
       "_comment": "Zcash $ZEC",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
Int3face bridge is beginning a wind-down process. This halts deposits on all ten int3 assets and surfaces an informational tooltip, while leaving withdrawals open so users and the alloys can still exit.

Affected assets: BTC, DOGE, SOL, XRP, BCH, LTC, TON, PENGU, TRUMP, ZEC (`.int3`).
Affected alloys: BCH, LTC, PENGU, TRUMP, ZEC

Each now carries:
- `osmosis_halt_deposits: true` + `osmosis_deposit_halt_reason: "planned_shutdown"`
- `osmosis_unstable: true` + `osmosis_unstable_reason: "manual"` (the six previously flagged `market` are normalised to `manual` for consistency across the set)
- a shared `tooltip_message` directing users to withdraw back to their native chains

Withdrawals are intentionally left open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only updates to the Osmosis asset registry; no application or bridge code changes.
> 
> **Overview**
> Marks **Int3face bridge** assets and **Int3-only alloyed** tokens (DOGE, BTC, BCH, LTC, SOL, XRP, TON, PENGU, TRUMP, ZEC, plus alloyed BCH/LTC/PENGU/TRUMP/ZEC) for the bridge wind-down in `osmosis.zone_assets.json`.
> 
> Each affected entry now sets **`osmosis_halt_deposits: true`** with **`osmosis_deposit_halt_reason: "planned_shutdown"`**, **`osmosis_unstable: true`** with **`osmosis_unstable_reason: "manual"`** (replacing prior **`market`** where present), and a **`tooltip_message`** telling users deposits are off and to withdraw to native chains (alloy entries use Int3-specific copy). Withdrawals are not halted in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b4481ff634607bbac70b6b4ab360effba3cdf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->