### PR TITLE
feat(zone): halt deposits on low-liquidity connectivity-failure assets

### DIFF
--- a/.github/workflows/utility/validateEndpoints.mjs
+++ b/.github/workflows/utility/validateEndpoints.mjs
@@ -1427,7 +1427,8 @@ function generateValidationReport(chainName) {
   const bumpCoverage = (c, asset) => {
     if (!haltCoverageByChain[c]) {
       haltCoverageByChain[c] = {
-        total: 0, unstable: 0, depositsHalted: 0, haltedBothDirections: 0
+        total: 0, unstable: 0, depositsHalted: 0, haltedBothDirections: 0,
+        assets: []
       };
     }
     haltCoverageByChain[c].total += 1;
@@ -1436,6 +1437,7 @@ function generateValidationReport(chainName) {
     if (asset.osmosis_halt_deposits && asset.osmosis_halt_withdrawals) {
       haltCoverageByChain[c].haltedBothDirections += 1;
     }
+    haltCoverageByChain[c].assets.push(asset);
   };
   zoneAssets.forEach(asset => {
     const chains = new Set();
@@ -1443,6 +1445,40 @@ function generateValidationReport(chainName) {
     if (asset.canonical?.chain_name) { chains.add(asset.canonical.chain_name); }
     chains.forEach(c => bumpCoverage(c, asset));
   });
+
+  // Render the per-asset status breakdown for a chain as one Markdown cell, one
+  // asset per line (joined with <br> since a literal newline would break the
+  // table row). Each line is "<symbol> — <status>", where status reflects the
+  // strongest halt flag set on that asset and its reason. This replaces the old
+  // aggregate-count cell so a reviewer can see exactly which assets are still
+  // exposed on an unreachable chain without the table ballooning into one row
+  // per asset. Asset identity prefers the human label parsed from _comment
+  // (e.g. "Evmos $EVMOS" -> "EVMOS"), falling back to base_denom.
+  const getAssetSymbol = (asset) => {
+    const ticker = asset._comment?.match(/\$([A-Za-z0-9.\-]+)/)?.[1];
+    return ticker || asset.base_denom || '(unknown)';
+  };
+  const getAssetStatusLine = (asset) => {
+    const reason = (r) => (r ? ` (${r})` : '');
+    let status;
+    if (asset.osmosis_halt_deposits && asset.osmosis_halt_withdrawals) {
+      status = `🛑 deposits + withdrawals halted${reason(asset.osmosis_deposit_halt_reason || asset.osmosis_withdrawal_halt_reason)}`;
+    } else if (asset.osmosis_halt_deposits) {
+      status = `🛑 deposits halted${reason(asset.osmosis_deposit_halt_reason)}`;
+    } else if (asset.osmosis_halt_withdrawals) {
+      status = `🛑 withdrawals halted${reason(asset.osmosis_withdrawal_halt_reason)}`;
+    } else if (asset.osmosis_unstable) {
+      status = `⚠️ unstable${reason(asset.osmosis_unstable_reason)}`;
+    } else {
+      status = '❗ not covered';
+    }
+    return `${getAssetSymbol(asset)} — ${status}`;
+  };
+  const getAssetBreakdownCell = (chain_name) => {
+    const cov = haltCoverageByChain[chain_name];
+    if (!cov || cov.assets.length === 0) { return '— no listed assets'; }
+    return cov.assets.map(getAssetStatusLine).join('<br>');
+  };
 
   // Render a short coverage label for a chain's assets. An asset counts as
   // "covered" only if it is deposit-halted or flagged unstable. osmosis_disabled
@@ -1659,10 +1695,11 @@ function generateValidationReport(chainName) {
     report += `### ❌ Connectivity Failures\n\n`;
     report += `The following chains have endpoints that failed connectivity tests (not just CORS). `;
     report += `The Halt Coverage column shows whether the chain's listed assets are already flagged `;
-    report += `unstable / deposit-halted by another mechanism. The Action column gives the suggested `;
+    report += `unstable / deposit-halted by another mechanism. The Assets column lists every asset on `;
+    report += `the chain with its individual status (one per line). The Action column gives the suggested `;
     report += `next step derived from that coverage and the chain's dead-chain streak.\n\n`;
-    report += `| Chain Name | Last Validation | Days Ago | RPC Status | REST Status | Halt Coverage | Action |\n`;
-    report += `|------------|----------------|----------|------------|-------------|---------------|--------|\n`;
+    report += `| Chain Name | Last Validation | Days Ago | RPC Status | REST Status | Halt Coverage | Assets | Action |\n`;
+    report += `|------------|----------------|----------|------------|-------------|---------------|--------|--------|\n`;
 
     failedChains.forEach(chain => {
       const validationDate = new Date(chain.validationDate);
@@ -1677,9 +1714,10 @@ function generateValidationReport(chainName) {
       const rpcStatus = rpcAllFailed ? '❌ All Failed' : '⚠️ Partial';
       const restStatus = restAllFailed ? '❌ All Failed' : '⚠️ Partial';
       const haltCoverage = getHaltCoverageLabel(chain.chain_name);
+      const assetBreakdown = getAssetBreakdownCell(chain.chain_name);
       const action = getActionLabel(chain.chain_name);
 
-      report += `| ${chain.chain_name} | ${validationDate.toISOString().split('T')[0]} | ${daysSince} | ${rpcStatus} | ${restStatus} | ${haltCoverage} | ${action} |\n`;
+      report += `| ${chain.chain_name} | ${validationDate.toISOString().split('T')[0]} | ${daysSince} | ${rpcStatus} | ${restStatus} | ${haltCoverage} | ${assetBreakdown} | ${action} |\n`;
     });
     report += `\n`;
   }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -459,7 +459,9 @@
       "osmosis_verified": true,
       "_comment": "BitCanna $BCNA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "bitsong",
@@ -511,7 +513,10 @@
       ],
       "_comment": "Comdex $CMDX",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Comdex team ended support for the Comdex chain on 31 October 2025, deposits are disabled. Withdrawals remain open. Source: https://x.com/ComdexOfficial/status/1968366352537682220"
     },
     {
       "chain_name": "cheqd",
@@ -1716,7 +1721,10 @@
       ],
       "_comment": "CMST $CMST",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Comdex team ended support for the Comdex chain on 31 October 2025, deposits are disabled. Withdrawals remain open. Source: https://x.com/ComdexOfficial/status/1968366352537682220"
     },
     {
       "chain_name": "imversed",
@@ -1874,7 +1882,9 @@
       "osmosis_verified": true,
       "_comment": "Canto $CANTO",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "quicksilver",
@@ -2041,7 +2051,12 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Harbor $HARBOR"
+      "_comment": "Harbor $HARBOR",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "The Comdex team ended support for the Comdex chain on 31 October 2025, deposits are disabled. Withdrawals remain open. Source: https://x.com/ComdexOfficial/status/1968366352537682220"
     },
     {
       "chain_name": "quicksilver",
@@ -2815,7 +2830,9 @@
       ],
       "_comment": "Bonk $BONK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "gateway",
@@ -2835,7 +2852,9 @@
       ],
       "_comment": "Tether USD (Ethereum via Wormhole) $USDT.eth.wh",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "gateway",
@@ -2868,7 +2887,9 @@
       ],
       "_comment": "Aptos Coin (Wormhole) $APT.wh",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "kujira",
@@ -2914,7 +2935,9 @@
       ],
       "_comment": "USDC (Ethereum via Wormhole) $USDC.eth.wh",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "gateway",
@@ -2931,7 +2954,9 @@
       ],
       "_comment": "Ethereum (Wormhole) $ETH.wh",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "noble",
@@ -3399,7 +3424,9 @@
       ],
       "_comment": "Pyth Network $PYTH",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "persistence",
@@ -3827,7 +3854,9 @@
       ],
       "_comment": "USDC (Solana via Wormhole) $USDC.sol.wh",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "humans",
@@ -3940,7 +3969,11 @@
           "withdraw_url": "https://www.bskt.fi/wormhole"
         }
       ],
-      "_comment": "Basket $BSKT"
+      "_comment": "Basket $BSKT",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "aioz",
@@ -3953,7 +3986,9 @@
       ],
       "_comment": "AIOZ Network (AIOZ Network) $AIOZ.aioz",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "stride",
@@ -4178,7 +4213,9 @@
       "osmosis_verified": true,
       "_comment": "Wormhole Token $W",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "dhealth",
@@ -4591,7 +4628,11 @@
           "withdraw_url": "https://portal.dymension.xyz/ibc/transfer?sourceId=osmosis-1&destinationId=dymension_1100-1"
         }
       ],
-      "_comment": "Nim Network $NIM"
+      "_comment": "Nim Network $NIM",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "seda",
@@ -5513,7 +5554,9 @@
       ],
       "_comment": "Mande Network $MAND",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "neutaro",
@@ -5542,7 +5585,11 @@
           "withdraw_url": "http://wormhole.bridge.sandwichswap.io/pumpfunosmo/pbj/withdraw"
         }
       ],
-      "_comment": "Pepe Bruce Jenner $PBJ"
+      "_comment": "Pepe Bruce Jenner $PBJ",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "noble",
@@ -7065,7 +7112,9 @@
         "base_denom": "attoaioz"
       },
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "oraichain",


### PR DESCRIPTION
## Summary

Halt deposits on connectivity-failing counterparty-chain assets that have under $10k of pool-locked liquidity on Osmosis, leaving withdrawals open so users can still exit. Assets at or above $10k (SOL.wh, NLS, SUI.wh) are unchanged.

These chains are currently failing endpoint connectivity validation. The under-$10k assets carry little enough onchain value that halting deposits is the right protective step; the three high-value assets are left open pending endpoint recovery.

## Changes

**`osmosis-1/osmosis.zone_assets.json`** (19 assets)

- 16 non-Comdex assets (gateway, aioz, bitcanna, canto, nim, mande): `osmosis_halt_deposits` with reason `extended_unstable_market`, plus `osmosis_unstable` reason `market`.
- 3 Comdex assets (CMDX, CMST, HARBOR): `osmosis_halt_deposits` with reason `planned_shutdown` and a `tooltip_message` citing the team shutdown announcement (support ended 31 October 2025). `osmosis_unstable` reason `market`.
  - `planned_shutdown_date` is intentionally omitted: with the date already in the past, the extended-halt cron would treat it as a both-directions shutdown deadline. Withdrawals are kept open per the announcement directing users to unstake/bridge out via the Comdex explorer. The tooltip curator-lock keeps the deposit halt from auto-clearing.
- Withdrawals remain open on all 19.

**`.github/workflows/utility/validateEndpoints.mjs`**

- The Connectivity Failures report table gains a per-asset breakdown column: every asset on a failing chain is listed with its individual status, one per line within a single cell, so the table stays at one row per chain even for asset-heavy chains like gateway.

## Validation

- `validate_zone_data.mjs osmosis` and `validate_zone_files.mjs` both pass.
- All reason values are within the `zone_assets.schema.json` enums.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing deposit availability for 19 IBC/wormhole assets and curation flags in zone data; report-only workflow changes are low risk but the asset halts affect live transfer UX.
> 
> **Overview**
> **Zone assets:** Deposits are halted on **19** counterparty assets on chains failing endpoint connectivity, with withdrawals left open. Sixteen use `osmosis_halt_deposits` with reason `extended_unstable_market` (plus existing or added `osmosis_unstable` / `market` where needed). Three Comdex tokens (CMDX, CMST, HARBOR) use `planned_shutdown`, a user-facing `tooltip_message` about the Oct 2025 shutdown, and no `planned_shutdown_date` so withdrawals stay open and the extended-halt cron does not force both-direction halts.
> 
> **Endpoint validation report:** The Connectivity Failures markdown table adds an **Assets** column. Halt coverage tracking now keeps per-chain asset lists; each failing chain row shows one line per asset (`symbol — status` with halt/unstable/not-covered and reasons), joined with `<br>` so the table stays one row per chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c1701a22650789cf878d5130835a6844583d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->