### PR TITLE
ci: migrate GitHub Actions off deprecated Node 20 runtime (MTN-122)

### DIFF
--- a/.github/workflows/check_verification_criteria.yml
+++ b/.github/workflows/check_verification_criteria.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -26,7 +26,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: pnpm
@@ -41,7 +41,7 @@ jobs:
           node checkVerificationCriteria.mjs osmosis-1
 
       - name: Upload Verification Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: verification-report
           path: osmosis-1/generated/verification_reports/verification_report_latest.json

--- a/.github/workflows/check_verification_criteria.yml
+++ b/.github/workflows/check_verification_criteria.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy_vercel_mainnet.yml
+++ b/.github/workflows/deploy_vercel_mainnet.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history to check file changes
 

--- a/.github/workflows/deploy_vercel_testnet.yml
+++ b/.github/workflows/deploy_vercel_testnet.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history to check file changes
 

--- a/.github/workflows/full_validation.yml
+++ b/.github/workflows/full_validation.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -37,7 +37,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           cache: pnpm

--- a/.github/workflows/full_validation.yml
+++ b/.github/workflows/full_validation.yml
@@ -34,7 +34,7 @@ jobs:
           git submodule update --recursive --remote
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -34,7 +34,7 @@ jobs:
           git submodule update --recursive --remote
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/generate_assetlist.yml
+++ b/.github/workflows/generate_assetlist.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -28,7 +28,7 @@ jobs:
           git submodule update --recursive --remote
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/generate_chainlist.yml
+++ b/.github/workflows/generate_chainlist.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -28,7 +28,7 @@ jobs:
           git submodule update --recursive --remote
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/generate_coingecko.yml
+++ b/.github/workflows/generate_coingecko.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -28,7 +28,7 @@ jobs:
           git submodule update --recursive --remote
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/generate_mintscan.yml
+++ b/.github/workflows/generate_mintscan.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -28,7 +28,7 @@ jobs:
           git submodule update --recursive --remote
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/propose_unverify.yml
+++ b/.github/workflows/propose_unverify.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
 

--- a/.github/workflows/update_chain_reg.yml
+++ b/.github/workflows/update_chain_reg.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true

--- a/.github/workflows/validate_zone_assets.yml
+++ b/.github/workflows/validate_zone_assets.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true

--- a/.github/workflows/validate_zone_chains.yml
+++ b/.github/workflows/validate_zone_chains.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true

--- a/.github/workflows/validate_zone_data.yml
+++ b/.github/workflows/validate_zone_data.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
@@ -32,7 +32,7 @@ jobs:
           git submodule update --recursive --remote
           
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           


### PR DESCRIPTION
## Summary

Migrate this repo's GitHub Actions off the deprecated Node 20 runtime (GitHub forces JS actions onto Node 24 on 2026-06-16; Node 20 removed from runners fall 2026).

- Bumped `actions/checkout@v4 -> @v6`, `actions/setup-node@v4 -> @v6`, and `actions/upload-artifact@v4 -> @v6` across all 15 workflows.
- Only the action `uses:` versions change. The `setup-node` `with:` blocks (e.g. `cache: pnpm`, `node-version: 20.x`) are untouched, so caching and the in-job Node version are unchanged.

## Why this is needed (note re #3555)

`main` was already standardized on `actions/checkout@v4` / `actions/setup-node@v4` (PR #3555 "bump deprecated actions... unify on pnpm"), but **v4 of these actions still runs on Node 20**. So #3555 did not clear the Node 20 deprecation; v5/v6 is required. This PR completes that.

Tracked in Linear MTN-122 (part of the org-wide MTN-106 umbrella).

## Affected workflows

`check_verification_criteria.yml`, `deploy_vercel_mainnet.yml`, `deploy_vercel_testnet.yml`, `full_validation.yml`, `generate_all_files.yml`, `generate_assetlist.yml`, `generate_chainlist.yml`, `generate_coingecko.yml`, `generate_mintscan.yml`, `localization.yml`, `propose_unverify.yml`, `update_chain_reg.yml`, `validate_zone_assets.yml`, `validate_zone_chains.yml`, `validate_zone_data.yml`.

## Test plan

- [ ] Confirm CI runs show no "Node.js 20 actions are deprecated" warning.
- [ ] `full_validation` / `validate_zone_*` (validation, read-only) run green on PR.
- Note: `deploy_vercel_*` only get a checkout bump and are validated on their normal push-to-main trigger.

Out of scope: third-party actions (`pnpm/action-setup`, `peter-evans/create-pull-request`) which are not `actions/*`.

cc @johnnywyles - heads up: this supersedes the action portion of #3555 for the Node 20 removal.
