### PR TITLE
chore(assets): mark PURSE source_chain_killed (PundiXChain sunset)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3582,7 +3582,14 @@
       },
       "osmosis_verified": false,
       "osmosis_unlisted": true,
-      "_comment": "PURSE Token $PURSE"
+      "_comment": "PURSE Token $PURSE",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "PURSE reached Osmosis through PundiXChain, which has been permanently sunset by passed governance (estimated chain closure 1 March 2026) as the network migrates to Ethereum. The PundiXChain transfer path is no longer available, so deposits and withdrawals are disabled. Source: https://px-rest.pundix.com/cosmos/gov/v1beta1/proposals/8"
     },
     {
       "chain_name": "injective",


### PR DESCRIPTION
## What

Marks the **PURSE** zone_asset (`chain_name: pundix`) as `source_chain_killed` — adds the standard unstable / deposit-halt / withdrawal-halt reason fields plus a tooltip.

## Why

PundiXChain has been permanently sunset by passed governance ([proposal #8](https://px-rest.pundix.com/cosmos/gov/v1beta1/proposals/8), "PundiXChain Sunset and Full Migration to Ethereum", estimated chain closure **1 March 2026**) as the network migrates to Ethereum. PURSE reached Osmosis through PundiXChain, so that transfer path is no longer available.

This was surfaced by the new weekly planned-shutdown scan in `report_dead_chains.mjs`.

## Scope

- Only the `chain_name: pundix` PURSE entry is touched (it was already `osmosis_unlisted: true`).
- **PUNDIX** on Osmosis is intentionally left untouched: it is `chain_name: fxcore`, canonical on Ethereum, bridged via fxcore/Starscan — an independent path that the PundiXChain sunset does not sever.
- Uses `source_chain_killed` (matching evmos / e-Money / milkINIT) rather than `planned_shutdown_date`, since the closure date is already past and `check_extended_halts` only fires that field for upcoming shutdowns. The date is recorded in the tooltip.

## Note

Upstream `cosmos/chain-registry` still lists pundix as `status: live` with no pending PR; a `status: killed` PR there is a separate follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata update to one zone asset entry; no runtime or bridge logic changes.
> 
> **Overview**
> Marks the **PURSE** zone asset on the **pundix** path (`osmosis.zone_assets.json`) with the usual **source chain killed** handling: `osmosis_unstable`, deposit and withdrawal halts, matching `source_chain_killed` reasons, plus a **tooltip** explaining that PundiXChain was sunset by governance and the IBC path is gone.
> 
> This aligns PURSE with other dead-source assets (e.g. Evmos, e-Money) so the UI and halt logic treat deposits and withdrawals as disabled. Only this unlisted PURSE entry changes; **PUNDIX** on the fxcore/Ethereum path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b1ae280c827abf8030d349bb579a629647f459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->