### PR TITLE
Revert "chore(int3): halt deposits and flag int3 assets unstable"

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6353,12 +6353,7 @@
           "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=dogecoin&fromToken=DOGE.int3"
         }
       ],
-      "_comment": "Dogecoin (Int3) $DOGE.int3",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "_comment": "Dogecoin (Int3) $DOGE.int3"
     },
     {
       "chain_name": "int3face",
@@ -6373,12 +6368,7 @@
           "withdraw_url": "https://app.int3face.zone/bridge"
         }
       ],
-      "_comment": "Bitcoin (Int3) $BTC.int3",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "_comment": "Bitcoin (Int3) $BTC.int3"
     },
     {
       "chain_name": "int3face",
@@ -6395,10 +6385,7 @@
       ],
       "_comment": "Bitcoin Cash (Int3) $BCH.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "int3face",
@@ -6415,10 +6402,7 @@
       ],
       "_comment": "Litecoin (Int3) $LTC.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "axelar",
@@ -6577,10 +6561,7 @@
       },
       "_comment": "Litecoin $LTC",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "osmosis",
@@ -6593,10 +6574,7 @@
       },
       "_comment": "Bitcoin Cash $BCH",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "mantrachain",
@@ -6827,10 +6805,7 @@
       },
       "_comment": "Toncoin (Int3) $TON.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "fetchhub",
@@ -7585,12 +7560,7 @@
           "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=solana&fromToken=SOL.int3"
         }
       ],
-      "_comment": "Solana (Int3) $SOL.int3",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "_comment": "Solana (Int3) $SOL.int3"
     },
     {
       "chain_name": "atomone",
@@ -7612,12 +7582,7 @@
           "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=xrpl&fromToken=XRP.int3"
         }
       ],
-      "_comment": "Ripple (xrpl via Int3) $XRP.xrpl.int3",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "_comment": "Ripple (xrpl via Int3) $XRP.xrpl.int3"
     },
     {
       "chain_name": "migaloo",
@@ -7812,10 +7777,7 @@
       ],
       "_comment": "Pudgy Penguins (Int3) $PENGU.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "int3face",
@@ -7835,10 +7797,7 @@
       ],
       "_comment": "Official Trump (Int3) $TRUMP.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "qfs",
@@ -7884,10 +7843,7 @@
       ],
       "_comment": "Official Trump $TRUMP",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "osmosis",
@@ -7910,10 +7866,7 @@
       },
       "_comment": "Pudgy Penguins $PENGU",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "neutron",
@@ -8024,10 +7977,7 @@
       ],
       "_comment": "Zcash (Int3) $ZEC.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down. Deposits are disabled. Please withdraw your int3 assets back to their native chains."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "osmosis",
@@ -8050,10 +8000,7 @@
       },
       "_comment": "Zcash $ZEC",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down. Deposits are disabled. Please withdraw and redeem your holdings."
+      "osmosis_unstable_reason": "market"
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
Reverts osmosis-labs/assetlists#3556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enabling deposits and removing planned-shutdown flags for bridge-backed assets affects how Osmosis surfaces transfer risk; wrong metadata could mislead users if the Int3 wind-down is still in effect.
> 
> **Overview**
> Reverts the Int3face wind-down treatment from `osmosis.zone_assets.json`, undoing deposit halts and shutdown messaging that were added for Int3-backed assets.
> 
> For **DOGE.int3**, **BTC.int3**, **SOL.int3**, and **XRP.xrpl.int3**, it removes `osmosis_unstable`, `osmosis_halt_deposits`, `osmosis_deposit_halt_reason: planned_shutdown`, and the Int3face bridge wind-down `tooltip_message` entirely so those entries look like normal verified bridge assets again.
> 
> For other Int3 and Int3-only alloyed tokens (e.g. **BCH/LTC** int3 and alloyed, **TON**, **PENGU/TRUMP**, **ZEC**), it drops deposit halts and wind-down tooltips but keeps `osmosis_unstable: true` with `osmosis_unstable_reason` changed from **`manual`** to **`market`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a889864f750cb2f5fb847bacb58f6441b7d529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->