### PR TITLE
Halt SEI/OIN/SEIYAN deposits and withdrawals (Sei IBC closed)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2758,7 +2758,13 @@
       "base_denom": "usei",
       "path": "transfer/channel-782/usei",
       "osmosis_verified": true,
-      "tooltip_message": "SEI Transfers will be disabled with the upcoming SIP Upgrade, estimated at the end of Q1 2026. For more information see: https://blog.sei.io/announcements/the-sip-3-upgrade-making-way-for-sei-giga/",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Sei disabled IBC transfers with the SIP-3 / Sei Giga upgrade (governance proposal 116, passed 12 May 2026). The channel is closed, so SEI deposits and withdrawals are disabled. Sei is now an EVM-only chain. For more information see: https://blog.sei.io/announcements/the-sip-3-upgrade-making-way-for-sei-giga/",
       "_comment": "Sei $SEI"
     },
     {
@@ -3082,6 +3088,13 @@
       "base_denom": "factory/sei1thgp6wamxwqt7rthfkeehktmq0ujh5kspluw6w/OIN",
       "path": "transfer/channel-782/factory/sei1thgp6wamxwqt7rthfkeehktmq0ujh5kspluw6w/OIN",
       "osmosis_verified": false,
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Sei disabled IBC transfers with the SIP-3 / Sei Giga upgrade (governance proposal 116, passed 12 May 2026). The channel is closed, so deposits and withdrawals are disabled. Sei is now an EVM-only chain. For more information see: https://blog.sei.io/announcements/the-sip-3-upgrade-making-way-for-sei-giga/",
       "_comment": "OIN STORE OF VALUE $OIN"
     },
     {
@@ -4075,6 +4088,13 @@
       "path": "transfer/channel-782/cw20:sei1hrndqntlvtmx2kepr0zsfgr7nzjptcc72cr4ppk4yav58vvy7v3s4er8ed",
       "osmosis_verified": false,
       "osmosis_unlisted": true,
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Sei disabled IBC transfers with the SIP-3 / Sei Giga upgrade (governance proposal 116, passed 12 May 2026). The channel is closed, so deposits and withdrawals are disabled. Sei is now an EVM-only chain. For more information see: https://blog.sei.io/announcements/the-sip-3-upgrade-making-way-for-sei-giga/",
       "categories": [
         "meme"
       ],


### PR DESCRIPTION
## What

Marks the three assets that route over the Sei IBC channel (`channel-782`) as bridge-down, halting both deposits and withdrawals:

- `usei` (Sei $SEI)
- `factory/sei1thgp.../OIN` (OIN Store of Value)
- `cw20:sei1hrnd...` (SEIYAN, already `osmosis_unlisted`)

Each entry now carries:

```json
"osmosis_unstable": true,
"osmosis_unstable_reason": "ibc_client",
"osmosis_halt_deposits": true,
"osmosis_deposit_halt_reason": "bridge_down",
"osmosis_halt_withdrawals": true,
"osmosis_withdrawal_halt_reason": "bridge_down"
```

The prior future-tense SEI tooltip ("will be disabled with the upcoming SIP Upgrade") is replaced with a past-tense closure notice.

## Why

Sei disabled IBC transfers via governance proposal 116 (passed 12 May 2026) as part of the SIP-3 / Sei Giga transition to an EVM-only chain. The channel is closed in both directions, so nothing can deposit or withdraw. Reference: https://www.mintscan.io/sei/proposals/116 and https://blog.sei.io/announcements/the-sip-3-upgrade-making-way-for-sei-giga/

## User-facing behaviour

Deposit and Withdraw buttons for SEI, OIN, and SEIYAN are greyed out, the bridge flow blocks both directions, and the tooltip explains why with a link to the Sei announcement.

## Scope

Source-file edit only (`osmosis-1/osmosis.zone_assets.json`). Generated files are produced by CI. The `bridge_down` reason matches the existing convention (e.g. the Gravity Bridge / pSTAKE entry).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only updates to asset metadata and user-facing bridge halts; no application logic changes.
> 
> **Overview**
> Reflects the **closed Sei IBC channel** (`channel-782`) after SIP-3 / Sei Giga by marking **SEI (`usei`)**, **OIN**, and **SEIYAN** in `osmosis.zone_assets.json` as unstable (`ibc_client`) and halting **deposits and withdrawals** with `bridge_down` reasons.
> 
> For native SEI, the change **replaces** the old upcoming-SIP warning tooltip with a closure notice (proposal 116, channel closed, EVM-only Sei). OIN and SEIYAN get the same halt flags and tooltip; SEIYAN keeps `osmosis_unlisted`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dae8e984e885dc525233b1a369f23ad49bfd4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->