### PR TITLE
Halt FX/PUNDIX deposits and withdrawals (fxcore chain killed)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3266,7 +3266,12 @@
       ],
       "_comment": "Function X $FX",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Pundi X Chain (FXCore) ceased operations on 1 March 2026 following governance proposal 76 (https://pundiscan.io/fxcore/proposals/76) and migrated to Ethereum. The chain no longer produces blocks and bridging is halted, so deposits and withdrawals are disabled. For more information see: https://medium.com/pundix/pundi-x-chain-to-cease-operations-on-1-march-2026-and-migrate-to-ethereum-4370c7edde4f"
     },
     {
       "chain_name": "nomic",
@@ -4190,6 +4195,13 @@
         "base_denom": "0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38"
       },
       "osmosis_verified": false,
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Pundi X Chain (FXCore) ceased operations on 1 March 2026 following governance proposal 76 (https://pundiscan.io/fxcore/proposals/76) and migrated to Ethereum. The chain no longer produces blocks and bridging is halted, so deposits and withdrawals are disabled. For more information see: https://medium.com/pundix/pundi-x-chain-to-cease-operations-on-1-march-2026-and-migrate-to-ethereum-4370c7edde4f",
       "categories": [
         "depin"
       ],


### PR DESCRIPTION
## What

Marks both fxcore-origin assets as `source_chain_killed`, halting deposits and withdrawals:

- `FX` (Function X) — `transfer/channel-2716/FX`
- `PUNDIX` (Pundi X Token, canonical Ethereum) — `transfer/channel-2716/eth0x0FD1...`

Each entry now carries:

```json
"osmosis_unstable": true,
"osmosis_unstable_reason": "source_chain_killed",
"osmosis_halt_deposits": true,
"osmosis_deposit_halt_reason": "source_chain_killed",
"osmosis_halt_withdrawals": true,
"osmosis_withdrawal_halt_reason": "source_chain_killed"
```

FX previously had only `osmosis_unstable_reason: market`; PUNDIX had no halt flags.

## Why

The Pundi X Chain (fxcore) ceased operations on **1 March 2026** following governance proposal 76, migrating to Ethereum. After that date the chain no longer produces blocks and bridging to/from it is halted, so both assets are unreachable over their only Osmosis route (`channel-2716`).

- Proposal: https://pundiscan.io/fxcore/proposals/76
- Announcement: https://medium.com/pundix/pundi-x-chain-to-cease-operations-on-1-march-2026-and-migrate-to-ethereum-4370c7edde4f

## Notes

- `source_chain_killed` (not `bridge_down`) because the chain itself was shut down by governance and stopped producing blocks, matching the existing Evmos convention. `bridge_down` is reserved for a closed channel on a still-live chain.
- PUNDIX's `canonical: ethereum` records token origin only; its sole route into Osmosis is the fxcore IBC path, so it is also unreachable.
- Chain registry still lists `fxcore` as `status: live` (registry lag); the assetlist halt flags are the operative kill switch.

## Scope

Source-file edit only (`osmosis-1/osmosis.zone_assets.json`). Generated files are produced by CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON metadata-only changes to asset halt flags; no application logic or funds movement, aligned with an existing `source_chain_killed` pattern.
> 
> **Overview**
> Updates **`osmosis-1/osmosis.zone_assets.json`** so fxcore-routed **FX** and **PUNDIX** are treated like other dead-source-chain assets (e.g. Evmos): deposits and withdrawals are halted with reason `source_chain_killed`, plus a user-facing `tooltip_message` about FXCore shutdown and migration to Ethereum.
> 
> For **FX**, `osmosis_unstable_reason` changes from **`market`** to **`source_chain_killed`**, and deposit/withdrawal halt flags are added. For **PUNDIX**, the same halt/unstable fields are newly set (it previously had no halt flags despite fxcore being its only Osmosis IBC path).
> 
> This is metadata-only in the zone asset list; CI regenerates downstream assetlist files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ac454b25273c5d5f520908f5120e2a6872959b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->