### PR TITLE
Re-path Hippo Protocol to channel-110277 and relist

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -7781,15 +7781,9 @@
     {
       "chain_name": "hippoprotocol",
       "base_denom": "ahp",
-      "path": "transfer/channel-104931/ahp",
+      "path": "transfer/channel-110277/ahp",
       "osmosis_verified": false,
-      "_comment": "Hippo Protocol $HP",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "_comment": "Hippo Protocol $HP"
     },
     {
       "chain_name": "int3face",


### PR DESCRIPTION
## What

Updates the Hippo Protocol (`HP`) listing to the new IBC channel and removes the prior halt:

- Path: `transfer/channel-104931/ahp` → `transfer/channel-110277/ahp`
- Removed `osmosis_unstable` / `osmosis_unstable_reason: ibc_client`
- Removed `osmosis_halt_deposits` / `osmosis_halt_withdrawals` (`bridge_down`)

## Why

The chain registry re-pathed the Osmosis↔hippoprotocol IBC connection from `channel-104931` to `channel-110277` in [cosmos/chain-registry #7722](https://github.com/cosmos/chain-registry/pull/7722). The assetlist still referenced the old channel, so `validate_zone_data` failed with `IBC Channel for Path: transfer/channel-104931/ahp does not exist in the chain registry` once CI pulled the fresh registry.

On-chain supply confirms the new channel is the live one:

| Denom | Channel | Supply |
|-------|---------|--------|
| `ibc/955E…` | channel-104931 (old) | 0.1 HP (dust) |
| `ibc/24C3…` | channel-110277 (new) | ~1.01 HP (live) |

The original channel had an IBC-client issue (which is why it was flagged `ibc_client` / `bridge_down` and why the registry re-pathed it). The new channel is `ACTIVE`/`preferred` in the registry and prices via SQS, so this is relisted as a clean entry over the working channel.

## Validation

`node .github/workflows/utility/validate_zone_data.mjs osmosis-1` exits 0 with no errors against the current chain registry (the `channel-104931` error is resolved).

## Scope

Source-file edit only (`osmosis-1/osmosis.zone_assets.json`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON listing update for IBC metadata and halt flags; no application or auth logic changes.
> 
> **Overview**
> Updates the **Hippo Protocol** (`ahp` / HP) zone asset to the registry’s new Osmosis↔hippoprotocol IBC route: `transfer/channel-104931/ahp` → **`transfer/channel-110277/ahp`**, so `validate_zone_data` matches the current chain registry.
> 
> Clears the prior **bridge-down** posture by removing `osmosis_unstable` (`ibc_client`) and deposit/withdrawal halt flags, effectively **relisting** HP on the active channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b48b8a90ea19f2d926018d7bbc2c0ade95d1bf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->