### PR TITLE
Halt deposits and withdrawals for Quicksilver assets (chain halted)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1898,7 +1898,12 @@
       ],
       "_comment": "Quicksilver Liquid Staked STARS $qSTARS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "juno",
@@ -2043,7 +2048,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked ATOM $qATOM"
+      "_comment": "Quicksilver Liquid Staked ATOM $qATOM",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "comdex",
@@ -2070,7 +2082,12 @@
       ],
       "_comment": "Quicksilver Liquid Staked Regen $qREGEN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "juno",
@@ -2089,7 +2106,12 @@
       ],
       "_comment": "Quicksilver $QCK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "arkh",
@@ -2114,7 +2136,12 @@
       ],
       "_comment": "Quicksilver Liquid Staked OSMO $qOSMO",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "noble",
@@ -2777,7 +2804,12 @@
       ],
       "_comment": "Quicksilver Liquid Staked SOMM $qSOMM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "passage",
@@ -4749,7 +4781,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked JUNO $qJUNO"
+      "_comment": "Quicksilver Liquid Staked JUNO $qJUNO",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -4759,7 +4798,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked SAGA $qSAGA"
+      "_comment": "Quicksilver Liquid Staked SAGA $qSAGA",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -4769,7 +4815,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked DYDX $qDYDX"
+      "_comment": "Quicksilver Liquid Staked DYDX $qDYDX",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -4779,7 +4832,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked BLD $qBLD"
+      "_comment": "Quicksilver Liquid Staked BLD $qBLD",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "composable",
@@ -7006,7 +7066,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked ARCH $qARCH"
+      "_comment": "Quicksilver Liquid Staked ARCH $qARCH",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -7016,7 +7083,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked PICA $qPICA"
+      "_comment": "Quicksilver Liquid Staked PICA $qPICA",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -7026,7 +7100,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked TIA $qTIA"
+      "_comment": "Quicksilver Liquid Staked TIA $qTIA",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -7036,7 +7117,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked FLIX $qFLIX"
+      "_comment": "Quicksilver Liquid Staked FLIX $qFLIX",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -7046,7 +7134,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked LUNA $qLUNA"
+      "_comment": "Quicksilver Liquid Staked LUNA $qLUNA",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "quicksilver",
@@ -7056,7 +7151,14 @@
       "categories": [
         "liquid_staking"
       ],
-      "_comment": "Quicksilver Liquid Staked INJ $qINJ"
+      "_comment": "Quicksilver Liquid Staked INJ $qINJ",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## What

Manually halts deposits and withdrawals for all **16 Quicksilver-origin assets** while the chain is down. Each entry gets:

```json
"osmosis_unstable": true,
"osmosis_unstable_reason": "manual",
"osmosis_halt_deposits": true,
"osmosis_deposit_halt_reason": "manual",
"osmosis_halt_withdrawals": true,
"osmosis_withdrawal_halt_reason": "manual",
"tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
```

Assets: qSTARS, qATOM, qREGEN, QCK, qOSMO, qSOMM, qJUNO, qSAGA, qDYDX, qBLD, qARCH, qPICA, qTIA, qFLIX, qLUNA, qINJ.

## Why

The Quicksilver chain is currently **halted** — confirmed via two independent LCDs: last block `18556563` is frozen (timestamp ~2.5h stale, node reports `syncing: false`, tip not advancing). Deposits/withdrawals over its IBC channels can't settle, so both directions are gated.

## Reason choice

`manual` (not `bridge_down` or `source_chain_killed`) because this is a **temporary operator halt of a still-existing chain**, distinct from a closed channel (bridge_down) or a dead chain (source_chain_killed). Intended to be **lifted once the chain resumes producing blocks**.

The prior `osmosis_unstable_reason: "market"` on six of the assets is overwritten to `manual` so the whole set reads consistently as halted; revert simply restores the flags.

## Validation

`node .github/workflows/utility/validate_zone_data.mjs osmosis-1` exits 0 with no errors. Diff is scoped to the 16 Quicksilver entries only (no reordering of other assets).

## Scope

Source-file edit only (`osmosis-1/osmosis.zone_assets.json`). **Temporary** — should be reverted when Quicksilver recovers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON metadata only—no application logic; affects user-facing deposit/withdrawal gating and messaging for Quicksilver assets until reverted.
> 
> **Overview**
> **Temporarily gates all 16 Quicksilver IBC assets** on Osmosis while the source chain is halted: deposits and withdrawals are disabled with `manual` halt reasons, assets are marked unstable (`osmosis_unstable_reason` changed from `market` to `manual` where it applied), and a shared **`tooltip_message`** explains the outage to users.
> 
> Coverage includes liquid-staking tokens (e.g. qATOM, qOSMO, QCK) and previously unflagged entries (e.g. qJUNO, qTIA) that now get the same halt/unstable block. **Config-only** change in `osmosis.zone_assets.json`; intended to be reverted when Quicksilver resumes block production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d2a1295b26427131b1e370d91d4495f7c1fac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->