### PR TITLE
Remove stale duplicate Hippo Protocol entry (old channel-104931)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11187,18 +11187,6 @@
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "bridge_down"
-    },
-    {
-      "chain_name": "hippoprotocol",
-      "base_denom": "ahp",
-      "path": "transfer/channel-104931/ahp",
-      "_comment": "Hippo Protocol $HP",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
     }
   ]
 }


### PR DESCRIPTION
## What

Removes the duplicate Hippo Protocol (`ahp`) listing that points at the old IBC channel `channel-104931`. A single clean entry on `channel-110277` remains.

## Why

After the re-path in #3574 (`channel-104931` → `channel-110277`), the **[AUTO] Asset and Chain Update (#3576)** re-appended the old-channel entry, with the prior `bridge_down` halt flags, as the last asset in the array. This left two `ahp` entries, which the generator disambiguated in the frontend as `HP` and `HP.hippoprotocol`.

The old channel was replaced upstream in [cosmos/chain-registry #7722](https://github.com/cosmos/chain-registry/pull/7722) and holds only dust (~0.1 HP); the live asset is on `channel-110277` (~1.01 HP). The duplicate is a merge-ordering artifact: #3576 was generated against a pre-re-path snapshot and merged on top of the fix.

## Will it come back?

No. `generate_assetlist.mjs` builds the IBC path from the chain registry's **default channel** (`getAssetsFromChainRegistry`, `getIBCFileProperty(...).channels` → the transfer/transfer channel). The registry now only has `channel-110277`, so the generator can only ever produce that path. There is no on-chain-supply auto-add path that would resurrect `channel-104931`.

## Validation

`node .github/workflows/utility/validate_zone_data.mjs osmosis-1` exits 0. Exactly one `hippoprotocol` `ahp` entry remains (on `channel-110277`); diff is a clean 12-line deletion, no other entries touched.

## Scope

Source-file edit only (`osmosis-1/osmosis.zone_assets.json`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON deletion of a duplicate asset entry; no change to the active channel-110277 listing or runtime logic.
> 
> **Overview**
> Removes a **duplicate** Hippo Protocol (`ahp`) row from `osmosis.zone_assets.json` that still pointed at the obsolete IBC path `transfer/channel-104931/ahp` and carried `bridge_down` halt flags.
> 
> The live listing on `channel-110277` is unchanged; this edit only drops the stale duplicate that was re-introduced after the channel re-path, so the UI no longer shows two `ahp` assets (e.g. `HP` vs `HP.hippoprotocol`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277343dbf65112bf4b000597e2cc54c3319ada85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->