### PR TITLE
Surface newly-added manual halts in daily PR summary

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -48,6 +48,16 @@ jobs:
           # sequence, so we snapshot once here and diff once at the end.
           cp osmosis-1/osmosis.zone_assets.json /tmp/zone-before.json
 
+          # Manual halts are applied by human PRs, not lifecycle scripts, so
+          # they never appear in the in-run before/after diff. To surface
+          # "newly halted this run", capture the previous run's manual-halt
+          # chain set, which is persisted as state.json's top-level
+          # manualHaltChains key (committed by the prior run). Missing on the
+          # first run after this lands, in which case the delta is empty.
+          jq -r '(.manualHaltChains // []) | sort | .[]' \
+            osmosis-1/generated/state/state.json 2>/dev/null \
+            > /tmp/manual-halts-prev.txt || touch /tmp/manual-halts-prev.txt
+
       - name: Check IBC Client Status
         working-directory: ./.github/workflows/utility
         run: |
@@ -228,6 +238,28 @@ jobs:
         working-directory: ./.github/workflows/utility
         run: node update_assetlist_state.mjs
 
+      - name: Persist manual-halt chain set to state
+        run: |
+          # Record the current set of chains with any manual halt as a
+          # top-level state.json key so the next run can diff against it to
+          # surface "newly halted this run" (see the Snapshot step). A chain
+          # counts as manual if its overall unstable reason or either
+          # per-direction halt reason is "manual". Distinct chains, sorted.
+          jq -r '
+            [ .assets[]
+              | select(
+                  (.osmosis_unstable_reason == "manual")
+                  or (.osmosis_deposit_halt_reason == "manual")
+                  or (.osmosis_withdrawal_halt_reason == "manual")
+                )
+              | .chain_name
+            ] | sort | unique
+          ' osmosis-1/osmosis.zone_assets.json > /tmp/manual-halts-now.json
+          jq --slurpfile mh /tmp/manual-halts-now.json \
+            '.manualHaltChains = $mh[0]' \
+            osmosis-1/generated/state/state.json > /tmp/state-with-mh.json
+          mv /tmp/state-with-mh.json osmosis-1/generated/state/state.json
+
       - name: Report Dead Chains and Planned Shutdowns
         working-directory: ./.github/workflows/utility
         run: |
@@ -311,7 +343,15 @@ jobs:
                 or (.osmosis_withdrawal_halt_reason == "manual")
               ))
             | map(.chain_name) | unique | .[]
-          ' osmosis-1/osmosis.zone_assets.json 2>/dev/null > /tmp/lc-manualHalts.txt && echo ok || echo err)
+          ' osmosis-1/osmosis.zone_assets.json 2>/dev/null | sort > /tmp/lc-manualHalts.txt && echo ok || echo err)
+
+          # Newly halted this run: chains in the current manual-halt set that
+          # were not in the previous run's persisted set. This is the delta a
+          # human PR (e.g. pausing Quicksilver) produces; the standing row
+          # below shows everything currently halted.
+          comm -13 /tmp/manual-halts-prev.txt /tmp/lc-manualHalts.txt \
+            > /tmp/lc-manualHaltsNew.txt 2>/dev/null || touch /tmp/lc-manualHaltsNew.txt
+          emit_row "🆕" "Manual halts added this run" /tmp/lc-manualHaltsNew.txt name
           emit_row "⚠️" "Manual halts in effect" /tmp/lc-manualHalts.txt name
 
           emit_row "⏸️" "Extended halt set" /tmp/lc-extendedHaltSet.txt symbol


### PR DESCRIPTION
## Problem

The daily auto-PR's **Quick summary** had two issues with manual halts, both noticed when Quicksilver was paused:

1. **Newly-paused chains weren't called out.** The `Manual halts in effect` row is a full current-state list (jq over `zone_assets.json`), unlike every other row, which is a *this-run delta*. Manual halts are applied by human PRs, which never write the lifecycle delta files (`/tmp/lc-*.txt`), so a newly paused chain (Quicksilver) blended in with standing halts (gravitybridge, persistence) with no "new this run" signal.
2. **Odd/inconsistent formatting.** That row lists chain names and is a state snapshot dropped among delta rows.

## Change

- **Persist** the manual-halt chain set into `state.json` as a top-level `manualHaltChains` key each run (new step after `update_assetlist_state`). This gives the next run a cross-run baseline (manual halts come from human PRs between runs, so an in-run before/after diff would always be empty).
- **Add a `🆕 Manual halts added this run` delta row** that diffs the prior run's persisted set against the current set (`comm -13`), placed just above the existing `⚠️ Manual halts in effect` standing row (kept for reference).
- Sort the standing-list jq output so `comm` can diff it.

A chain counts as manual if its overall unstable reason **or** either per-direction halt reason is `manual` (matches the existing standing-row logic).

## Behaviour

- **First run after merge:** `manualHaltChains` is absent, so the prior set is empty and all current manual halts show as "added this run" once. Self-corrects on the next run.
- **Steady state:** only genuinely new manual halts (e.g. the day a chain like Quicksilver is paused) appear in the new row; the standing row keeps the full list.

## Validation

- `generate_all_files.yml` parses as valid YAML.
- Both added `jq` expressions verified against the live `zone_assets.json` and `state.json`: persist writes `manualHaltChains`, prev-read round-trips it sorted, and `comm -13` correctly isolates a newly-added chain (simulated: prev = {gravitybridge, persistence}, now adds quicksilver → delta = quicksilver only).

## Scope

CI workflow only (`.github/workflows/generate_all_files.yml`). No asset-data or generated-output changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and a new optional `state.json` field; no changes to asset validation logic or runtime behavior beyond summary text and committed state metadata.
> 
> **Overview**
> The daily **Generate All Files** workflow now tracks **manual halt** chains across runs so the PR **Quick summary** can show a delta, not only the full current list.
> 
> At the start of a run it reads the prior run’s `manualHaltChains` from `osmosis-1/generated/state/state.json`. After `update_assetlist_state`, a new step writes the current manual-halt chain set (from `zone_assets.json`, same `manual` reason rules as before) back into `state.json` as `manualHaltChains` for the next run.
> 
> The summary adds a **🆕 Manual halts added this run** row via `comm` against that persisted baseline, above the existing **⚠️ Manual halts in effect** snapshot; the standing list is **sorted** so the diff is reliable. The first run after merge may list all current manual halts as “added” once if the key is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 363f572af42373a47b1bae7ef1e25410c688e85d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->