### PR TITLE
feat(osmosis-1): flag all Gravity Bridge assets manual, lock new assets on fully-manual chains

### DIFF
--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -119,6 +119,14 @@ function isThinEntry(asset) {
 const OWNED_HALT_REASONS = new Set(['bridge_down', 'source_chain_killed']);
 const OWNED_UNSTABLE_REASONS = new Set(['ibc_client', 'source_chain_killed']);
 
+// Tooltip stamped on assets auto-created as manual because their source
+// chain is already fully manually halted (see buildManualHaltChains). The
+// tooltip both informs users and, via canModify*, locks the entry so the
+// same automation cannot later auto-clear it on a transient Active reading.
+const MANUAL_CHAIN_INHERIT_TOOLTIP =
+  'This asset appeared on a source chain whose transfers are manually halted. ' +
+  'Deposits and withdrawals are halted pending manual review.';
+
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
 function sleep(ms) {
@@ -370,6 +378,54 @@ function canModifyUnstable(zoneAsset) {
 }
 
 /**
+ * Is this asset curator-locked under a manual halt? True when a curator has
+ * taken explicit ownership: the unstable reason is 'manual', either halt
+ * reason is 'manual', or a tooltip_message is set (which locks all
+ * automation via canModify*). Used to detect chains the curator has fully
+ * taken over so new assets that appear on them inherit the same treatment.
+ */
+function isManuallyLocked(zoneAsset) {
+  return (
+    zoneAsset.osmosis_unstable_reason === 'manual' ||
+    zoneAsset.osmosis_deposit_halt_reason === 'manual' ||
+    zoneAsset.osmosis_withdrawal_halt_reason === 'manual' ||
+    Boolean(zoneAsset.tooltip_message)
+  );
+}
+
+/**
+ * Build the set of source chains the curator has fully taken over with
+ * manual halts, from the PRE-RUN zone state. A chain qualifies when it has
+ * at least one listed asset AND every one of its listed assets is
+ * manually locked (isManuallyLocked).
+ *
+ * Why this matters (attack-vector guard): when a bridge or source chain is
+ * compromised, a curator halts every known asset manually. But a
+ * compromised chain can begin advertising NEW assets in the chain registry.
+ * Those flow into the generated assetlist and this script would otherwise
+ * auto-create them with the script-owned 'ibc_client'/'bridge_down' reasons,
+ * which the same automation will happily auto-CLEAR the moment the client
+ * reports Active again, silently relisting an attacker-introduced asset on a
+ * still-compromised bridge. Treating new assets on a fully-manual chain as
+ * manual too keeps them locked until a human clears them.
+ */
+function buildManualHaltChains(assets) {
+  const byChain = new Map(); // chain_name -> { total, locked }
+  for (const a of assets) {
+    if (!a.chain_name) continue;
+    const c = byChain.get(a.chain_name) ?? { total: 0, locked: 0 };
+    c.total += 1;
+    if (isManuallyLocked(a)) c.locked += 1;
+    byChain.set(a.chain_name, c);
+  }
+  const fullyManual = new Set();
+  for (const [chain, c] of byChain) {
+    if (c.total > 0 && c.locked === c.total) fullyManual.add(chain);
+  }
+  return fullyManual;
+}
+
+/**
  * Best-effort classification of *why* an asset is unstable, used by the
  * safety-net paths when we don't have channel-walk evidence in hand.
  * Returns the most specific script-owned reason that can be proved from
@@ -456,6 +512,13 @@ async function main() {
   for (const asset of zoneData.assets) {
     if (asset.path) zoneByPath.set(asset.path, asset);
   }
+
+  // Snapshot, from PRE-RUN state, the chains the curator has fully taken
+  // over with manual halts. New assets the channel walk discovers on these
+  // chains will be created as manual (curator-locked) rather than with the
+  // auto-clearable ibc_client/bridge_down reasons. Computed once here, before
+  // any mutation, so assets this run appends don't perturb the membership.
+  const manualHaltChains = buildManualHaltChains(zoneData.assets);
 
   // Group frontend IBC assets by Osmosis-side channel id, but record
   // the counterparty (chainName, channelId, port) on each asset entry
@@ -624,6 +687,7 @@ async function main() {
 
       if (bridgeDown) {
         // ── Bridge-down ────────────────────────────────────────────────────
+        const isNewEntry = !zoneAsset;
         if (!zoneAsset) {
           zoneAsset = {
             chain_name: fa.chainName,
@@ -633,6 +697,37 @@ async function main() {
           };
           zoneData.assets.push(zoneAsset);
           zoneByPath.set(fa.ibcPath, zoneAsset);
+        }
+
+        // Attack-vector guard: a brand-new asset that first appears on a
+        // source chain the curator has already fully manually halted is
+        // created manual (curator-locked) rather than with the script-owned
+        // ibc_client/bridge_down reasons. Stamping the manual reasons plus a
+        // tooltip makes every canModify* gate below short-circuit, so this
+        // run leaves it as written AND no future run can auto-clear it on a
+        // transient Active reading. A human must clear it deliberately.
+        // Pre-existing entries are never converted here — only newly created
+        // ones — so this can't silently rewrite a curator's existing choice.
+        if (isNewEntry && manualHaltChains.has(fa.chainName)) {
+          zoneAsset.osmosis_unstable = true;
+          zoneAsset.osmosis_unstable_reason = 'manual';
+          zoneAsset.osmosis_halt_deposits = true;
+          zoneAsset.osmosis_deposit_halt_reason = 'manual';
+          zoneAsset.osmosis_halt_withdrawals = true;
+          zoneAsset.osmosis_withdrawal_halt_reason = 'manual';
+          zoneAsset.tooltip_message = MANUAL_CHAIN_INHERIT_TOOLTIP;
+          applyDowntimeDateRule(
+            stateAsset ?? materialiseStateAsset(state, fa.coinMinimalDenom),
+            nowIso
+          );
+          mutations.push({
+            kind: 'manual_inherited',
+            fa,
+            reason: 'manual',
+            haltReason: 'manual',
+            zoneAsset,
+          });
+          continue;
         }
 
         const before = { ...zoneAsset };
@@ -866,9 +961,12 @@ async function main() {
   console.log(`  distinct source chains touched: ${affectedChains.size}`);
   console.log('='.repeat(70));
 
-  // Machine-readable summary
-  console.log(`\nIBC_NEWLY_FLAGGED=${byKind.bridge_down ?? 0}`);
+  // Machine-readable summary. manual_inherited assets are a flag event
+  // (a new asset locked down), so they roll into NEWLY_FLAGGED and also get
+  // their own counter for visibility in the PR summary.
+  console.log(`\nIBC_NEWLY_FLAGGED=${(byKind.bridge_down ?? 0) + (byKind.manual_inherited ?? 0)}`);
   console.log(`IBC_NEWLY_CLEARED=${(byKind.bridge_up ?? 0) + (byKind.thin_removed ?? 0)}`);
+  console.log(`IBC_MANUAL_INHERITED=${byKind.manual_inherited ?? 0}`);
   console.log(`IBC_ERRORS=${byKind.ibc_error ?? 0}`);
   console.log(`AFFECTED_CHAINS=${affectedChains.size}`);
 }

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -640,11 +640,12 @@
       ],
       "_comment": "Gravity Bridge $GRAV",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "decentr",
@@ -853,7 +854,9 @@
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -873,7 +876,9 @@
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -896,7 +901,9 @@
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -919,7 +926,9 @@
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -942,7 +951,9 @@
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "juno",
@@ -3626,11 +3637,12 @@
       ],
       "_comment": "Page $PAGE",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market",
+      "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "pundix",
@@ -4474,7 +4486,9 @@
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits are halted while the situation is assessed."
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "migaloo",
@@ -11216,11 +11230,12 @@
       "path": "transfer/channel-144/gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
       "_comment": "pSTAKE Finance (Gravity Bridge) $PSTAKE.grv",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -11228,11 +11243,12 @@
       "path": "transfer/channel-144/gravity0x83F20F44975D03b1b09e64809B757c47f942BEeA",
       "_comment": "Savings Dai (Gravity Bridge) $sDAI.grv",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     },
     {
       "chain_name": "gravitybridge",
@@ -11240,11 +11256,12 @@
       "path": "transfer/channel-144/gravity0x2F109021aFe75B949429fe30523Ee7C0D5B27207",
       "_comment": "OccamFi (Gravity Bridge) $OCC.grv",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
     }
   ]
 }


### PR DESCRIPTION
## What

Bring **every Gravity Bridge asset** under a single, consistent manual halt, and add a guard so the IBC health-check can't auto-list new assets on an already-fully-halted chain with an auto-clearable reason.

### Data (`osmosis.zone_assets.json`)

All 11 `gravitybridge` assets now carry `osmosis_unstable_reason: manual`, both deposit and withdrawal halts (`bridge_down`), and a both-directions tooltip:

- **GRAV, PSTAKE.grv, sDAI.grv, OCC.grv**: `ibc_client` → `manual`. The latter three were auto-added by `check_ibc_clients.mjs` when the chain registry began advertising them while `channel-144`'s client was expired; GRAV was auto-flagged the same way.
- **PAGE**: `market` → `manual` (it lives on Gravity Bridge, so folding it in makes the chain unambiguously fully-manual).
- **WBTC/ETH/USDC/DAI/USDT/PAXG**: previously deposit-only manual halts; withdrawal halts added to match.

### Script (`check_ibc_clients.mjs`)

When the channel walk discovers a **brand-new** asset on a source chain whose every listed asset is already manually locked, it is now created `manual` (curator-locked, with a tooltip) rather than with the script-owned `ibc_client`/`bridge_down` reasons.

## Why

When a bridge or source chain is compromised, a curator halts every known asset manually. But a compromised chain can begin advertising **new** assets in the chain registry. Those flow into the generated assetlist, and the health check would otherwise auto-create them with `ibc_client`/`bridge_down` — reasons the same automation will happily **auto-clear** the moment the client reports `Active` again, silently relisting an attacker-introduced asset on a still-compromised bridge.

Stamping new assets on a fully-manual chain as `manual` (plus a tooltip, which locks every `canModify*` gate) keeps them halted until a human clears them deliberately. Only newly created entries are affected; pre-existing curator choices are never rewritten.

## Behaviour change

- Withdrawals on WBTC/ETH/USDC/DAI/USDT/PAXG (Gravity) are now halted in addition to deposits.
- PAGE no longer auto-recovers via the market track; it is now a manual halt like the rest of the chain.
- New Gravity Bridge assets appearing in the registry will be created halted (`manual`) and will not auto-clear.

## Tests / verification

- `node --check check_ibc_clients.mjs` — clean.
- Unit assertions on the new `buildManualHaltChains` / `isManuallyLocked` helpers (all-manual chain qualifies, mixed chain does not, tooltip/reason lock detection) — all pass.
- Schema-enum check on all Gravity entries passes.
- Diff verified to touch only the 11 Gravity entries; no reordering of other assets.

## Risk / notes

- The on-chain effect is purely transfer-halt metadata and stability flags; no routing/pricing/decimal surface is touched.
- The guard's "fully manual" test requires **every** listed asset on the chain to be manual-locked, so it won't fire spuriously on chains with a mix of tracks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transfer-halt and stability metadata for a compromised bridge (user-visible deposit/withdrawal behavior) and alters automation that could otherwise relist new registry assets; logic is scoped to new entries on chains where every asset is already manual-locked.
> 
> **Overview**
> Aligns **all 11 Gravity Bridge** entries in `osmosis.zone_assets.json` under curator-style manual instability, **both-direction** deposit/withdrawal halts, and a shared compromise tooltip—so the chain is **fully manually locked** and won’t be auto-cleared by script-owned `ibc_client` / `bridge_down` reasons.
> 
> **`check_ibc_clients.mjs`** adds an attack-vector guard: before mutations, it snapshots chains where **every** listed asset is manually locked (`isManuallyLocked` / `buildManualHaltChains`). **Brand-new** zone entries discovered on bridge-down for those chains are created with `manual` halt reasons and `MANUAL_CHAIN_INHERIT_TOOLTIP` (locking `canModify*`), instead of auto-clearable script reasons; pre-existing rows are unchanged. Run output adds `IBC_MANUAL_INHERITED` and counts `manual_inherited` in `IBC_NEWLY_FLAGGED`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8daec6c2702d626a2887a14385d09fe4881b99c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->