### PR TITLE
fix(osmosis-1): delist stale Hippo Protocol channel-104931, fix lifecycle-diff channel collision

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -176,14 +176,25 @@ jobs:
           # current zone_assets.json to produce one symbol list per mutation
           # category. Each file is "chain_name|SYMBOL" per line. Symbol is
           # resolved against the freshly-generated frontend assetlist.
+          #
+          # Keying: a single (chain_name, base_denom) pair can be listed on
+          # more than one IBC channel (e.g. a re-pathed asset whose old, dead
+          # channel still lingers in zone_assets). Those entries are distinct
+          # rows that differ only by `path`, so keying on chain_name|base_denom
+          # alone collapses them — the before/after compare and symbol lookup
+          # bleed across channels and produce phantom flagged/cleared lines for
+          # the wrong variant. Key on `path` (unique per IBC entry), falling
+          # back to chain_name|base_denom for non-IBC entries that have no path.
           jq -r --slurpfile fe osmosis-1/generated/frontend/assetlist.json --slurpfile before /tmp/zone-before.json '
-            ($fe[0].assets | map({key: (.chainName + "|" + .sourceDenom), value: .symbol}) | from_entries) as $symByOrigin
-            | ($before[0].assets | map({key: (.chain_name + "|" + .base_denom), value: .}) | from_entries) as $beforeByOrigin
+            def feKey: (([.transferMethods[]? | select(.type == "ibc") | .chain.path] | first) // (.chainName + "|" + .sourceDenom));
+            def zoneKey: (.path // (.chain_name + "|" + .base_denom));
+            ($fe[0].assets | map({key: feKey, value: .symbol}) | from_entries) as $symByOrigin
+            | ($before[0].assets | map({key: zoneKey, value: .}) | from_entries) as $beforeByOrigin
             | .assets as $now
             | $now | map(
                 . as $a
-                | $beforeByOrigin[$a.chain_name + "|" + $a.base_denom] as $b
-                | ($symByOrigin[$a.chain_name + "|" + $a.base_denom] // $a._comment // $a.base_denom) as $sym
+                | $beforeByOrigin[$a | zoneKey] as $b
+                | ($symByOrigin[$a | zoneKey] // $a._comment // $a.base_denom) as $sym
                 | {
                     chain: $a.chain_name,
                     symbol: $sym,

--- a/osmosis-1/generated/asset_detail/assetlist.json
+++ b/osmosis-1/generated/asset_detail/assetlist.json
@@ -5890,15 +5890,6 @@
       "description": "The native staking and governance token of HazinaChain"
     },
     {
-      "base": "ibc/955E5E0BED298F85956121C3BD627CEB12B858A9EB7C1ED24B1515A658318CE4",
-      "name": "Hippo Protocol",
-      "symbol": "HP.hippoprotocol",
-      "description": "The native token of Hippo Protocol.\n\nOne Protocol. Every Patient. Infinite Possibility.",
-      "coingeckoID": "hippo-protocol",
-      "websiteURL": "https://hippoprotocol.ai/",
-      "twitterURL": "https://x.com/Hippo_Protocol"
-    },
-    {
       "base": "ibc/CBC60FC96BD21708D3B60B2E4AD949E0DA07C67EFE6A8D463298806CD507A9CF",
       "name": "pSTAKE Finance (Gravity Bridge)",
       "symbol": "PSTAKE.grv",

--- a/osmosis-1/generated/chain_registry/assetlist.json
+++ b/osmosis-1/generated/chain_registry/assetlist.json
@@ -37049,41 +37049,6 @@
     {
       "denom_units": [
         {
-          "denom": "ibc/955E5E0BED298F85956121C3BD627CEB12B858A9EB7C1ED24B1515A658318CE4",
-          "exponent": 0,
-          "aliases": [
-            "ahp"
-          ]
-        },
-        {
-          "denom": "hp",
-          "exponent": 18
-        }
-      ],
-      "type_asset": "ics20",
-      "base": "ibc/955E5E0BED298F85956121C3BD627CEB12B858A9EB7C1ED24B1515A658318CE4",
-      "name": "Hippo Protocol",
-      "display": "hp",
-      "symbol": "HP",
-      "traces": [
-        {
-          "type": "ibc",
-          "counterparty": {
-            "chain_name": "hippoprotocol",
-            "base_denom": "ahp",
-            "channel_id": "channel-104931"
-          },
-          "chain": {
-            "channel_id": "channel-104931",
-            "path": "transfer/channel-104931/ahp"
-          }
-        }
-      ],
-      "coingecko_id": "hippo-protocol"
-    },
-    {
-      "denom_units": [
-        {
           "denom": "ibc/CBC60FC96BD21708D3B60B2E4AD949E0DA07C67EFE6A8D463298806CD507A9CF",
           "exponent": 0,
           "aliases": [

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -44221,62 +44221,6 @@
       "lastDowntimeDate": "2026-06-09T16:05:28.294Z"
     },
     {
-      "chainName": "hippoprotocol",
-      "sourceDenom": "ahp",
-      "coinMinimalDenom": "ibc/955E5E0BED298F85956121C3BD627CEB12B858A9EB7C1ED24B1515A658318CE4",
-      "symbol": "HP.hippoprotocol",
-      "decimals": 18,
-      "logoURIs": {
-        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/hippoprotocol/images/logo.svg"
-      },
-      "coingeckoId": "hippo-protocol",
-      "categories": [],
-      "transferMethods": [
-        {
-          "name": "Osmosis IBC Transfer",
-          "type": "ibc",
-          "counterparty": {
-            "chainName": "hippoprotocol",
-            "chainId": "hippo-protocol-1",
-            "sourceDenom": "ahp",
-            "port": "transfer",
-            "channelId": "channel-104931"
-          },
-          "chain": {
-            "port": "transfer",
-            "channelId": "channel-104931",
-            "path": "transfer/channel-104931/ahp"
-          }
-        }
-      ],
-      "counterparty": [
-        {
-          "chainName": "hippoprotocol",
-          "sourceDenom": "ahp",
-          "chainType": "cosmos",
-          "chainId": "hippo-protocol-1",
-          "symbol": "HP",
-          "decimals": 18,
-          "logoURIs": {
-            "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/hippoprotocol/images/logo.svg"
-          }
-        }
-      ],
-      "variantGroupKey": "ibc/24C3429B835A84801EFEFC28C8CBDF787C4067D971CB6E510BB525FA462CCE1C",
-      "name": "Hippo Protocol",
-      "isAlloyed": false,
-      "verified": false,
-      "unstable": true,
-      "unstableReason": "ibc_client",
-      "disabled": false,
-      "haltDeposits": true,
-      "depositHaltReason": "bridge_down",
-      "haltWithdrawals": true,
-      "withdrawalHaltReason": "bridge_down",
-      "preview": false,
-      "lastDowntimeDate": "2026-05-22T09:57:52.115Z"
-    },
-    {
       "chainName": "gravitybridge",
       "sourceDenom": "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
       "coinMinimalDenom": "ibc/CBC60FC96BD21708D3B60B2E4AD949E0DA07C67EFE6A8D463298806CD507A9CF",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11199,18 +11199,6 @@
       "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
-      "chain_name": "hippoprotocol",
-      "base_denom": "ahp",
-      "path": "transfer/channel-104931/ahp",
-      "_comment": "Hippo Protocol $HP",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
-    },
-    {
       "chain_name": "gravitybridge",
       "base_denom": "gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
       "path": "transfer/channel-144/gravity0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",


### PR DESCRIPTION
## What

Two related fixes for the duplicate Hippo Protocol listing.

### 1. Delist the stale channel

HP was re-pathed to the live **channel-110277** (the only `ACTIVE`, registry-preferred `osmosis<->hippoprotocol` channel; client `07-tendermint-3711` = `Active`). The superseded **channel-104931** (client `07-tendermint-3519` = `Expired`) is not in the chain registry and holds only dust.

It was manually removed once before, but the **next automated run re-created it**: `check_ibc_clients.mjs` reads the committed frontend assetlist (which still listed channel-104931) before regeneration runs, finds the expired client, finds no matching zone entry, and re-adds it. The prior manual fix only edited `zone_assets.json` and never regenerated the frontend file, so the loop persisted.

This PR removes the `zone_assets.json` entry **and regenerates the assetlists** so the committed frontend no longer carries channel-104931, breaking the resurrection loop. Only the live HP on channel-110277 remains.

### 2. Fix the lifecycle-diff channel collision

The per-mutation lifecycle diff in `generate_all_files.yml` keyed every asset on `chain_name|base_denom`. The two HP entries share that key and differ only by `path`, so `from_entries` collapsed them and the before/after compare leaked across channels, emitting a phantom **"IBC cleared: HP.hippoprotocol"** on runs where nothing about that asset changed.

Now keyed on `path` (unique per IBC entry), with a fallback to `chain_name|base_denom` for non-IBC entries that have no path. Any asset listed on two channels now diffs per channel.

## Why

The dead channel kept resurfacing in the frontend and the summary kept reporting a clear that never happened, both traceable to the same root cause: one subsystem keys on `path`, the other on `chain_name|base_denom`.

## Tests / verification

- Live LCD client status checked for both HP channels (110277 = Active, 104931 = Expired).
- Regenerated assetlist verified: only HP (channel-110277) remains; HP.hippoprotocol/channel-104931 gone from frontend, asset_detail, and chain_registry outputs. No unrelated churn.
- jq program reproduced against fixtures: the **old** key emits `hippoprotocol|HP.hippoprotocol` as a phantom `ibcCleared`; the **new** key emits nothing, while a legitimate new-flag event still fires correctly. jq program compiles and runs.
- YAML parses.

## Risk / notes

- Generated files were produced locally; CI regenerates them authoritatively on merge. The diff was confirmed to contain only the HP removal.
- No routing/pricing surface touched; this is a listing removal plus a reporting-key fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Listing cleanup and CI reporting-key fix; live HP on channel-110277 is unchanged and routing/pricing surfaces are not modified.
> 
> **Overview**
> Removes the **expired** Hippo Protocol listing on **channel-104931** (`HP.hippoprotocol`) from `osmosis.zone_assets.json` and regenerates **frontend**, **asset_detail**, and **chain_registry** outputs so only the live **HP** on **channel-110277** remains. That stops the automated IBC client check from re-adding the dead channel because the committed frontend no longer advertises it.
> 
> Updates the **Extract per-mutation symbol lists** step in `generate_all_files.yml` to key zone and frontend assets by **IBC `path`** (with `chain_name|base_denom` fallback when there is no path), instead of `chain_name|base_denom` alone. Assets on multiple channels no longer collapse in `from_entries`, so lifecycle summaries avoid phantom **IBC cleared** lines when only one channel variant changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f07227c0aeb2e2e1622ac1cdb8e4429c520dc06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->