### PR TITLE
ci(generate-all): report unstable reason and re-lay-out PR summary

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -187,17 +187,15 @@ jobs:
                 | {
                     chain: $a.chain_name,
                     symbol: $sym,
+                    # Reason the asset is currently flagged unstable. Surfaced
+                    # in the "IBC flagged unstable" row so the reader can tell
+                    # *why* an asset was flagged (ibc_client, market, manual,
+                    # source_chain_killed, ...) rather than just that it was.
+                    reason: ($a.osmosis_unstable_reason // "?"),
                     ibcFlagged:
                       ((($a.osmosis_unstable // false) == true) and (($b.osmosis_unstable // false) != true)),
                     ibcCleared:
                       ((($a.osmosis_unstable // false) != true) and (($b.osmosis_unstable // false) == true)),
-                    marketFlagged:
-                      ((($a.osmosis_unstable // false) == true)
-                        and (($a.osmosis_unstable_reason // "") == "market")
-                        and (($b.osmosis_unstable_reason // "") != "market")),
-                    marketRecovered:
-                      ((($a.osmosis_unstable // false) != true)
-                        and (($b.osmosis_unstable_reason // "") == "market")),
                     extendedHaltSet:
                       ((($a.osmosis_halt_deposits // false) == true)
                         and (($a.osmosis_deposit_halt_reason // "") == "extended_unstable_market")
@@ -209,29 +207,24 @@ jobs:
                       ((($a.osmosis_halt_deposits // false) == true)
                         and (($a.osmosis_deposit_halt_reason // "") == "planned_shutdown")
                         and (($b.osmosis_deposit_halt_reason // "") != "planned_shutdown")),
-                    plannedShutdownCleared:
-                      ((($a.osmosis_halt_deposits // false) != true)
-                        and (($b.osmosis_deposit_halt_reason // "") == "planned_shutdown")),
                   }
               ) as $rows
             | $rows
           ' osmosis-1/osmosis.zone_assets.json > /tmp/lifecycle-diff.json
 
-          # Write one file per category, "chain|symbol" per line.
-          for kind in ibcFlagged ibcCleared marketFlagged marketRecovered extendedHaltSet extendedHaltCleared plannedShutdownSet plannedShutdownCleared; do
+          # Write one file per category, "chain|symbol" per line. ibcFlagged
+          # carries a third column with the unstable reason so the summary can
+          # report what each asset was flagged for.
+          jq -r '.[] | select(.ibcFlagged == true) | "\(.chain)|\(.symbol)|\(.reason)"' /tmp/lifecycle-diff.json > /tmp/lc-ibcFlagged.txt
+          for kind in ibcCleared extendedHaltSet extendedHaltCleared plannedShutdownSet; do
             jq -r --arg k "$kind" '.[] | select(.[$k] == true) | "\(.chain)|\(.symbol)"' /tmp/lifecycle-diff.json > /tmp/lc-${kind}.txt
           done
 
           # Capture summary counts from the lifecycle script logs.
-          if [ -f market-health.log ]; then
-            echo "MARKET_FLAGGED=$(grep -oP 'market_flagged\s+:\s+\K[0-9]+' market-health.log || echo 0)" >> $GITHUB_ENV
-            echo "MARKET_RECOVERED=$(grep -oP 'market_recovered\s+:\s+\K[0-9]+' market-health.log || echo 0)" >> $GITHUB_ENV
-          fi
           if [ -f extended-halts.log ]; then
             echo "EXTENDED_HALT_SET=$(grep -oP 'extended_halt_set\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
             echo "EXTENDED_HALT_CLEARED=$(grep -oP 'extended_halt_cleared\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
             echo "PLANNED_SHUTDOWN_SET=$(grep -oP 'planned_shutdown_set\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
-            echo "PLANNED_SHUTDOWN_CLEARED=$(grep -oP 'planned_shutdown_cleared\s+:\s+\K[0-9]+' extended-halts.log || echo 0)" >> $GITHUB_ENV
           fi
 
       - name: Run code to Update State
@@ -300,32 +293,42 @@ jobs:
           echo "## 📋 Quick summary" >> workflow-summary.md
           echo "" >> workflow-summary.md
 
-          # Helper: emit "- {emoji} {label} ({count}): {comma-joined items}".
-          # Items are read from the supplied file (one per line). If the file
-          # is empty/missing, prints ", none" instead. For lifecycle-script
-          # files keyed by "chain|symbol", takes only the symbol column.
+          # Helper: emit a labelled row. When the category is empty it renders
+          # inline ("- {emoji} **{label}**: none") so quiet categories stay on
+          # one line and the reader can skim them. When there are entries the
+          # header line carries the count and each item is its own indented
+          # sub-bullet, so a populated list reads top-to-bottom.
+          #
+          # mode selects how each line of {file} is rendered:
+          #   name           whole line is the display value (chain names)
+          #   symbol         "chain|symbol", display the symbol column
+          #   symbol_reason  "chain|symbol|reason", display "symbol (reason)"
+          #                  so the reader sees what each asset was flagged for
           emit_row() {
             local emoji="$1" label="$2" file="$3" mode="$4"
-            local count=0 items=""
+            local count=0
+            local -a items=()
             if [ -f "$file" ] && [ -s "$file" ]; then
-              if [ "$mode" = "symbol" ]; then
-                items=$(awk -F'|' 'NF>0{print $2}' "$file" | paste -sd', ' -)
-                count=$(awk 'NF>0' "$file" | wc -l | tr -d ' ')
-              else
-                items=$(awk 'NF>0' "$file" | paste -sd', ' -)
-                count=$(awk 'NF>0' "$file" | wc -l | tr -d ' ')
-              fi
+              case "$mode" in
+                symbol)        mapfile -t items < <(awk -F'|' 'NF>0{print $2}' "$file") ;;
+                symbol_reason) mapfile -t items < <(awk -F'|' 'NF>0{print $2" ("$3")"}' "$file") ;;
+                *)             mapfile -t items < <(awk 'NF>0' "$file") ;;
+              esac
+              count=${#items[@]}
             fi
             if [ "$count" = "0" ]; then
               echo "- ${emoji} **${label}**: none" >> workflow-summary.md
             else
-              echo "- ${emoji} **${label} (${count}):** ${items}" >> workflow-summary.md
+              echo "- ${emoji} **${label} (${count}):**" >> workflow-summary.md
+              for item in "${items[@]}"; do
+                echo "  - ${item}" >> workflow-summary.md
+              done
             fi
           }
 
           emit_row "🆕" "New Chains" new-chains.txt name
           emit_row "🆕" "New Assets" new-assets.txt name
-          emit_row "🔴" "IBC flagged unstable" /tmp/lc-ibcFlagged.txt symbol
+          emit_row "🔴" "IBC flagged unstable" /tmp/lc-ibcFlagged.txt symbol_reason
           emit_row "🟢" "IBC cleared" /tmp/lc-ibcCleared.txt symbol
 
           # Manual halts: list chain names of assets that were manually flagged
@@ -357,9 +360,6 @@ jobs:
           emit_row "⏸️" "Extended halt set" /tmp/lc-extendedHaltSet.txt symbol
           emit_row "▶️" "Extended halt cleared" /tmp/lc-extendedHaltCleared.txt symbol
           emit_row "⏰" "Planned shutdown set" /tmp/lc-plannedShutdownSet.txt symbol
-          emit_row "▶️" "Planned shutdown cleared" /tmp/lc-plannedShutdownCleared.txt symbol
-          emit_row "📉" "Market flagged" /tmp/lc-marketFlagged.txt symbol
-          emit_row "📈" "Market recovered" /tmp/lc-marketRecovered.txt symbol
 
           echo "" >> workflow-summary.md
           echo "---" >> workflow-summary.md


### PR DESCRIPTION
@
## What

Improves the daily Automated Update Summary PR body generated by `generate_all_files.yml`.

- **Report the unstable reason.** The "IBC flagged unstable" row now shows what each asset was flagged for, e.g. `KAVA (ibc_client)`, `LUNC (market)`, `ATOM (manual)`, instead of only that it was flagged. The lifecycle-diff carries `osmosis_unstable_reason` through to the per-category file as a third column.
- **New layout.** Empty categories still render inline as `none` so quiet rows stay skimmable. Populated categories now print a header line with the count followed by one indented sub-bullet per entry, so the list reads top-to-bottom.
- **Dropped rows.** Removed "Planned shutdown cleared", "Market flagged", and "Market recovered". A market flag sets `osmosis_unstable=true` with reason `market`, so it is now subsumed by the unstable row and its reason. The orphaned lifecycle-diff predicates and unused env-var captures that fed those rows are removed too. "Planned shutdown set" and the extended-halt rows are kept.

## Example

```
- 🔴 **IBC flagged unstable (3):**
  - KAVA (ibc_client)
  - LUNC (market)
  - ATOM (manual)
- 🟢 **IBC cleared**: none
```

## Notes

- Report-only change. No effect on lifecycle mutations or generated assetlists; the market-health check still runs and still sets the flag, it just no longer gets its own summary rows.
- The "IBC flagged unstable" label now covers any newly-unstable asset (not just IBC-client-driven), but the reason column makes the cause explicit. Left the label unchanged to keep the diff minimal; happy to rename if preferred.

## Tested

- Unit-tested the `emit_row` helper: inline `none` for empty/missing files, header + indented sub-bullets for populated ones, `SYMBOL (reason)` rendering.
- Validated the updated lifecycle-diff jq against a synthetic before/now snapshot; `ibcFlagged` extraction produces `chain|symbol|reason`.
@

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only reporting and markdown formatting; lifecycle scripts and generated asset data are unaffected.
> 
> **Overview**
> **Report-only** tweaks to the daily Automated Update Summary PR body in `generate_all_files.yml`—no lifecycle mutations or assetlist output changes.
> 
> The **IBC flagged unstable** quick-summary row now shows **why** each asset was newly flagged: lifecycle-diff jq adds `osmosis_unstable_reason`, `ibcFlagged` lines are written as `chain|symbol|reason`, and `emit_row` gains a `symbol_reason` mode so entries render like `KAVA (ibc_client)`.
> 
> **Quick summary layout** changes: empty categories stay a single `none` line; non-empty categories use a count header plus **indented sub-bullets** per item instead of one comma-separated line.
> 
> **Removed** quick-summary rows for planned shutdown cleared, market flagged, and market recovered (market instability is covered by the unstable row + reason), along with the jq predicates, category files, and `market-health.log` env captures that fed them. Extended-halt and planned-shutdown-set rows remain; the market-health script still runs and its detailed log section is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27c396e54f926ce2f24deee4a0408f3bd49683c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->