### PR TITLE
feat(osmosis-1): fully close Stargaze assets after chain shutdown

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -299,11 +299,18 @@
       "categories": [
         "nft_protocol"
       ],
-      "_comment": "Stargaze $STARS",
-      "planned_shutdown_date": "2026-06-15T00:00:00Z",
-      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/",
+      "override_properties": {
+        "name": "Stargaze (old)",
+        "symbol": "STARS.old"
+      },
+      "_comment": "Stargaze (old) $STARS.old",
+      "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. This is the old STARS; deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown"
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed"
     },
     {
       "chain_name": "chihuahua",
@@ -3249,11 +3256,12 @@
       "osmosis_verified": true,
       "_comment": "Stardust STRDST $STRDST",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market",
-      "planned_shutdown_date": "2026-06-15T00:00:00Z",
-      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/",
+      "osmosis_unstable_reason": "source_chain_killed",
+      "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. Deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown"
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed"
     },
     {
       "chain_name": "doravota",
@@ -3364,10 +3372,13 @@
       "path": "transfer/channel-75/factory/stars16da2uus9zrsy83h23ur42v3lglg5rmyrpqnju4/uBRNCH",
       "osmosis_verified": false,
       "_comment": "Branch $BRNCH",
-      "planned_shutdown_date": "2026-06-15T00:00:00Z",
-      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. Deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown"
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed"
     },
     {
       "chain_name": "neutron",
@@ -3736,10 +3747,13 @@
       "path": "transfer/channel-75/factory/stars1xx5976njvxpl9n4v8huvff6cudhx7yuu8e7rt4/usneaky",
       "osmosis_verified": false,
       "_comment": "Sneaky Productions $SNEAKY",
-      "planned_shutdown_date": "2026-06-15T00:00:00Z",
-      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. Deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown"
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed"
     },
     {
       "chain_name": "osmosis",
@@ -7326,10 +7340,13 @@
       "path": "transfer/channel-75/factory/stars1rru5m2wh3fylpheqh8h5g968jwhe7rctkfm7u0gwk7ka4vx3q5tqukjl4z/hood",
       "osmosis_verified": false,
       "_comment": "HOOD $HOOD",
-      "planned_shutdown_date": "2026-06-15T00:00:00Z",
-      "tooltip_message": "The Stargaze chain is shutting down on 15 June 2026 as the project migrates to the Cosmos Hub. Deposits are being disabled ahead of the shutdown. Migrate your assets via https://automigration.stargaze.zone/",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. Deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown"
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed"
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## What

The Stargaze chain has shut down as the project migrated to the Cosmos Hub. This moves all five channel-75 Stargaze assets from their pre-shutdown state (`planned_shutdown`, deposits halted, withdrawals open) to the terminal **source-chain-killed** state.

| Asset | Rename | New state |
|---|---|---|
| STARS (`ustars`) | → **STARS.old** | unstable + deposits + withdrawals halted, all `source_chain_killed` |
| Stardust (`STRDST`) | — | same |
| Branch (`BRNCH`) | — | same |
| Sneaky (`SNEAKY`) | — | same |
| HOOD | — | same |

For every entry:
- `osmosis_unstable: true` / `osmosis_unstable_reason: "source_chain_killed"` (STRDST's prior `market` reason superseded).
- `osmosis_deposit_halt_reason`: `planned_shutdown` → `source_chain_killed`.
- Added `osmosis_halt_withdrawals: true` / `osmosis_withdrawal_halt_reason: "source_chain_killed"` — withdrawals are now closed too (the "fully close" part).
- Removed the obsolete `planned_shutdown_date`.
- Tooltip rewritten to past tense ("has shut down... deposits and withdrawals are closed").

STARS additionally gets an `override_properties` rename (`name` "Stargaze (old)", `symbol` "STARS.old", `_comment` updated), freeing up "STARS" for the new Cosmos Hub token. This mirrors the existing `DGN.old` / `dungeon1` precedent for a killed source chain.

## Why

The chain is dead, so deposits and withdrawals can never succeed again; both directions must be halted with `source_chain_killed`. The `.old` rename prepares the symbol namespace for the new STARS.

## Out of scope

The new Cosmos Hub STARS entry is **not** added here. It will be a follow-up once it appears in the chain registry.

## Tested

- `jq empty` → valid JSON.
- Verified all five channel-75 assets are in the terminal state and no `planned_shutdown` reason or `planned_shutdown_date` remains on any Stargaze asset.
- Checked every field value against the schema enums: `source_chain_killed` is valid for `osmosis_unstable_reason`, `osmosis_deposit_halt_reason`, and `osmosis_withdrawal_halt_reason`; `override_properties.name`/`symbol` are valid.

## Notes

- Source-file edit only; the `generated/` outputs are produced by the CI generation pipeline.
- The killed-chain lifecycle automation only auto-applies `source_chain_killed` once the chain registry flips stargaze to `status: "killed"` (currently still `live`), so this manual edit does not conflict with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON-only Osmosis asset metadata updates with no runtime logic; incorrect flags would mainly affect UI labels and transfer halts for already-dead Stargaze IBC balances.
> 
> **Overview**
> Marks all five **channel-75 Stargaze** IBC assets in `osmosis.zone_assets.json` as fully closed now that Stargaze has shut down, moving them from pre-shutdown **`planned_shutdown`** (deposits only) to the terminal **`source_chain_killed`** pattern used for other dead chains.
> 
> For **STARS** (`ustars`), adds **`override_properties`** to display **Stargaze (old)** / **`STARS.old`**, freeing the STARS symbol for a future Cosmos Hub token. For every Stargaze entry in this PR, sets **`osmosis_unstable`** with **`source_chain_killed`**, switches deposit halt reasons from **`planned_shutdown`** to **`source_chain_killed`**, adds **`osmosis_halt_withdrawals`** with the same withdrawal reason, drops **`planned_shutdown_date`**, and rewrites tooltips to past tense (chain has shut down; deposits and withdrawals closed; migration link unchanged). **STRDST** no longer uses **`market`** as its unstable reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f39e1de1fb6ad885c793661d51affbe609e3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->