### PR TITLE
feat(osmosis-1): mark confirmed-dead source chains as source_chain_killed

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1590,11 +1590,12 @@
       "osmosis_verified": false,
       "_comment": "Lambda $LAMB",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Lambda chain has been discontinued; the project migrated from Cosmos to an Ethereum Layer 2 and LAMB converts to the new LAMBDA token. Deposits and withdrawals are disabled. For more information see: https://docs.lambda.im/token-distribution/migrate-lamb-lambda"
     },
     {
       "chain_name": "kujira",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3244,12 +3244,11 @@
       ],
       "_comment": "StaFi Hub $FIS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "stafihub",
@@ -3261,12 +3260,11 @@
       ],
       "_comment": "rATOM $rATOM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and rATOM migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "stargaze",
@@ -6246,12 +6244,11 @@
         "liquid_staking"
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol moved to BNB Chain. Deposits and withdrawals are disabled. For more information see: https://medium.com/@lorenzoprotocol/lorenzo-protocol-adds-btcb-support-details-future-bnb-chain-integrations-4595a55ea2e9"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "osmosis",
@@ -8444,12 +8441,11 @@
       "path": "transfer/channel-5413/uriris",
       "osmosis_unstable": true,
       "_comment": "rIRIS $rIRIS",
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "stafihub",
@@ -8457,12 +8453,11 @@
       "path": "transfer/channel-5413/urhuahua",
       "osmosis_unstable": true,
       "_comment": "rHUAHUA $rHUAHUA",
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "stafihub",
@@ -8470,12 +8465,11 @@
       "path": "transfer/channel-5413/urswth",
       "osmosis_unstable": true,
       "_comment": "rSWTH $rSWTH",
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "scorum",
@@ -8495,12 +8489,11 @@
       "path": "transfer/channel-79840/alrz",
       "osmosis_unstable": true,
       "_comment": "Lorenzo Protocol $LRZ",
-      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_unstable_reason": "ibc_client",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol moved to BNB Chain. Deposits and withdrawals are disabled. For more information see: https://medium.com/@lorenzoprotocol/lorenzo-protocol-adds-btcb-support-details-future-bnb-chain-integrations-4595a55ea2e9"
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "pryzm",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -403,7 +403,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Starname (IOV) chain has been abandoned and is no longer producing blocks. Deposits and withdrawals are disabled. For more information see: https://www.mintscan.io/starname"
+      "tooltip_message": "The Starname (IOV) chain is no longer producing blocks. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "emoney",
@@ -1255,7 +1255,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Tgrade chain has been discontinued and is no longer producing blocks; its developer Confio is in liquidation. Deposits and withdrawals are disabled. For more information see: https://confio.gmbh/"
+      "tooltip_message": "The Tgrade chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "echelon",
@@ -3249,7 +3249,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
     },
     {
       "chain_name": "stafihub",
@@ -3266,7 +3266,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and rATOM migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
+      "tooltip_message": "The StaFiHub chain has been retired and rATOM migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
     },
     {
       "chain_name": "stargaze",
@@ -5854,7 +5854,14 @@
           "withdraw_url": "https://beta-mainnet.routernitro.com/swap?fromChain=osmosis-1&toChain=728126428&fromToken=factory%2Fosmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9%2FTRX.rt&toToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
         }
       ],
-      "_comment": "Tron (Router) $TRX.rt"
+      "_comment": "Tron (Router) $TRX.rt",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "This asset reached Osmosis through the Router bridge, which has been permanently sunset following a passed governance proposal. The bridge path is no longer available, so deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
     },
     {
       "chain_name": "osmosis",
@@ -5898,7 +5905,12 @@
       },
       "_comment": "Tether USD (Ethereum via Router) $USDT.eth.rt",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "This asset reached Osmosis through the Router bridge, which has been permanently sunset following a passed governance proposal. The bridge path is no longer available, so deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
     },
     {
       "chain_name": "injective",
@@ -5957,7 +5969,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Router Chain has been permanently sunset following a passed governance proposal, and ROUTE migrated to Ethereum. Deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
+      "tooltip_message": "The Router Chain has been permanently sunset following a passed governance proposal, and ROUTE migrated to Ethereum. Assets bridged to Osmosis via Router are affected as well. Deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
     },
     {
       "chain_name": "osmosis",
@@ -6239,7 +6251,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol relaunched on BNB Chain. Deposits and withdrawals are disabled. For more information see: https://lorenzo-protocol.gitbook.io/docs"
+      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol moved to BNB Chain. Deposits and withdrawals are disabled. For more information see: https://medium.com/@lorenzoprotocol/lorenzo-protocol-adds-btcb-support-details-future-bnb-chain-integrations-4595a55ea2e9"
     },
     {
       "chain_name": "osmosis",
@@ -6273,7 +6285,14 @@
           "withdraw_url": "https://beta-mainnet.routernitro.com/swap?toChain=1&fromChain=osmosis-1&fromToken=factory%2Fosmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9%2FAVAIL.rt&toToken=0xEeB4d8400AEefafC1B2953e0094134A887C76Bd8"
         }
       ],
-      "_comment": "Avail (Ethereum via Router) $AVAIL.eth.rt"
+      "_comment": "Avail (Ethereum via Router) $AVAIL.eth.rt",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "This asset reached Osmosis through the Router bridge, which has been permanently sunset following a passed governance proposal. The bridge path is no longer available, so deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
     },
     {
       "chain_name": "noble",
@@ -6659,7 +6678,14 @@
           "withdraw_url": "https://app.routernitro.com/swap?fromChain=osmosis-1&fromToken=factory%2Fosmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9%2FBTC.rt&toChain=30&toToken=0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
         }
       ],
-      "_comment": "Rootstock (Router) $RBTC.rt"
+      "_comment": "Rootstock (Router) $RBTC.rt",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "source_chain_killed",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "This asset reached Osmosis through the Router bridge, which has been permanently sunset following a passed governance proposal. The bridge path is no longer available, so deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
     },
     {
       "chain_name": "osmosis",
@@ -8423,7 +8449,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
     },
     {
       "chain_name": "stafihub",
@@ -8436,7 +8462,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
     },
     {
       "chain_name": "stafihub",
@@ -8449,7 +8475,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://medium.com/stafi/2024q4-roadmap-deflation-adoption-and-lsaas-open-as-a-sustainable-platform-11974d71d979"
     },
     {
       "chain_name": "scorum",
@@ -8474,7 +8500,7 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
-      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol relaunched on BNB Chain. Deposits and withdrawals are disabled. For more information see: https://lorenzo-protocol.gitbook.io/docs"
+      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol moved to BNB Chain. Deposits and withdrawals are disabled. For more information see: https://medium.com/@lorenzoprotocol/lorenzo-protocol-adds-btcb-support-details-future-bnb-chain-integrations-4595a55ea2e9"
     },
     {
       "chain_name": "pryzm",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -398,11 +398,12 @@
       ],
       "_comment": "Starname $IOV",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Starname (IOV) chain has been abandoned and is no longer producing blocks. Deposits and withdrawals are disabled. For more information see: https://www.mintscan.io/starname"
     },
     {
       "chain_name": "emoney",
@@ -1249,11 +1250,12 @@
       "osmosis_verified": true,
       "_comment": "Tgrade $TGD",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Tgrade chain has been discontinued and is no longer producing blocks; its developer Confio is in liquidation. Deposits and withdrawals are disabled. For more information see: https://confio.gmbh/"
     },
     {
       "chain_name": "echelon",
@@ -2297,11 +2299,12 @@
       ],
       "_comment": "OmniFlix $FLIX",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The OmniFlix Hub chain has shut down as the project migrated from Cosmos to Base, with FLIX transitioning to FUN. Deposits and withdrawals are disabled. For more information see: https://paragraph.com/@flix/flix-to-fun-transformation-window-extended-to-jan-20th"
     },
     {
       "chain_name": "juno",
@@ -3240,11 +3243,12 @@
       ],
       "_comment": "StaFi Hub $FIS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
     },
     {
       "chain_name": "stafihub",
@@ -3256,11 +3260,12 @@
       ],
       "_comment": "rATOM $rATOM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The StaFiHub chain has been retired and rATOM migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
     },
     {
       "chain_name": "stargaze",
@@ -5946,11 +5951,12 @@
       ],
       "_comment": "Router Protocol $ROUTE",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Router Chain has been permanently sunset following a passed governance proposal, and ROUTE migrated to Ethereum. Deposits and withdrawals are disabled. For more information see: https://routerprotocol.medium.com/proposal-to-sunset-router-chain-55ea9fd0e799"
     },
     {
       "chain_name": "osmosis",
@@ -6227,11 +6233,12 @@
         "liquid_staking"
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol relaunched on BNB Chain. Deposits and withdrawals are disabled. For more information see: https://lorenzo-protocol.gitbook.io/docs"
     },
     {
       "chain_name": "osmosis",
@@ -6779,11 +6786,12 @@
       "osmosis_verified": true,
       "_comment": "Yield GATA $YGATA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The OmniFlix Hub chain has shut down as the project migrated from Cosmos to Base. Deposits and withdrawals are disabled. For more information see: https://paragraph.com/@flix/flix-to-fun-transformation-window-extended-to-jan-20th"
     },
     {
       "chain_name": "dungeon1",
@@ -8409,11 +8417,12 @@
       "path": "transfer/channel-5413/uriris",
       "osmosis_unstable": true,
       "_comment": "rIRIS $rIRIS",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
     },
     {
       "chain_name": "stafihub",
@@ -8421,11 +8430,12 @@
       "path": "transfer/channel-5413/urhuahua",
       "osmosis_unstable": true,
       "_comment": "rHUAHUA $rHUAHUA",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
     },
     {
       "chain_name": "stafihub",
@@ -8433,11 +8443,12 @@
       "path": "transfer/channel-5413/urswth",
       "osmosis_unstable": true,
       "_comment": "rSWTH $rSWTH",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The StaFiHub chain has been retired and migrated to Neutron. Deposits and withdrawals are disabled. For more information see: https://docs.stafihub.io/welcome-to-stafihub"
     },
     {
       "chain_name": "scorum",
@@ -8457,11 +8468,12 @@
       "path": "transfer/channel-79840/alrz",
       "osmosis_unstable": true,
       "_comment": "Lorenzo Protocol $LRZ",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Lorenzo Cosmos appchain has been discontinued and the protocol relaunched on BNB Chain. Deposits and withdrawals are disabled. For more information see: https://lorenzo-protocol.gitbook.io/docs"
     },
     {
       "chain_name": "pryzm",


### PR DESCRIPTION
Part of the dead-chain sweep from the daily lifecycle PR. Rebased onto current `main` (after the Stargaze shutdown PR landed).

## What

Marks the **confirmed**-dead source chains (plus the sunset Router bridge) as permanently killed. This upgrades **10 Osmosis assets** from the recoverable `ibc_client` / `bridge_down` reasons (or, for the Router-bridged assets, from no halt) to the terminal **`source_chain_killed`** on all three reason fields, and adds a **user-facing `tooltip_message`** on each.

Deposits and withdrawals were already halted on the chains (the IBC client had expired); the substantive change is recording that the halt is permanent and adding the explanatory tooltip.

| Chain / source | Assets | What happened | Tooltip link |
|---|---|---|---|
| omniflixhub | FLIX, YGATA | Migrated Cosmos → Base; FLIX → FUN. | paragraph.com FLIX announcement |
| routerchain | ROUTE | DAO-passed sunset; ROUTE migrated to Ethereum. | routerprotocol.medium.com sunset post |
| Router bridge | TRX.rt, USDT.eth.rt, AVAIL.eth.rt, RBTC.rt | Reached Osmosis via the Router bridge, which sunset; bridge path gone. | routerprotocol.medium.com sunset post |
| lambda | LAMB | Cosmos chain abandoned; migrated to an Ethereum L2 (LAMB → LAMBDA). | docs.lambda.im migrate page |
| starname | IOV | Chain no longer producing blocks. | none (description-only) |
| tgrade | TGD | Chain stopped producing blocks, no longer maintained. | none (description-only) |

## Tooltips

- **starname, tgrade** — description-only, no link: no surviving page names the chain and documents the shutdown, so the tooltip states the situation plainly rather than linking a parked domain or an unrelated company page.
- **omniflixhub, routerchain, lambda** — linked to the team's own announcement / migration docs.
- **routerchain (ROUTE)** — tooltip notes that assets bridged to Osmosis via Router are affected too.
- **Router-bridged `.rt` assets** — newly closed (they were not previously halted); each gets a Router-shutdown tooltip explaining the bridge path is gone.

All tooltips follow the house style ("The X chain has … Deposits and withdrawals are disabled. [For more information see: <url>]"). No GitHub/API/status links, and no exchange/price-aggregator links.

## Why

The source chains are dead (and the Router bridge is sunset), so the transfers can never complete; the recoverable reasons understate that. `source_chain_killed` is the terminal state (same pattern as the Stargaze kill and the DGN.old precedent).

## Removed from this PR (could not confirm a permanent shutdown)

- **stafihub** (FIS, rATOM, rIRIS, rHUAHUA, rSWTH) — public nodes are all offline and StaFi migrated rTokens to Neutron, but there is **no published chain-halt record**, and StaFi frames it as a migration rather than a permanent sunset (possible foundation/maintenance state). `source_chain_killed` would over-claim. Reverted to the prior recoverable state.
- **lorenzo** (stBTC, LRZ) — the BNB Chain pivot is documented, but no explicit Cosmos-appchain retirement or frozen-block record could be confirmed. Reverted to the prior recoverable state.

Both can be revisited once a definitive halt is confirmed.

## Notes / caveats

- For `lambda`, only the **Cosmos chain** is dead; the protocol continues on an Ethereum L2. This kills only the Cosmos-sourced asset entry.
- The four `.rt` assets are factory tokens on the **osmosis** chain minted by the Router bridge contract; `source_chain_killed` marks the now-permanently-unavailable bridge path.
- The chains still read `status: "live"` in the cosmos chain-registry (stale). Matching upstream `status: killed` PRs to follow separately.
- **Companion PR #3590** covers seven further confirmed-dead chains (odin, migaloo, konstellation, echelon, qwoyn, galaxy, aaronetwork) with description-only tooltips.
- Source-file edit only; `generated/` outputs come from the CI pipeline.

## Tested

- `jq empty` → valid JSON.
- Verified all 10 target assets are `source_chain_killed` on all three reason fields with both halt booleans true, each carries a non-empty tooltip, and none contains an em-dash. StaFiHub and Lorenzo entries are byte-identical to `main` (zero drift). No other assets touched.
- Diff vs `main` touches only the zone file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Source-only asset registry JSON with no runtime code changes; impact is accurate UI halt messaging and lifecycle reporting.
> 
> **Overview**
> **Permanently flags 10 Osmosis zone assets** whose IBC or Router bridge paths cannot recover, moving halt metadata from recoverable reasons (`ibc_client`, `bridge_down`, or unset) to the terminal **`source_chain_killed`** on unstable, deposit, and withdrawal fields.
> 
> Affected sources include **Starname (IOV), Tgrade, Lambda, OmniFlix (FLIX, YGATA), Router chain (ROUTE)**, and **Router-bridged factory tokens** (TRX.rt, USDT.eth.rt, AVAIL.eth.rt, RBTC.rt). Several Router `.rt` entries **gain new deposit/withdrawal halts** where they were not fully halted before; **USDT.eth.rt** also shifts unstable reason from `market` to `source_chain_killed`.
> 
> Each updated entry adds a **`tooltip_message`** explaining why transfers are disabled (chain shutdown, migration, or Router sunset), with links where documentation exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15b0fb062ce4bb556f4636c5c9df4e87aba6b6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->