### PR TITLE
feat(osmosis-1): mark seven more confirmed-dead source chains as source_chain_killed

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -619,11 +619,12 @@
       "osmosis_verified": true,
       "osmosis_unstable": true,
       "_comment": "Konstellation $DARC",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Konstellation chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "umee",
@@ -986,11 +987,12 @@
       "osmosis_verified": false,
       "_comment": "Galaxy $GLX",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Galaxy chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "juno",
@@ -1270,11 +1272,12 @@
       ],
       "_comment": "Echelon $ECH",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Echelon chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "odin",
@@ -1286,11 +1289,12 @@
       ],
       "_comment": "Odin Protocol $ODIN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Odin Protocol chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "odin",
@@ -1299,11 +1303,12 @@
       "osmosis_verified": false,
       "osmosis_unstable": true,
       "_comment": "GEO $GEO",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Odin Protocol chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "odin",
@@ -1312,11 +1317,12 @@
       "osmosis_verified": false,
       "osmosis_unstable": true,
       "_comment": "O9W $O9W",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Odin Protocol chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "kichain",
@@ -2192,11 +2198,12 @@
       ],
       "_comment": "Migaloo $WHALE",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "juno",
@@ -3434,11 +3441,12 @@
       "osmosis_verified": false,
       "_comment": "Qwoyn $QWOYN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Qwoyn chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "bostrom",
@@ -3574,11 +3582,12 @@
       ],
       "_comment": "ASH $ASH",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -3591,11 +3600,12 @@
       ],
       "_comment": "Racoon $RAC",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -3607,11 +3617,12 @@
       ],
       "_comment": "GUPPY $GUPPY",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "haqq",
@@ -4109,11 +4120,12 @@
       "osmosis_verified": true,
       "_comment": "DOKI $DOKI",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Odin Protocol chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "osmosis",
@@ -4136,11 +4148,12 @@
       ],
       "_comment": "SHARK $SHARK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "coreum",
@@ -4511,11 +4524,12 @@
       "osmosis_verified": false,
       "_comment": "RESTAKE $RSTK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "osmosis",
@@ -6984,11 +6998,12 @@
       "osmosis_verified": false,
       "_comment": "Aaron Network $AARON",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Aaron Network chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "chihuahua",
@@ -7771,11 +7786,12 @@
       "osmosis_unlisted": true,
       "_comment": "OPHIR $OPHIR",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "cosmoshub",
@@ -8385,11 +8401,12 @@
       "path": "transfer/channel-258/umyrk",
       "osmosis_unstable": true,
       "_comment": "MYRK $MYRK",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Odin Protocol chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "planq",
@@ -11026,11 +11043,12 @@
       "path": "transfer/channel-642/factory/migaloo1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgshqdky4/ampWHALE",
       "osmosis_unstable": true,
       "_comment": "ampWHALE $ampWHALE",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11038,11 +11056,12 @@
       "path": "transfer/channel-642/factory/migaloo1mf6ptkssddfmxvhdx0ech0k03ktp6kf9yk59renau2gvht3nq2gqdhts4u/boneWhale",
       "osmosis_unstable": true,
       "_comment": "BackBone Labs Liquid Staked WHALE $bWHALE",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11050,11 +11069,12 @@
       "path": "transfer/channel-642/factory/migaloo18a9m9stu3dyvewwcq9qmp85euxqcvln5mefync/fable",
       "osmosis_unstable": true,
       "_comment": "FABLE $FABLE",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11062,11 +11082,12 @@
       "path": "transfer/channel-642/factory/migaloo1p3aj9f09d7c4jxhgue0hpdpw370j6gzc59nxxx6l8d0gc9f9rfwsdwetus/lsdSHARK",
       "osmosis_unstable": true,
       "_comment": "lsdSHARK $lsdSHARK",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11074,11 +11095,12 @@
       "path": "transfer/channel-642/factory/migaloo1r9x8fz4alekzr78k42rpmr9unpa7egsldpqeynmwl2nfvzexue9sn8l5rg/gash",
       "osmosis_unstable": true,
       "_comment": "GASH $GASH",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11086,11 +11108,12 @@
       "path": "transfer/channel-642/factory/migaloo1eqntnl6tzcj9h86psg4y4h6hh05g2h9nj8e09l/ugrac",
       "osmosis_unstable": true,
       "_comment": "Gaming RAC Token $GRAC",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11098,11 +11121,12 @@
       "path": "transfer/channel-642/factory/migaloo1nsskhvvh0msm7d5ke2kfg24a8d4jecsnxd28s27h0uz5kf9ap60shlqmcl/ampGASH",
       "osmosis_unstable": true,
       "_comment": "ampGASH $ampGASH",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11110,11 +11134,12 @@
       "path": "transfer/channel-642/factory/migaloo1axtz4y7jyvdkkrflknv9dcut94xr5k8m6wete4rdrw4fuptk896su44x2z/uLP",
       "osmosis_unstable": true,
       "_comment": "WHALE-wBTC WW LP $WHALE-wBTC-WW-LP",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "migaloo",
@@ -11122,11 +11147,12 @@
       "path": "transfer/channel-642/factory/migaloo1zsptvkg5aeg4tjksgv7vp4x5s9p5euqrh9jl3sfdv48wtnrhftlszsvmu5/uwhalex",
       "osmosis_unstable": true,
       "_comment": "WHALEX $WHALEX",
-      "osmosis_unstable_reason": "ibc_client",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Migaloo (White Whale) chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "bluzelle",


### PR DESCRIPTION
> **Draft.** Second batch of the dead-chain sweep (companion to #3589). These seven chains hardened to **confirmed-dead** during verification but have no surviving official shutdown announcement, so they were split out from the first PR.

## What

Seven additional source chains are **confirmed permanently halted**. This upgrades their 26 Osmosis assets from the recoverable `ibc_client` / `bridge_down` reasons to the terminal **`source_chain_killed`** on all three reason fields, with a user-facing `tooltip_message` on each.

Deposits and withdrawals were **already halted** on every one (the IBC client had expired); this records that the halt is permanent and adds the explanatory tooltip.

| Chain | Assets | Evidence |
|---|---|---|
| odin | ODIN, GEO, O9W, DOKI, MYRK | Independent archive RPC shows the chain halted at a fixed height (~2026-04); next block never produced. |
| migaloo | WHALE + 15 others | Tip frozen ~2025-11 across a fully dead endpoint set; AMM at zero volume. |
| konstellation | DARC | Tip frozen ~2025-05 (~13 months); all endpoints down. |
| echelon | ECH | Abandoned ~2024; project domain parked for sale; ~23 months stale. |
| qwoyn | QWOYN | All infrastructure offline; project tooling archived read-only. |
| galaxy | GLX | Abandoned; registry endpoints stripped; project domain parked for sale. |
| aaronetwork | AARON | Last block ~2025-08 (directly verified); project site offline. |

## Tooltips

These chains have **no surviving official shutdown announcement**, and per review guidance the tooltips do **not** link to exchanges or price aggregators. So each tooltip is **description-only**: a brief plain-English statement in the house style ("The X chain has stopped producing blocks and is no longer maintained. Deposits and withdrawals are disabled."), no link.

## Why

The source chains are dead, so an IBC transfer can never complete; `source_chain_killed` is the terminal state (same pattern as #3589, the Stargaze kill, and the DGN.old precedent).

## Notes

- All seven still read `status: "live"` in the cosmos chain-registry (stale). Matching upstream `status: killed` PRs to follow separately.
- **Not included here:** nine chains that remain *likely*-dead on softer evidence (imversed, scorum, self, sge, sidechain, synternet, acrechain, furya, fandomchain) are deliberately left out pending firmer confirmation.
- Source-file edit only; `generated/` outputs come from the CI pipeline.

## Tested

- `jq empty` → valid JSON.
- Verified all 26 target assets are `source_chain_killed` on all three reason fields with both halt booleans true, each carries a non-empty tooltip, and no out-of-scope asset was touched (26/26, 0 out-of-scope, 0 missing tooltip). No em-dashes.
- Diff vs `main` touches only the zone file.
