### PR TITLE
fix(schema): correct additionalProperties typo and dangling refs

### DIFF
--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -22,7 +22,7 @@
       }
     }
   },
-  "additionalPropserties": false,
+  "additionalProperties": false,
   "$defs": {
     "asset": {
       "type": "object",
@@ -162,7 +162,6 @@
                 "type": "string",
                 "enum": [
                   "external_interface",
-                  "integrated_bridge",
                   "fiat_onramp"
                 ]
               },
@@ -194,6 +193,10 @@
             "symbol": {
               "type": "string",
               "description": "The symbol of an asset. For example BTC."
+            },
+            "use_asset_name": {
+              "type": "boolean",
+              "description": "When true, the Zone displays the asset's name in place of the symbol where a symbol would normally be shown."
             },
             "logo_URIs": {
               "type": "object",

--- a/zone_chains.schema.json
+++ b/zone_chains.schema.json
@@ -19,7 +19,7 @@
       }
     }
   },
-  "additionalPropserties": false,
+  "additionalProperties": false,
   "$defs": {
     "chain": {
       "type": "object",
@@ -148,6 +148,26 @@
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "pointer": {
+      "type": "object",
+      "description": "The (primary) key used to identify an object within the Chain Registry. Mirrors the Chain Registry's own pointer definition.",
+      "required": [
+        "chain_name"
+      ],
+      "properties": {
+        "chain_name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The chain name or platform from which the object resides. E.g., 'cosmoshub', 'ethereum', 'forex', or 'nasdaq'"
+        },
+        "base_denom": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The base denom of the asset from which the object originates. E.g., when describing ATOM from Cosmos Hub, specify 'uatom', NOT 'atom' nor 'ATOM'; base units are unique per platform."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Schema-only correctness pass. Four fixes, no data changes.

## Fixes

- **`additionalPropserties` typo (both schemas, top level).** Misspelled, so it was a silent no-op and the wrapper object accepted arbitrary top-level keys. Current data uses only the declared keys (`$schema`, `chain_name`, `assets` / `$schema`, `chains`), so enforcing `additionalProperties: false` changes nothing today but closes the gap.
- **Missing `pointer` `$def` in `zone_chains.schema.json`.** `override_properties.images[].image_sync` referenced `#/$defs/pointer`, which did not exist. The first chain to use `image_sync` would fail validation with an unresolved-ref error. Added a `pointer` def mirroring the Chain Registry's own (`chain_name` required, optional `base_denom`).
- **Dropped `integrated_bridge` from the transfer-method `type` enum.** It has no `oneOf` branch (only `external_interface` and `fiat_onramp` do), and zero usage in the data, so the enum advertised a value the `oneOf` (with `additionalProperties: false`) would then reject.
- **Added typed boolean `use_asset_name` to asset `override_properties`.** It is a live field in `osmosis-1/osmosis.zone_assets.json`, previously tolerated only via `additionalProperties: true`.

## Validation

Validated all four data files (osmosis-1 and osmo-test-5, assets and chains) against the modified schemas with the same `jsonschema` CLI the PR-check workflows use: all VALID.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSON Schema metadata only; tightens validation and fixes an unresolved ref without changing runtime code or zone data.
> 
> **Overview**
> **Schema-only correctness** for `zone_assets.schema.json` and `zone_chains.schema.json`—no data file edits.
> 
> Both schemas fix a top-level **`additionalPropserties` → `additionalProperties`** typo so unknown top-level keys are actually rejected (current JSON already only uses declared keys).
> 
> **`zone_chains.schema.json`** adds the missing **`pointer`** `$def` referenced by `override_properties.images[].image_sync`, matching Chain Registry shape (`chain_name` required, optional `base_denom`).
> 
> **`zone_assets.schema.json`** removes **`integrated_bridge`** from the transfer-method `type` enum (no `oneOf` branch and no data usage). It also documents **`use_asset_name`** as a typed boolean under asset `override_properties`, aligning the schema with fields already present in live zone asset JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30c8f7e9138606ef869fd23e0f847c8252ca197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->