### PR TITLE
ci: install with pnpm so the inlang CLI patch is applied

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -33,13 +33,17 @@ jobs:
           git submodule update --init --recursive
           git submodule update --recursive --remote
           
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 20.x
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Snapshot zone_assets before lifecycle scripts
         run: |
@@ -285,7 +289,7 @@ jobs:
 
       - name: Run localization
         working-directory: ./.github/workflows/utility
-        run: npx pnpm inlang machine translate --force
+        run: pnpm inlang machine translate --force
 
       - name: Run post-localization code
         working-directory: ./.github/workflows/utility

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -22,17 +22,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
           
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 20.x
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run localization
         working-directory: ./.github/workflows/utility
-        run: npx pnpm inlang machine translate --force
+        run: pnpm inlang machine translate --force
 
       - name: Run post-localization code
         working-directory: ./.github/workflows/utility


### PR DESCRIPTION
## Problem

The daily `generate_all_files` run and the standalone `localization` workflow installed deps with `npm install`, but this repo has a pnpm-only `pnpm-lock.yaml` and a `pnpm.patchedDependencies` entry in `package.json` (`patches/@inlang__cli@1.20.0.patch`). `npm install` ignores `pnpm.patchedDependencies`, so:

- the `@inlang/cli` patch was silently never applied on the daily run, and
- the caret-ranged deps re-resolved fresh every run (not reproducible).

## Fix

Switch both workflows to the same setup `full_validation.yml` and `check_verification_criteria.yml` already use:

- `pnpm/action-setup@v6`
- `actions/setup-node@v6` with `cache: pnpm`
- `pnpm install --frozen-lockfile`

Also dropped the now-redundant `npx` prefix on the inlang command (pnpm is on PATH after `action-setup`).

## Verification

Locally with pnpm 10:

- `pnpm install --frozen-lockfile` succeeds against the existing lockfile (lockfile is in sync with `package.json`).
- After install, the patch IS present in the installed CLI: the `validatedModuleSettings(...)` block in `@inlang/cli/dist/main.js` is commented out, exactly as the patch intends. Under `npm install` that block is live (patch not applied).

Scope: only the two workflows that actually run the inlang CLI. The other `npm install` workflows (generate_chainlist / coingecko / mintscan, propose_unverify) do not need the patch; converting them for reproducibility is a lower-urgency follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes to dependency installation and how the inlang CLI is invoked; no application runtime or security-sensitive logic is modified.
> 
> **Overview**
> Aligns **`generate_all_files`** and **`localization`** with the pnpm-based install path already used in **`full_validation`** and **`check_verification_criteria`**.
> 
> Both workflows now run **`pnpm/action-setup@v6`**, enable **`cache: pnpm`** on **`setup-node`**, install with **`pnpm install --frozen-lockfile`** instead of **`npm install`**, and invoke **`pnpm inlang machine translate --force`** directly (no **`npx`**). That ensures **`pnpm.patchedDependencies`** (the **`@inlang/cli`** patch) is applied in CI and installs are lockfile-reproducible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8e55d910bbb4885deee5da7badbd1ca67943a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->