### PR TITLE
chore: collapse submodule init, de-dup state helpers, prune dead skip-arms

### DIFF
--- a/.github/workflows/full_validation.yml
+++ b/.github/workflows/full_validation.yml
@@ -30,8 +30,7 @@ jobs:
 
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -30,8 +30,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
           
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/generate_assetlist.yml
+++ b/.github/workflows/generate_assetlist.yml
@@ -24,8 +24,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
           
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/generate_chainlist.yml
+++ b/.github/workflows/generate_chainlist.yml
@@ -24,8 +24,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
           
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/generate_coingecko.yml
+++ b/.github/workflows/generate_coingecko.yml
@@ -24,8 +24,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
           
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/generate_mintscan.yml
+++ b/.github/workflows/generate_mintscan.yml
@@ -24,8 +24,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
           
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/update_chain_reg.yml
+++ b/.github/workflows/update_chain_reg.yml
@@ -24,8 +24,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
       
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -29,6 +29,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { calculateIbcHash } from './assetlist_functions.mjs';
+import { loadJSON, findStateAsset, materialiseStateAsset } from './lifecycle_helpers.mjs';
 
 const DEFAULT_LCD = "https://lcd.osmosis.zone";
 const CONCURRENCY = 5;
@@ -304,32 +305,12 @@ async function getCounterpartyClientStatus(chainName, channelId, port, zoneChain
 
 // ── State helpers ───────────────────────────────────────────────────────────
 
+// findStateAsset (read-only) and materialiseStateAsset (create-if-missing) are
+// shared with the other lifecycle scripts via lifecycle_helpers.mjs. Imported
+// above. loadState wraps the shared loadJSON with this script's state path and
+// the empty-state fallback used on the first run.
 function loadState() {
-  try {
-    return JSON.parse(fs.readFileSync(statePath, 'utf8'));
-  } catch (err) {
-    if (err.code === 'ENOENT') return { assets: [] };
-    throw err;
-  }
-}
-
-// Read-only state lookup. Returns undefined if no entry exists; callers that
-// only need to read date/streak fields should use this so we don't pollute
-// state.assets with empty {base_denom} placeholders on every iteration.
-function findStateAsset(state, baseDenom) {
-  return state.assets?.find((a) => a.base_denom === baseDenom);
-}
-
-// Create-if-missing variant. Only callers about to write a real value
-// (lastDowntimeDate, lastRecoveryDate, etc.) should use this.
-function materialiseStateAsset(state, baseDenom) {
-  if (!state.assets) state.assets = [];
-  let s = state.assets.find((a) => a.base_denom === baseDenom);
-  if (!s) {
-    s = { base_denom: baseDenom };
-    state.assets.push(s);
-  }
-  return s;
+  return loadJSON(statePath, { assets: [] });
 }
 
 /**

--- a/.github/workflows/utility/validate_zone_data.mjs
+++ b/.github/workflows/utility/validate_zone_data.mjs
@@ -151,17 +151,19 @@ function checkAssetIBCData(zoneAsset, chainName, IS_MAINNET) {
   const ibcChannels = chain_reg.getIBCFileProperty(chainName, zoneAsset.chain_name, "channels");
 
   if (!chain1Data || !ibcChannels) {
-    // Check if chain is killed/archived in chain registry
+    // Check if the source chain is killed in the chain registry.
     const chainStatus = chain_reg.getFileProperty(zoneAsset.chain_name, "chain", "status");
     const isKilledChain = chainStatus === "killed";
 
-    // Allow archived/legacy assets or killed chains to skip IBC validation
-    if (zoneAsset.archived || zoneAsset.legacy || isKilledChain) {
-      const reason = isKilledChain ? "killed chain" : "archived/legacy asset";
-      console.log(`Info: ${reason} ${zoneAsset.chain_name}:${zoneAsset.base_denom} has no IBC connection (expected).`);
+    // A killed source chain has no live IBC connection, so skip IBC validation.
+    // (The old `zoneAsset.archived` / `zoneAsset.legacy` arms were unreachable:
+    // the asset schema sets additionalProperties:false and defines neither key,
+    // so any asset carrying them already fails schema validation.)
+    if (isKilledChain) {
+      console.log(`Info: killed chain ${zoneAsset.chain_name}:${zoneAsset.base_denom} has no IBC connection (expected).`);
       return;
     }
-    // For non-archived assets with live chains, this is an error
+    // For a live chain, the missing IBC connection is an error.
     throw new Error(`No IBC connection found for ${zoneAsset.chain_name} (${zoneAsset.base_denom}). Chain status: ${chainStatus || 'unknown'}`);
   }
 

--- a/.github/workflows/validate_zone_data.yml
+++ b/.github/workflows/validate_zone_data.yml
@@ -28,8 +28,7 @@ jobs:
           
       - name: Git Submodule Update
         run: |
-          git submodule update --init --recursive
-          git submodule update --recursive --remote
+          git submodule update --init --remote --recursive
           
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
Behavior-preserving CI and script cleanups. No change to generated output.

## Changes

- **Submodule init collapse (8 workflows).** Replaced the two-line `git submodule update --init --recursive` + `git submodule update --recursive --remote` with a single `git submodule update --init --remote --recursive`. Checkout already inits via `submodules: true`, and the single command both inits and pulls the latest submodule commit.
- **De-dup state helpers in `check_ibc_clients.mjs`.** It re-defined `findStateAsset` and `materialiseStateAsset` as byte-identical copies of the exports in `lifecycle_helpers.mjs`. Now imports them (plus `loadJSON`) and expresses `loadState()` as `loadJSON(statePath, { assets: [] })`. Verified the shared helpers behave identically across the edge cases (read-only lookup with no mutation, create-if-missing, init on empty `state.assets`).
- **Prune dead skip-arms in `validate_zone_data.mjs`.** Reduced the IBC-skip condition to `isKilledChain`. The `zoneAsset.archived` / `zoneAsset.legacy` arms were unreachable: the asset schema sets `additionalProperties: false` and defines neither key, and zero assets use them, so any asset carrying them already fails schema validation.

## Validation

- `node --check` passes on both modified scripts.
- All 8 modified workflows parse (`yaml.safe_load`).
- Helper-equivalence spot test passes for the imported `findStateAsset` / `materialiseStateAsset` / `loadJSON`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactors CI submodule commands and shared helper imports without changing validation rules for live chains; killed-chain IBC skip behavior is unchanged.
> 
> **Overview**
> **Behavior-preserving CI and script cleanup** — no intended change to generated outputs.
> 
> Eight GitHub Actions workflows now run a **single** `git submodule update --init --remote --recursive` instead of separate init/recursive and remote update steps, while checkout still uses `submodules: true`.
> 
> `check_ibc_clients.mjs` **drops local copies** of `findStateAsset`, `materialiseStateAsset`, and inline state JSON loading in favor of **`lifecycle_helpers.mjs`** (`loadJSON` for `loadState()`).
> 
> `validate_zone_data.mjs` **narrows** the missing-IBC skip path to **killed** source chains only, removing **`archived` / `legacy`** branches documented as unreachable under the asset schema (`additionalProperties: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 388e0804bfe1a4d87cb1f213fcbfa28a71cb014b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->