### PR TITLE
ci: pin pnpm version so action-setup resolves it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@10.18.2",
   "dependencies": {
     "inlang": "^0.1.2",
     "pnpm": "^9.1.0",


### PR DESCRIPTION
Follow-up fix for #3596. The daily Generate All Files run failed at the Setup pnpm step:

```
Error: No pnpm version is specified.
```

`pnpm/action-setup@v6` needs a pnpm version and reads it from `package.json`'s `packageManager` field (or an explicit `version:` input). The repo had neither.

## Fix

Add `"packageManager": "pnpm@10.18.2"` to `package.json`.

**Why pnpm 10 and not 9:** the committed `pnpm-lock.yaml` stores `patchedDependencies` in the pnpm-10 format. `pnpm install --frozen-lockfile` errors under pnpm 9 (`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` on `patchedDependencies`) and succeeds under pnpm 10. The repo's `pnpm@^9.1.0` *dependency* is unrelated to the runner version and is left as-is to avoid a lockfile change here.

## Verification (clean node_modules)

- `pnpm@10.18.2 install --frozen-lockfile` succeeds from scratch.
- The `@inlang/cli` patch is applied afterward (the whole point of #3596).
- `pnpm inlang --version` runs (1.20.0).
- `pnpm-lock.yaml` is unchanged by the install.

This also fixes the same Setup pnpm step in `localization.yml`, `full_validation.yml`, and `check_verification_criteria.yml`, which read the same field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field for the package manager; no application or runtime logic changes.
> 
> **Overview**
> Adds **`"packageManager": "pnpm@10.18.2"`** to `package.json` so **`pnpm/action-setup@v6`** can resolve a pnpm version during CI (workflows such as generate all files, localization, and validation only call the action without a `version:` input).
> 
> **pnpm 10.18.2** is chosen to align with the existing lockfile’s pnpm-10 `patchedDependencies` format so **`pnpm install --frozen-lockfile`** keeps working; the separate `pnpm@^9.1.0` dependency entry is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 658c98d83c436f4813def132c311ffbe191b0a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->