### PR TITLE
ci: give the two PR validation workflows distinct, descriptive names

### DIFF
--- a/.github/workflows/validate_zone_data.yml
+++ b/.github/workflows/validate_zone_data.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     branches:
       - main
-name: Pull request workflow
+name: Validate against Chain Registry
 jobs:
   validate_zone_data:
-    name: Validate Zone Data
+    name: zone data
     runs-on: ubuntu-latest
     
     defaults:

--- a/.github/workflows/validate_zone_files.yml
+++ b/.github/workflows/validate_zone_files.yml
@@ -8,10 +8,10 @@ on:
   pull_request:
     branches:
       - main
-name: Pull request workflow
+name: Validate against Schema
 jobs:
   validate_zone_files:
-    name: Validate zone ${{ matrix.kind }}
+    name: ${{ matrix.kind }} files
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Both PR-triggered workflows were named `Pull request workflow`, so the Checks UI grouped unrelated checks under one ambiguous label. This renames them so each check reads as one phrase across the `workflow / job` slash.

## ⚠️ Branch protection needs updating

The check **context strings change**. If any of these are in the `main` required-checks list, update them in the same change or PRs will block waiting on the old (now-missing) names:

| Old context | New context |
|---|---|
| `Pull request workflow / Validate zone assets` | `Validate against Schema / assets files` |
| `Pull request workflow / Validate zone chains` | `Validate against Schema / chains files` |
| `Pull request workflow / Validate Zone Data` | `Validate against Chain Registry / zone data` |

## Changes

- `validate_zone_files.yml`: workflow `name` → **Validate against Schema**; job name → `${{ matrix.kind }} files`.
- `validate_zone_data.yml`: workflow `name` → **Validate against Chain Registry**; job name → `zone data`.

No behavior change, only the displayed workflow and job names. Both files parse and the matrix name template resolves to `assets files` / `chains files`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CI metadata changes; no runtime or validation logic is modified, though branch protection may need matching context renames.
> 
> **Overview**
> Renames the two PR validation workflows so GitHub Checks no longer share the generic **Pull request workflow** label.
> 
> **`validate_zone_files.yml`** uses workflow name **Validate against Schema** and job name **`${{ matrix.kind }} files`** (e.g. `assets files`, `chains files`). **`validate_zone_data.yml`** uses **Validate against Chain Registry** and job **zone data**. Steps, triggers, and scripts are unchanged.
> 
> **Branch protection:** required-check context strings follow `workflow name / job name`. Any rules still pointing at the old contexts must be updated or PRs can stall on missing checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2eeb542e2ca5f9cdab84870a1083c7612ea698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->