### PR TITLE
ci(generate-all): hide empty Quick summary rows

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -359,17 +359,20 @@ jobs:
           echo "" >> workflow-summary.md
 
           # ── Quick summary (top-of-PR glance) ──────────────────────────────
-          # One row per category. Lists chain names or asset symbols inline;
-          # empty categories render with a dim "none" so the reader can see
-          # what's currently quiet vs busy.
+          # One row per non-empty category. Empty categories are omitted
+          # entirely so the summary only lists what actually happened this run;
+          # if nothing did, a single "nothing notable" line stands in.
           echo "## 📋 Quick summary" >> workflow-summary.md
           echo "" >> workflow-summary.md
 
-          # Helper: emit a labelled row. When the category is empty it renders
-          # inline ("- {emoji} **{label}**: none") so quiet categories stay on
-          # one line and the reader can skim them. When there are entries the
-          # header line carries the count and each item is its own indented
-          # sub-bullet, so a populated list reads top-to-bottom.
+          # Tracks how many rows emit_row actually printed, so we can fall back
+          # to a "nothing notable" line when every category is empty.
+          QS_ROWS=0
+
+          # Helper: emit a labelled row only when the category has entries.
+          # Empty categories print nothing. A populated category renders a
+          # header line carrying the count, then one indented sub-bullet per
+          # item so it reads top-to-bottom.
           #
           # mode selects how each line of {file} is rendered:
           #   name           whole line is the display value (chain names)
@@ -388,14 +391,13 @@ jobs:
               esac
               count=${#items[@]}
             fi
-            if [ "$count" = "0" ]; then
-              echo "- ${emoji} **${label}**: none" >> workflow-summary.md
-            else
-              echo "- ${emoji} **${label} (${count}):**" >> workflow-summary.md
-              for item in "${items[@]}"; do
-                echo "  - ${item}" >> workflow-summary.md
-              done
-            fi
+            # Skip empty categories entirely.
+            [ "$count" = "0" ] && return 0
+            QS_ROWS=$((QS_ROWS + 1))
+            echo "- ${emoji} **${label} (${count}):**" >> workflow-summary.md
+            for item in "${items[@]}"; do
+              echo "  - ${item}" >> workflow-summary.md
+            done
           }
 
           emit_row "🆕" "New Chains" new-chains.txt name
@@ -432,6 +434,12 @@ jobs:
           emit_row "⏸️" "Extended halt set" /tmp/lc-extendedHaltSet.txt symbol
           emit_row "▶️" "Extended halt cleared" /tmp/lc-extendedHaltCleared.txt symbol
           emit_row "⏰" "Planned shutdown set" /tmp/lc-plannedShutdownSet.txt symbol
+
+          # If every category was empty, leave a single line so the section is
+          # never just a bare header.
+          if [ "$QS_ROWS" = "0" ]; then
+            echo "- _Nothing notable this run (metadata/endpoint refresh only)._" >> workflow-summary.md
+          fi
 
           echo "" >> workflow-summary.md
           echo "---" >> workflow-summary.md


### PR DESCRIPTION
Follow-up to the [AUTO] PR restructure (#3593). The Quick summary still printed a row for every category even when empty, so quiet runs showed a stack of "none" lines:

```
- 🆕 New Chains: none
- 🟢 IBC cleared: none
- 🆕 Manual halts added this run: none
- ⏸️ Extended halt set: none
- ▶️ Extended halt cleared: none
- ⏰ Planned shutdown set: none
```

## Fix

`emit_row` now skips empty categories entirely, so the Quick summary lists only what changed this run. A `QS_ROWS` counter drives a single fallback line ("Nothing notable this run") when every category is empty, so the section is never a bare header.

## Verified (dry-run against the latest run's data, PR #3601)

Before: 9 rows (3 populated, 6 "none"). After:

```
## 📋 Quick summary

- 🆕 New Assets (1):
  - VERONA
- 🔴 IBC flagged unstable (1):
  - NINJA (market)
- ⚠️ Manual halts in effect (3):
  - gravitybridge
  - persistence
  - quicksilver
```

The all-empty case renders just `- _Nothing notable this run (metadata/endpoint refresh only)._`. YAML parses and the summary step passes `bash -n`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only change to automated PR body generation; no runtime or asset pipeline logic affected.
> 
> **Overview**
> The **Generate All Files** workflow’s PR **Quick summary** no longer prints a row for every lifecycle category when that category had no changes.
> 
> `emit_row` now **returns without output** when a category file is empty, instead of writing `**label**: none`. A **`QS_ROWS`** counter tracks how many rows were emitted; if all categories are empty, a single italic fallback line (*Nothing notable this run (metadata/endpoint refresh only).*) is added so the section is never just a bare header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4f02ade28da2d0b891b927d720e8e5ae59005a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->