### PR TITLE
fix(assetlist): route Wormhole/Int3face alloy withdrawals to external connector

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6235,6 +6235,14 @@
       "override_properties": {
         "use_asset_name": true
       },
+      "transfer_methods": [
+        {
+          "name": "Int3face Bridge",
+          "type": "external_interface",
+          "deposit_url": "https://app.int3face.zone/bridge",
+          "withdraw_url": "https://app.int3face.zone/bridge"
+        }
+      ],
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "market"
     },
@@ -6726,6 +6734,14 @@
         "chain_name": "litecoin",
         "base_denom": "litoshi"
       },
+      "transfer_methods": [
+        {
+          "name": "Int3face Bridge",
+          "type": "external_interface",
+          "deposit_url": "https://app.int3face.zone/bridge",
+          "withdraw_url": "https://app.int3face.zone/bridge"
+        }
+      ],
       "_comment": "Litecoin $LTC",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "market"
@@ -6739,6 +6755,14 @@
         "chain_name": "bitcoincash",
         "base_denom": "sat"
       },
+      "transfer_methods": [
+        {
+          "name": "Int3face Bridge",
+          "type": "external_interface",
+          "deposit_url": "https://app.int3face.zone/bridge",
+          "withdraw_url": "https://app.int3face.zone/bridge"
+        }
+      ],
       "_comment": "Bitcoin Cash $BCH",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "market"
@@ -7245,6 +7269,14 @@
         "chain_name": "sui",
         "base_denom": "0x2::sui::SUI"
       },
+      "transfer_methods": [
+        {
+          "name": "Osmosis Wormhole Connect",
+          "type": "external_interface",
+          "deposit_url": "/wormhole?from=sui&to=osmosis&token=SUI",
+          "withdraw_url": "/wormhole?from=osmosis&to=sui&token=SUI"
+        }
+      ],
       "_comment": "Sui $SUI"
     },
     {
@@ -7256,6 +7288,14 @@
         "chain_name": "aptos",
         "base_denom": "0x1::aptos_coin::AptosCoin"
       },
+      "transfer_methods": [
+        {
+          "name": "Osmosis Wormhole Connect",
+          "type": "external_interface",
+          "deposit_url": "/wormhole?from=aptos&to=osmosis&token=APT",
+          "withdraw_url": "/wormhole?from=osmosis&to=aptos&token=APT"
+        }
+      ],
       "_comment": "Aptos Coin $APT",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "market"


### PR DESCRIPTION
## What

Adds alloy-level `external_interface` (external connector) transfer methods to five alloyed assets:

| Alloy | Connector added | Why |
|---|---|---|
| allSUI | Osmosis Wormhole Connect | **Bug:** no withdraw route at all |
| allAPT | Osmosis Wormhole Connect | **Bug:** no withdraw route at all |
| allBCH | Int3face Bridge | Defensive fallback |
| allLTC | Int3face Bridge | Defensive fallback |
| allTON | Int3face Bridge | Defensive fallback |

## Why

On withdraw, the frontend surfaces a usable route only if (a) an integrated quote provider returns a supported chain whose `chainType` is handled in the bridge `availableChains` switch, or (b) the alloy itself carries an `external_interface` method.

**allSUI / allAPT were broken:** their destination chains (`sui`, `aptos`) are supported by no integrated quote provider (Wormhole's provider is Solana-only) and are absent from the `availableChains` switch (which handles evm/cosmos/bitcoin/solana/tron/penumbra/doge/bitcoin-cash/litecoin/xrpl/ton). With no alloy-level `external_interface`, `hasSupportedChains` was false and the external-URL fallback found nothing, so withdrawals had no path. allSOL works because it carries the Wormhole Connect `external_interface`; mirroring it fixes SUI/APT (withdraw opens Wormhole Connect, which converts alloy to the `.wh` variant 1:1 and bridges out).

**allBCH / allLTC / allTON are a defensive hedge:** these withdraw solely via Int3face's in-app quote route. If that route ever becomes unavailable (live quote failure, `.int3` constituent removed while the frontend's hardcoded token config keeps the symbol, or the symbol dropped from the config), they would hit the same dead end, because the external-URL fallback only reads `external_interface` from the alloy itself, not its constituents. Adding the alloy-level Int3face connector (same form as allDOGE) lets them degrade gracefully.

## Scope

- Source file only: `osmosis-1/osmosis.zone_assets.json`. Generated artifacts are produced by CI and intentionally not edited here.
- `osmosis_disabled` is deliberately **not** used: it would route to the "IBC Connection Down" banner/modal and block deposits; the `external_interface` alone yields the clean inline connector (as the standalone Wormhole assets demonstrate).
- allSOL/allDOGE/allXRP/allTRUMP/allPENGU already carry alloy-level `external_interface` and are unchanged.

## Follow-up

The systemic fix (have the frontend's `getExternalUrls` aggregate `external_interface` methods from an alloy's constituents, so per-asset hedges like the BCH/LTC/TON entries become unnecessary) is tracked separately for the frontend repo.

## Testing

- `osmosis.zone_assets.json` parses; all five entries validated against `zone_assets.schema.json` (`transfer_methods` / `external_interface` shape).
- Confirmed `.wh` variant symbols (`SUI.wh`/`APT.wh`) resolve and their `variantGroupKey` links to the alloy, so the Wormhole convert step works.
- Audited all 28 alloys: SUI/APT were the only broken cases; BCH/LTC/TON the only Int3face single-point-of-failure alloys lacking an alloy-level connector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only updates to the zone asset list; no on-chain or application code changes, with URLs aligned to existing connector patterns.
> 
> **Overview**
> Adds alloy-level **`transfer_methods`** with **`external_interface`** to five alloyed assets in `osmosis.zone_assets.json` so the Osmosis frontend can show deposit/withdraw routes when integrated quotes do not cover the destination chain.
> 
> **allSUI** and **allAPT** get **Osmosis Wormhole Connect** URLs (same pattern as allSOL), fixing withdrawals that previously had no path because Sui/Aptos are not handled by in-app quote providers or `availableChains`.
> 
> **allTON**, **allLTC**, and **allBCH** get **Int3face Bridge** URLs as a fallback if the primary Int3face quote route fails, matching the defensive pattern used for assets like allDOGE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1a6184bc7a79a4ab7d28a162314f77a69b5bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->