### PR TITLE
feat(assetlist): add XION-to-Verona rebrand tooltip

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6960,7 +6960,11 @@
       "base_denom": "uxion",
       "path": "transfer/channel-89321/uxion",
       "osmosis_verified": true,
-      "tooltip_message": "This asset was XION until 2026-06-17, when the project rebranded to Verona and the ticker changed to VERONA. Source: https://verona.dev/blog/welcome-to-verona-the-intelligence-layer-for-ai",
+      "categories": [
+        "ai"
+      ],
+      "tooltip_message": "XION has rebranded to Verona on 17th June 2026. Source: https://verona.dev/blog/welcome-to-verona-the-intelligence-layer-for-ai",
+      "tooltip_expiry_date": "2026-09-15",
       "_comment": "Verona $VERONA"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6960,6 +6960,7 @@
       "base_denom": "uxion",
       "path": "transfer/channel-89321/uxion",
       "osmosis_verified": true,
+      "tooltip_message": "This asset was XION until 2026-06-17, when the project rebranded to Verona and the ticker changed to VERONA. Source: https://verona.dev/blog/welcome-to-verona-the-intelligence-layer-for-ai",
       "_comment": "Verona $VERONA"
     },
     {


### PR DESCRIPTION
## What

Adds a `tooltip_message` to the Verona (formerly XION, `xion`/`uxion`) asset noting that it was XION until the 2026-06-17 rebrand to Verona (ticker XION → VERONA), with a link to the announcement.

## Why

XION rebranded to Verona today. Per the announcement, it is the same network and the same token contract at 1:1 with nothing to migrate; the name and ticker update across explorers and exchanges over the coming days. Because chain-registry (the source of display metadata) still resolves this asset as XION, the live Osmosis UI shows XION in the interim, so a tooltip clarifies the prior name for users who know it as Verona.

## Scope

- Source file only: `osmosis-1/osmosis.zone_assets.json`, one line added. Generated artifacts are produced by CI and not edited here.
- No change to `chain_name`/`base_denom`/symbol; the canonical rename will follow upstream in chain-registry.

## Source

https://verona.dev/blog/welcome-to-verona-the-intelligence-layer-for-ai

## Testing

- `osmosis.zone_assets.json` parses; tooltip confirmed on the `xion`/`uxion` entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata-only edit to the zone assets JSON; no trading, bridge, or halt behavior changes.
> 
> **Overview**
> Updates the **`xion` / `uxion`** asset in `osmosis.zone_assets.json` so the Osmosis UI can explain the XION → Verona rebrand while upstream metadata still shows XION.
> 
> Adds an **`ai`** category, a **`tooltip_message`** with the 17 June 2026 rebrand date and link to the Verona announcement, and **`tooltip_expiry_date`** `2026-09-15` so the notice can drop off later. **`chain_name`**, **`base_denom`**, and IBC path are unchanged; display rename is expected to follow chain-registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a6a1fb4221dbf53fb795cded9412caa49830a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->