### PR TITLE
feat(lifecycle): auto-expire curator tooltips on a flagged date

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -61,6 +61,15 @@ jobs:
             osmosis-1/generated/state/state.json 2>/dev/null \
             > /tmp/manual-halts-prev.txt || touch /tmp/manual-halts-prev.txt
 
+      - name: Check Tooltip Expiry (curator-flagged removals/decays)
+        working-directory: ./.github/workflows/utility
+        # Runs first among the lifecycle scripts: an expired tooltip must be
+        # cleared (or decayed) before the lock-respecting scripts
+        # (check_ibc_clients, check_market_health, check_extended_halts)
+        # evaluate, so they don't treat an already-expired tooltip as a live
+        # curator lock for one extra run.
+        run: node check_tooltip_expiry.mjs osmosis-1 2>&1 | tee ../../../tooltip-expiry.log
+
       - name: Check IBC Client Status
         working-directory: ./.github/workflows/utility
         run: |
@@ -93,10 +102,6 @@ jobs:
           elif [ "$rc" -ne 0 ]; then
             exit $rc
           fi
-
-      - name: Check Tooltip Expiry (curator-flagged removals)
-        working-directory: ./.github/workflows/utility
-        run: node check_tooltip_expiry.mjs osmosis-1 2>&1 | tee ../../../tooltip-expiry.log
 
       - name: Add Chain Stubs
         working-directory: ./.github/workflows/utility

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -94,6 +94,10 @@ jobs:
             exit $rc
           fi
 
+      - name: Check Tooltip Expiry (curator-flagged removals)
+        working-directory: ./.github/workflows/utility
+        run: node check_tooltip_expiry.mjs osmosis-1 2>&1 | tee ../../../tooltip-expiry.log
+
       - name: Add Chain Stubs
         working-directory: ./.github/workflows/utility
         run: node add_chain_stubs.mjs osmosis-1

--- a/.github/workflows/utility/check_tooltip_expiry.mjs
+++ b/.github/workflows/utility/check_tooltip_expiry.mjs
@@ -1,0 +1,165 @@
+// Purpose:
+//   Curator-driven tooltip expiry. Daily cron, runs alongside the other
+//   lifecycle scripts (after check_extended_halts). A curator can flag a
+//   tooltip for automatic removal on a future date by adding an optional
+//   `tooltip_expiry_date` (ISO `YYYY-MM-DD`) next to `tooltip_message` on a
+//   zone_asset. Once that date has arrived (today >= expiry, UTC), this
+//   script deletes BOTH `tooltip_message` and `tooltip_expiry_date` from the
+//   source zone_assets.json, and the generator then propagates the absence
+//   into the generated outputs on the same daily PR.
+//
+//   Use this for tooltips whose informational value lapses on a known date:
+//   rebrand notices, time-boxed support windows, "until <date>" warnings.
+//   Do NOT set an expiry on a tooltip that documents a permanent condition
+//   (dead chain, compromised bridge): leave those without an expiry so they
+//   persist until a curator removes them by hand.
+//
+//   Interaction with the curator lock: other lifecycle scripts treat a
+//   non-empty `tooltip_message` as a lock that pauses their automation. This
+//   script is the one sanctioned path that clears a curator tooltip, and it
+//   only does so when the curator themselves set an expiry date that has
+//   passed. A tooltip with no `tooltip_expiry_date` is never touched here.
+//
+//   `tooltip_expiry_date` without a `tooltip_message` is a no-op orphan; it
+//   is cleaned up (deleted) so the source does not accumulate dangling keys.
+//
+// Usage:
+//   node check_tooltip_expiry.mjs [<zone_name>] [--dry-run]
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { loadJSON } from './lifecycle_helpers.mjs';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const positional = args.filter((a) => !a.startsWith('--'));
+const zoneBasePath = positional[0] || 'osmosis-1';
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const filePrefix = zoneBasePath.split('-')[0];
+const zoneAssetsPath = path.join(zonePath, `${filePrefix}.zone_assets.json`);
+const reportsDir = path.join(zonePath, 'generated', 'reports');
+
+// Parse an expiry date as an end-of-day UTC instant: a tooltip flagged for
+// 2026-06-30 stays live through all of June 30 (UTC) and is removed on the
+// first run dated July 1 or later. Returns null for an unparseable value so
+// a typo never silently expires a tooltip.
+function expiryInstantMs(value) {
+  if (typeof value !== 'string') return null;
+  const ms = Date.parse(`${value}T23:59:59.999Z`);
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function main() {
+  const zoneData = loadJSON(zoneAssetsPath);
+  const nowIso = new Date().toISOString();
+  const nowMs = new Date(nowIso).getTime();
+
+  const removals = [];
+  // Expiry dates that could not be parsed: surfaced so a curator can fix the
+  // typo. Never expires the tooltip (fail-safe: keep showing it).
+  const invalid = [];
+
+  for (const asset of zoneData.assets) {
+    const label = asset._comment ?? `${asset.chain_name}/${asset.base_denom}`;
+    const hasExpiry = Object.prototype.hasOwnProperty.call(
+      asset,
+      'tooltip_expiry_date'
+    );
+    if (!hasExpiry) continue;
+
+    // Orphan: an expiry date with no message. Nothing to expire; drop the
+    // dangling key so the source stays clean.
+    if (!asset.tooltip_message) {
+      delete asset.tooltip_expiry_date;
+      removals.push({ kind: 'orphan_expiry_cleared', asset: label });
+      continue;
+    }
+
+    const expiryMs = expiryInstantMs(asset.tooltip_expiry_date);
+    if (expiryMs === null) {
+      invalid.push({ asset: label, value: asset.tooltip_expiry_date });
+      continue;
+    }
+
+    if (nowMs >= expiryMs) {
+      const expiry = asset.tooltip_expiry_date;
+      delete asset.tooltip_message;
+      delete asset.tooltip_expiry_date;
+      removals.push({ kind: 'tooltip_expired', asset: label, expiry });
+    }
+  }
+
+  if (dryRun) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+    const reportPath = path.join(
+      reportsDir,
+      `tooltip_expiry_dry_run_${nowIso.slice(0, 10)}.md`
+    );
+    const lines = [
+      `# Tooltip expiry dry-run, ${nowIso}`,
+      ``,
+      `Removals: ${removals.length}`,
+      ``,
+      `| Kind | Asset |`,
+      `|------|-------|`,
+    ];
+    for (const r of removals) {
+      lines.push(`| ${r.kind} | ${r.asset} |`);
+    }
+    if (invalid.length > 0) {
+      lines.push(
+        ``,
+        `## Unparseable tooltip_expiry_date (tooltip kept, please fix)`,
+        ``,
+        `| Asset | Value |`,
+        `|-------|-------|`
+      );
+      for (const i of invalid) {
+        lines.push(`| ${i.asset} | ${i.value} |`);
+      }
+    }
+    fs.writeFileSync(reportPath, lines.join('\n') + '\n', 'utf8');
+    console.log(`\n📝 Dry-run report: ${reportPath}`);
+    return;
+  }
+
+  if (removals.length > 0) {
+    fs.writeFileSync(
+      zoneAssetsPath,
+      JSON.stringify(zoneData, null, 2) + '\n',
+      'utf8'
+    );
+    console.log(`✓ Updated ${zoneAssetsPath}`);
+  } else {
+    console.log('No changes needed.');
+  }
+
+  const byKind = {};
+  for (const r of removals) byKind[r.kind] = (byKind[r.kind] || 0) + 1;
+  console.log('\n' + '='.repeat(70));
+  console.log('  TOOLTIP EXPIRY SUMMARY');
+  console.log('='.repeat(70));
+  if (removals.length === 0) {
+    console.log('  (nothing expired)');
+  } else {
+    for (const [k, v] of Object.entries(byKind)) {
+      console.log(`  ${k.padEnd(28)}: ${v}`);
+    }
+    for (const r of removals) {
+      console.log(`   - ${r.kind.padEnd(26)} ${r.asset}`);
+    }
+  }
+
+  if (invalid.length > 0) {
+    console.log('\n' + '-'.repeat(70));
+    console.log('  UNPARSEABLE tooltip_expiry_date (tooltip kept, please fix)');
+    console.log('-'.repeat(70));
+    for (const i of invalid) {
+      console.log(`  ⚠️  ${(i.asset ?? '-').padEnd(28)} "${i.value}"`);
+    }
+  }
+}
+
+main();

--- a/.github/workflows/utility/check_tooltip_expiry.mjs
+++ b/.github/workflows/utility/check_tooltip_expiry.mjs
@@ -1,27 +1,42 @@
 // Purpose:
-//   Curator-driven tooltip expiry. Daily cron, runs alongside the other
-//   lifecycle scripts (after check_extended_halts). A curator can flag a
-//   tooltip for automatic removal on a future date by adding an optional
-//   `tooltip_expiry_date` (ISO `YYYY-MM-DD`) next to `tooltip_message` on a
-//   zone_asset. Once that date has arrived (today >= expiry, UTC), this
-//   script deletes BOTH `tooltip_message` and `tooltip_expiry_date` from the
-//   source zone_assets.json, and the generator then propagates the absence
-//   into the generated outputs on the same daily PR.
+//   Curator-driven tooltip expiry and decay. Daily cron, runs FIRST among the
+//   lifecycle scripts (before check_ibc_clients / check_market_health /
+//   check_extended_halts) so an expired tooltip is resolved before those
+//   lock-respecting scripts evaluate, rather than being honoured as a live
+//   curator lock for one extra run.
 //
-//   Use this for tooltips whose informational value lapses on a known date:
-//   rebrand notices, time-boxed support windows, "until <date>" warnings.
+//   A curator flags a tooltip for a dated change by adding an optional
+//   `tooltip_expiry_date` (ISO `YYYY-MM-DD`) next to `tooltip_message`. Once
+//   that date has arrived (today >= expiry, UTC, end-of-day inclusive), this
+//   script does one of two things on the source zone_assets.json, and the
+//   generator propagates the result on the same daily PR:
+//
+//     • Decay (preferred when the message should change rather than vanish):
+//       if `tooltip_decay_message` is also set, the tooltip_message is
+//       REPLACED by it and the expiry fields are cleared. Use this for a
+//       "supported until <date>" notice that should become "support has
+//       ended" rather than disappear. The decayed message has no expiry of
+//       its own, so it persists until a curator removes it by hand.
+//
+//     • Removal (no decay message set): both `tooltip_message` and
+//       `tooltip_expiry_date` are deleted. Use this for notices whose value
+//       fully lapses on the date: rebrands, time-boxed warnings.
+//
 //   Do NOT set an expiry on a tooltip that documents a permanent condition
 //   (dead chain, compromised bridge): leave those without an expiry so they
 //   persist until a curator removes them by hand.
 //
 //   Interaction with the curator lock: other lifecycle scripts treat a
 //   non-empty `tooltip_message` as a lock that pauses their automation. This
-//   script is the one sanctioned path that clears a curator tooltip, and it
-//   only does so when the curator themselves set an expiry date that has
-//   passed. A tooltip with no `tooltip_expiry_date` is never touched here.
+//   script is the one sanctioned path that clears or rewrites a curator
+//   tooltip, and it only does so when the curator themselves set an expiry
+//   date that has passed. A tooltip with no `tooltip_expiry_date` is never
+//   touched here. (A decayed tooltip is still a non-empty tooltip_message, so
+//   it continues to act as a curator lock for the other scripts.)
 //
-//   `tooltip_expiry_date` without a `tooltip_message` is a no-op orphan; it
-//   is cleaned up (deleted) so the source does not accumulate dangling keys.
+//   Orphan cleanup: `tooltip_expiry_date` (or `tooltip_decay_message`)
+//   without a `tooltip_message` is a no-op; the dangling key(s) are deleted
+//   so the source does not accumulate cruft.
 //
 // Usage:
 //   node check_tooltip_expiry.mjs [<zone_name>] [--dry-run]
@@ -56,7 +71,7 @@ function main() {
   const nowIso = new Date().toISOString();
   const nowMs = new Date(nowIso).getTime();
 
-  const removals = [];
+  const mutations = [];
   // Expiry dates that could not be parsed: surfaced so a curator can fix the
   // typo. Never expires the tooltip (fail-safe: keep showing it).
   const invalid = [];
@@ -67,13 +82,25 @@ function main() {
       asset,
       'tooltip_expiry_date'
     );
-    if (!hasExpiry) continue;
+    const hasDecay = Object.prototype.hasOwnProperty.call(
+      asset,
+      'tooltip_decay_message'
+    );
+    if (!hasExpiry && !hasDecay) continue;
 
-    // Orphan: an expiry date with no message. Nothing to expire; drop the
-    // dangling key so the source stays clean.
+    // Orphan: expiry/decay metadata with no message to act on. Nothing to
+    // expire; drop the dangling key(s) so the source stays clean.
     if (!asset.tooltip_message) {
       delete asset.tooltip_expiry_date;
-      removals.push({ kind: 'orphan_expiry_cleared', asset: label });
+      delete asset.tooltip_decay_message;
+      mutations.push({ kind: 'orphan_cleared', asset: label });
+      continue;
+    }
+
+    // A decay message with no expiry date can never fire: surface as invalid
+    // so the curator adds the date (don't silently drop a deliberate message).
+    if (!hasExpiry) {
+      invalid.push({ asset: label, value: '(decay set, no expiry date)' });
       continue;
     }
 
@@ -85,9 +112,20 @@ function main() {
 
     if (nowMs >= expiryMs) {
       const expiry = asset.tooltip_expiry_date;
-      delete asset.tooltip_message;
-      delete asset.tooltip_expiry_date;
-      removals.push({ kind: 'tooltip_expired', asset: label, expiry });
+      if (hasDecay && asset.tooltip_decay_message) {
+        // Decay: replace the message, drop the expiry metadata. The decayed
+        // message persists (no expiry of its own) until a curator clears it.
+        asset.tooltip_message = asset.tooltip_decay_message;
+        delete asset.tooltip_decay_message;
+        delete asset.tooltip_expiry_date;
+        mutations.push({ kind: 'tooltip_decayed', asset: label, expiry });
+      } else {
+        // Removal: no decay message, so the tooltip fully lapses.
+        delete asset.tooltip_message;
+        delete asset.tooltip_decay_message;
+        delete asset.tooltip_expiry_date;
+        mutations.push({ kind: 'tooltip_expired', asset: label, expiry });
+      }
     }
   }
 
@@ -100,18 +138,18 @@ function main() {
     const lines = [
       `# Tooltip expiry dry-run, ${nowIso}`,
       ``,
-      `Removals: ${removals.length}`,
+      `Mutations: ${mutations.length}`,
       ``,
       `| Kind | Asset |`,
       `|------|-------|`,
     ];
-    for (const r of removals) {
-      lines.push(`| ${r.kind} | ${r.asset} |`);
+    for (const m of mutations) {
+      lines.push(`| ${m.kind} | ${m.asset} |`);
     }
     if (invalid.length > 0) {
       lines.push(
         ``,
-        `## Unparseable tooltip_expiry_date (tooltip kept, please fix)`,
+        `## Invalid expiry/decay config (tooltip kept, please fix)`,
         ``,
         `| Asset | Value |`,
         `|-------|-------|`
@@ -125,7 +163,7 @@ function main() {
     return;
   }
 
-  if (removals.length > 0) {
+  if (mutations.length > 0) {
     fs.writeFileSync(
       zoneAssetsPath,
       JSON.stringify(zoneData, null, 2) + '\n',
@@ -137,24 +175,24 @@ function main() {
   }
 
   const byKind = {};
-  for (const r of removals) byKind[r.kind] = (byKind[r.kind] || 0) + 1;
+  for (const m of mutations) byKind[m.kind] = (byKind[m.kind] || 0) + 1;
   console.log('\n' + '='.repeat(70));
   console.log('  TOOLTIP EXPIRY SUMMARY');
   console.log('='.repeat(70));
-  if (removals.length === 0) {
-    console.log('  (nothing expired)');
+  if (mutations.length === 0) {
+    console.log('  (nothing expired or decayed)');
   } else {
     for (const [k, v] of Object.entries(byKind)) {
       console.log(`  ${k.padEnd(28)}: ${v}`);
     }
-    for (const r of removals) {
-      console.log(`   - ${r.kind.padEnd(26)} ${r.asset}`);
+    for (const m of mutations) {
+      console.log(`   - ${m.kind.padEnd(26)} ${m.asset}`);
     }
   }
 
   if (invalid.length > 0) {
     console.log('\n' + '-'.repeat(70));
-    console.log('  UNPARSEABLE tooltip_expiry_date (tooltip kept, please fix)');
+    console.log('  INVALID expiry/decay config (tooltip kept, please fix)');
     console.log('-'.repeat(70));
     for (const i of invalid) {
       console.log(`  ⚠️  ${(i.asset ?? '-').padEnd(28)} "${i.value}"`);

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Four orthogonal states describe an asset's transfer health. Each has a distinct 
 
 - **`planned_shutdown_date`** (string, ISO 8601 UTC, optional). Date when the asset is scheduled to be shut down. When the date is within 14 days, `check_extended_halts.mjs` pre-emptively sets `osmosis_halt_deposits=true` with reason `planned_shutdown`.
 
-**Tooltip override / curator lock.** The existing `tooltip_message` field doubles as the override signal for automation. If any asset has a non-empty `tooltip_message`, **no automated script will modify its halt or unstable flags** (the curator has taken ownership). Use this when you want to set a halt manually with bespoke context, or when you want to prevent the automated lifecycle from clearing a flag during recovery.
+**Tooltip override / curator lock.** The existing `tooltip_message` field doubles as the override signal for automation. If any asset has a non-empty `tooltip_message`, **no automated script will modify its halt or unstable flags** (the curator has taken ownership). Use this when you want to set a halt manually with bespoke context, or when you want to prevent the automated lifecycle from clearing a flag during recovery. The one sanctioned exception is a curator-set expiry: pairing `tooltip_message` with `tooltip_expiry_date` lets `check_tooltip_expiry.mjs` clear or decay the tooltip on that date (it runs first, before the lock-respecting scripts). See RB009.
 
 **Reason-vocabulary contract.** Each automated script only modifies flags whose current reason value it owns (see "Owners" above). This means `check_ibc_clients` will never overwrite a `manual` halt or an `extended_unstable_market` halt that another script set. To release a manual override, clear `tooltip_message` and either set the reason back to one the relevant script owns, or remove the flag and let the script re-derive it on the next run.
 
@@ -192,6 +192,10 @@ Four orthogonal states describe an asset's transfer health. Each has a distinct 
 - **`tooltip_message`** (string) - Custom on-hover tooltip message displayed for the asset.
   - Use for warnings, clarifications, or important notices to users
   - Example: "This asset is NOT affiliated with the Bad Kids NFT collection."
+
+- **`tooltip_expiry_date`** (string, ISO `YYYY-MM-DD`, optional) - Date on which `check_tooltip_expiry.mjs` acts on the tooltip at the daily PR: it removes `tooltip_message`, or, if `tooltip_decay_message` is set, replaces it. The tooltip stays live through the whole expiry day (UTC) and changes on the first run dated the next day. Use for time-bound notices (rebrands, "supported until `<date>`"); leave unset for permanent ones. See RB009.
+
+- **`tooltip_decay_message`** (string, optional) - Replacement applied on `tooltip_expiry_date` instead of removing the tooltip, for a notice that should change rather than vanish (e.g. "supported until `<date>`" → "support has ended"). Requires `tooltip_expiry_date`. The decayed message has no expiry of its own.
 
 - **`listing_date_time_utc`** (string, ISO 8601 format) - UTC timestamp when asset was listed on Osmosis Zone.
   - Format: `"YYYY-MM-DDTHH:MM:SSZ"`
@@ -509,6 +513,7 @@ The `Generate All Files` bundle workflow runs automatically and includes:
   - Creates minimal entries (chain_name + comment) for chains in `zone_assets.json` not yet in `zone_chains.json`
   - Makes it easy for maintainers to add custom RPC/REST endpoints later
   - All fields default to Chain Registry values unless explicitly overridden
+- Runs the **tooltip-expiry check** (`check_tooltip_expiry.mjs`): first lifecycle step; clears or decays any curator tooltip whose `tooltip_expiry_date` has passed (see "Asset lifecycle automation" below).
 - Runs the **bridge-state check** (`check_ibc_clients.mjs`): unified detection that drives both the IBC and killed-chain branches of the lifecycle (see "Asset lifecycle automation" below).
 - Runs the **market-health check** (`check_market_health.mjs`): independent unstable track driven by Numia liquidity/volume.
 - Runs the **extended-halts check** (`check_extended_halts.mjs`): 60-day deposit halt and planned-shutdown halt.
@@ -535,7 +540,7 @@ Individual generation workflows can be triggered manually via GitHub Actions:
 
 ### Asset lifecycle automation
 
-When an asset stops working, it moves through a single observable timeline anchored on `state.lastDowntimeDate`. Five automated scripts cooperate to drive that timeline, each with a well-defined scope and a non-overlapping set of "reason" enum values it owns.
+When an asset stops working, it moves through a single observable timeline anchored on `state.lastDowntimeDate`. Five automated scripts cooperate to drive that timeline, each with a well-defined scope and a non-overlapping set of "reason" enum values it owns. A sixth daily script, `check_tooltip_expiry.mjs`, owns no reason enum; it runs first to resolve any expired curator tooltip before the lock-respecting scripts evaluate.
 
 #### The four-state model
 
@@ -582,13 +587,15 @@ A second, independent track exists for market-driven unstable. When a verified, 
 
 #### Scripts in the daily cron (in order)
 
-1. **`check_ibc_clients.mjs`**, the unified bridge-state check. Detects IBC client status and source chain `status="killed"`. Owns reasons `ibc_client`, `source_chain_killed` (unstable) and `bridge_down`, `source_chain_killed` (halts). Implements the flap-vs-fresh-incident rule (within 30 days of recovery = continuation; beyond = fresh incident). Includes a "manual-flip safety net" that populates `state.lastDowntimeDate` if a curator manually sets `osmosis_unstable` without one.
+1. **`check_tooltip_expiry.mjs`**, the curator-driven tooltip expiry/decay. Runs first so an expired tooltip is cleared (or decayed via `tooltip_decay_message`) before the lock-respecting scripts below see it. Acts only on a curator-set `tooltip_expiry_date` that has passed; never touches a tooltip without one. Owns no halt/unstable reason enum.
 
-2. **`check_market_health.mjs`**, the market track. Owns reason `market` for unstable and is the **only** writer that fully recovers an asset from market-driven instability. Skipped for unverified, disabled, and preview assets, and for assets within the 23-day post-listing grace window. Alloyed assets are evaluated normally; constituents of an alloy inherit the alloy's volume and liquidity via `max(self, alloy)` so they are not falsely flagged when their standalone Numia row reads zero but the alloy carries real activity. Constituent membership is determined from SQS pool composition (positive balance in the alloyed transmuter pool).
+2. **`check_ibc_clients.mjs`**, the unified bridge-state check. Detects IBC client status and source chain `status="killed"`. Owns reasons `ibc_client`, `source_chain_killed` (unstable) and `bridge_down`, `source_chain_killed` (halts). Implements the flap-vs-fresh-incident rule (within 30 days of recovery = continuation; beyond = fresh incident). Includes a "manual-flip safety net" that populates `state.lastDowntimeDate` if a curator manually sets `osmosis_unstable` without one.
 
-3. **`check_extended_halts.mjs`**, the 60-day rule and planned-shutdown rule. Owns reasons `extended_unstable_market` and `planned_shutdown` for deposit halts. Pre-emptively halts deposits 14 days before a `planned_shutdown_date`.
+3. **`check_market_health.mjs`**, the market track. Owns reason `market` for unstable and is the **only** writer that fully recovers an asset from market-driven instability. Skipped for unverified, disabled, and preview assets, and for assets within the 23-day post-listing grace window. Alloyed assets are evaluated normally; constituents of an alloy inherit the alloy's volume and liquidity via `max(self, alloy)` so they are not falsely flagged when their standalone Numia row reads zero but the alloy carries real activity. Constituent membership is determined from SQS pool composition (positive balance in the alloyed transmuter pool).
 
-4. **`report_dead_chains.mjs`** (report-only, owns no reason enum and writes no lifecycle flags). Maintains the per-chain dead-endpoint streak in `generated/state/dead_chain_streaks.json` and renders the "Dead chain candidates" and "Possible planned shutdowns" sections of the PR body. The cheap streak counter runs every day; the heavier half (governance-proposal scan plus cosmos.directory corroboration, and the published candidate list) runs only on the Monday `--weekly` invocation to bound CI cost and external load. A chain reaching the 7-run all-endpoints-failed streak and corroborated as dead is a candidate for a `source_chain_killed` flag plus an upstream chain-registry `status: killed` PR.
+4. **`check_extended_halts.mjs`**, the 60-day rule and planned-shutdown rule. Owns reasons `extended_unstable_market` and `planned_shutdown` for deposit halts. Pre-emptively halts deposits 14 days before a `planned_shutdown_date`.
+
+5. **`report_dead_chains.mjs`** (report-only, owns no reason enum and writes no lifecycle flags). Maintains the per-chain dead-endpoint streak in `generated/state/dead_chain_streaks.json` and renders the "Dead chain candidates" and "Possible planned shutdowns" sections of the PR body. The cheap streak counter runs every day; the heavier half (governance-proposal scan plus cosmos.directory corroboration, and the published candidate list) runs only on the Monday `--weekly` invocation to bound CI cost and external load. A chain reaching the 7-run all-endpoints-failed streak and corroborated as dead is a candidate for a `source_chain_killed` flag plus an upstream chain-registry `status: killed` PR.
 
 #### Bi-weekly cron
 
@@ -603,7 +610,7 @@ A second, independent track exists for market-driven unstable. When a verified, 
 - **`--dry-run` flag.** Every writer script accepts `--dry-run`, which emits a markdown report of intended mutations without writing any file. Always use this before enabling a fresh script in CI or after a chain-registry submodule bump that might flip many chains at once.
 - **Mutation cap.** `check_ibc_clients.mjs` and `check_extended_halts.mjs` will not write changes touching more than **10 distinct source chains** in a single run. If exceeded, the script exits with code 2 and demands a `--force` flag. This catches mass-flips from upstream regressions. `check_market_health.mjs` is exempt: market-wide liquidity/volume swings legitimately move many chains at once, so it always applies its full diff.
 - **Reason-vocabulary contract.** Each reason enum value has exactly one owner script (or `manual` = the curator). No two scripts ever race on the same flag.
-- **Curator lock.** Any non-empty `tooltip_message` on a halted or unstable asset is treated as curator-owned and never overwritten by automation. To release the lock, clear the tooltip.
+- **Curator lock.** Any non-empty `tooltip_message` on a halted or unstable asset is treated as curator-owned and never overwritten by automation. To release the lock, clear the tooltip, or set a `tooltip_expiry_date` and let `check_tooltip_expiry.mjs` clear/decay it on that date (the one sanctioned auto-clear path; it runs first so the lock is released before the other scripts evaluate).
 
 ### Pull Request Workflow
 

--- a/RUNBOOKS.md
+++ b/RUNBOOKS.md
@@ -1023,7 +1023,7 @@ Edit the zone_assets entry directly:
 Two changes from an auto-set halt:
 
 1. The `*_halt_reason` is set to `manual`. Script-owned reasons get auto-cleared on recovery; `manual` does not.
-2. `tooltip_message` is non-empty. Any tooltip locks the asset against all automation.
+2. `tooltip_message` is non-empty. Any tooltip locks the asset against all automation. The one sanctioned exception is a curator-set expiry: if you also set `tooltip_expiry_date`, `check_tooltip_expiry.mjs` will clear or decay the tooltip on that date (see RB009).
 
 Commit and let the daily cron run. Verify the asset is now ignored by automation by checking the next workflow summary's "Manual halts currently in effect" section.
 
@@ -1091,3 +1091,47 @@ A cap hit usually means one of: a chain-registry submodule bump flipped many cha
 - `--force` only bypasses the chain-count cap; all the script's other guards (owned-reason checks, tooltip locks) still apply.
 - The cap value lives in `MAX_CHAINS_PER_RUN` in each script. Raise it only with a clear reason; the point is to catch mass-flips before they ship onchain.
 - If both scripts capped in the same run, triage them independently; they own different reason vocabularies.
+
+---
+
+### RB009: Set a tooltip that expires or decays on a date
+
+**Use when**: a `tooltip_message` only makes sense for a known period: a rebrand notice, a "supported until `<date>`" window, or any "until `<date>`" warning. Instead of relying on someone to delete it later, flag the change at write time and let the daily cron apply it.
+
+**Purpose**: `check_tooltip_expiry.mjs` runs first among the lifecycle scripts each day. On the expiry date it either removes the tooltip or replaces it with a decay message, writes the source `osmosis.zone_assets.json`, and the generator ships the result in the same `[AUTO]` PR.
+
+#### Procedure
+
+Add `tooltip_expiry_date` (ISO `YYYY-MM-DD`) next to the `tooltip_message`. Optionally add `tooltip_decay_message` to change the text instead of removing it.
+
+Remove on the date (rebrand, one-off notice):
+
+```json
+{
+  "chain_name": "examplehub",
+  "base_denom": "uex",
+  "tooltip_message": "EXAMPLE has rebranded to NEW on 2026-06-17. Source: https://...",
+  "tooltip_expiry_date": "2026-09-15"
+}
+```
+
+Decay on the date (notice should change, not vanish):
+
+```json
+{
+  "chain_name": "examplehub",
+  "base_denom": "uex",
+  "tooltip_message": "Bridged via Example Bridge, supported through 2026-06-30. Withdraw before then.",
+  "tooltip_expiry_date": "2026-06-30",
+  "tooltip_decay_message": "Example Bridge support ended on 2026-06-30. Withdrawals are no longer available."
+}
+```
+
+Commit and let the daily cron run. On the first run dated after the expiry day (the tooltip stays live through the whole expiry day, UTC), the expiry fields are cleared and the tooltip is removed or replaced.
+
+#### Notes
+
+- A tooltip with no `tooltip_expiry_date` is never auto-touched. Leave permanent notices (dead chains, compromised bridges) without an expiry.
+- A decayed tooltip is a normal `tooltip_message` with no expiry of its own, so it persists and still acts as a curator lock against the other lifecycle scripts until someone removes it by hand.
+- Fail-safe: an unparseable `tooltip_expiry_date`, or a `tooltip_decay_message` with no expiry date, does not change the tooltip; it is surfaced in the run summary and the `--dry-run` report (`generated/reports/tooltip_expiry_dry_run_<date>.md`) for a curator to fix.
+- Preview what a run would do without writing: `cd .github/workflows/utility && node check_tooltip_expiry.mjs osmosis-1 --dry-run`.

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -105,7 +105,11 @@
         "tooltip_expiry_date": {
           "type": "string",
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-          "description": "Optional ISO date (YYYY-MM-DD) on which check_tooltip_expiry.mjs automatically removes this asset's tooltip_message (and this field) at the daily PR. The tooltip stays live through the whole expiry day (UTC) and is removed on the first run dated the following day. Only set this for tooltips whose value lapses on a known date (rebrands, time-boxed warnings); leave it unset for permanent notices."
+          "description": "Optional ISO date (YYYY-MM-DD) on which check_tooltip_expiry.mjs acts on this asset's tooltip at the daily PR: if tooltip_decay_message is set it replaces tooltip_message with it, otherwise it removes tooltip_message. Either way this field (and tooltip_decay_message) is cleared. The tooltip stays live through the whole expiry day (UTC) and changes on the first run dated the following day. Only set this for tooltips whose value lapses on a known date (rebrands, time-boxed warnings); leave it unset for permanent notices."
+        },
+        "tooltip_decay_message": {
+          "type": "string",
+          "description": "Optional replacement tooltip applied on tooltip_expiry_date instead of removing the tooltip outright. Use when a notice should change rather than vanish (e.g. a 'supported until <date>' message decaying to 'support has ended'). Requires tooltip_expiry_date to be set. The decayed message has no expiry of its own and persists until a curator removes it."
         },
         "listing_date_time_utc": {
           "type": "string",

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -102,6 +102,11 @@
           "type": "string",
           "description": "A custom on-hover tooltip message descirbing the asset on the Osmosis Zone app."
         },
+        "tooltip_expiry_date": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "description": "Optional ISO date (YYYY-MM-DD) on which check_tooltip_expiry.mjs automatically removes this asset's tooltip_message (and this field) at the daily PR. The tooltip stays live through the whole expiry day (UTC) and is removed on the first run dated the following day. Only set this for tooltips whose value lapses on a known date (rebrands, time-boxed warnings); leave it unset for permanent notices."
+        },
         "listing_date_time_utc": {
           "type": "string",
           "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"


### PR DESCRIPTION
## What

Adds a system for tooltips to be flagged for automatic removal on a future date at the daily PR.

- New optional field `tooltip_expiry_date` (`YYYY-MM-DD`) alongside `tooltip_message` on a zone_asset.
- New lifecycle script `.github/workflows/utility/check_tooltip_expiry.mjs` that, on the daily run, deletes both `tooltip_message` and `tooltip_expiry_date` from the source `osmosis.zone_assets.json` once the expiry date has passed (UTC, inclusive of the whole expiry day). The generator then propagates the removal into `generated/` on the same PR.
- Wired into `generate_all_files.yml` immediately after `check_extended_halts`.
- Documented the field in `zone_assets.schema.json`.

## Why

Some tooltips have a natural shelf life (rebrand notices, time-boxed support windows like "supported through June 30 2026"). Today they linger until someone remembers to remove them. This lets a curator set the removal date when they write the tooltip.

## Design notes

- **Curator-lock interaction:** other lifecycle scripts treat a non-empty `tooltip_message` as a lock that pauses their automation. This script is the single sanctioned path that clears a curator tooltip, and only when the curator themselves set an expiry date that has passed. A tooltip with no `tooltip_expiry_date` is never touched, so permanent notices (dead chains, compromised bridges) are unaffected.
- **Boundary semantics:** the tooltip stays live through the entire expiry day (UTC end-of-day) and is removed on the first run dated the following day.
- **Fail-safe:** an unparseable `tooltip_expiry_date` does not expire the tooltip; it is surfaced in the run summary/dry-run report for a curator to fix.
- **Orphan cleanup:** a `tooltip_expiry_date` with no `tooltip_message` is a no-op and is deleted to keep the source clean.
- Mirrors the existing `check_extended_halts.mjs` pattern (loadJSON, source write-back, dry-run report under `generated/reports/`, summary block).

## Testing

- Unit-tested the expiry decision logic across cases: past date → removed; expiry-day boundary → kept; future → kept; orphan → cleaned; invalid date → kept and flagged; no expiry → untouched.
- `node check_tooltip_expiry.mjs osmosis-1 --dry-run` and a live run both execute cleanly against current data (no asset currently carries an expiry date, so a live run is a no-op).
- Schema JSON and workflow YAML validated.

## Note

This PR also covers the "audit existing tooltips" task: removal candidates were reviewed and are being handled in the relevant per-asset branches (e.g. the Coreum/TX rebrand and the Verona/XION 90-day expiry, which is the first consumer of this feature).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The script is the only automated path that clears or rewrites curator `tooltip_message`, which affects halt/unstable automation ordering; risk is mitigated by requiring an explicit expiry date, fail-safe parsing, and running before lock-respecting lifecycle scripts.
> 
> **Overview**
> Adds **scheduled tooltip expiry/decay** for time-bound curator notices on zone assets.
> 
> Curators can set optional `tooltip_expiry_date` (`YYYY-MM-DD`) and, when needed, `tooltip_decay_message` next to `tooltip_message`. New `check_tooltip_expiry.mjs` runs **first** in the daily `Generate All Files` pipeline (before IBC, market, and extended-halt checks) so an expired tooltip is removed or rewritten **before** other scripts treat a stale `tooltip_message` as a curator lock.
> 
> On the first run after the expiry day (UTC, end-of-day inclusive), the script either **replaces** the tooltip with the decay text or **deletes** the tooltip and expiry fields; it also cleans orphan expiry metadata and **does not** expire on bad config (invalid dates are reported; tooltips stay visible).
> 
> Schema (`zone_assets.schema.json`), README lifecycle docs, and **RB009** in `RUNBOOKS.md` document the fields and the sanctioned exception to the curator-lock rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91cc7fd443f13832e15997dba840efe010a79d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->