### PR TITLE
chore(assetlist): tooltip audit cleanups

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3292,7 +3292,6 @@
       "base_denom": "ucore",
       "path": "transfer/channel-2188/ucore",
       "osmosis_verified": true,
-      "tooltip_message": "Coreum has rebranded to TX - https://www.mintscan.io/coreum/proposals/29",
       "categories": [
         "bridges"
       ],
@@ -3403,6 +3402,8 @@
       "path": "transfer/channel-874/factory/neutron1ug740qrkquxzrk2hh29qrlx3sktkfml3je7juusc2te7xmvsscns0n2wry/wstETH",
       "osmosis_verified": true,
       "tooltip_message": "The canonical interchain wstETH contracts currently hosted on Neutron are only guaranteed to be supported through June 30 2026 due to Neutron transitioning to long-term support. To withdraw to Ethereum follow this guide: https://x.com/neutron_org/status/2034971022236004762",
+      "tooltip_expiry_date": "2026-06-30",
+      "tooltip_decay_message": "Guaranteed support for the canonical interchain wstETH contracts on Neutron ended on 30 June 2026 as Neutron transitioned to long-term support. To withdraw to Ethereum follow this guide: https://x.com/neutron_org/status/2034971022236004762",
       "canonical": {
         "chain_name": "ethereum",
         "base_denom": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0"
@@ -7486,7 +7487,7 @@
       "base_denom": "unil",
       "path": "transfer/channel-98416/unil",
       "osmosis_verified": true,
-      "tooltip_message": "NilChain is halting 23rd March 2026. Transfers will no longer be possible after the halt. See Nillion socials for more information.",
+      "tooltip_message": "NilChain halted on 23 March 2026 and is no longer producing blocks. Deposits and withdrawals are disabled. See Nillion socials for more information.",
       "_comment": "Nillion $NIL",
       "categories": [
         "privacy"


### PR DESCRIPTION
## What

Acts on the tooltip audit (74 tooltips reviewed). Three changes:

- **Remove $TX (Coreum)** — deletes the "Coreum has rebranded to TX" tooltip. The rebrand is well-established; the notice no longer carries useful information.
- **Decay $wstETH (Neutron)** — flags the "supported through June 30 2026" notice to auto-decay on `2026-06-30` into a past-tense "support ended" message, using the `tooltip_expiry_date` + `tooltip_decay_message` mechanism. First production use of the decay path.
- **Reword $NIL (Nillion)** — "NilChain is halting 23rd March 2026" → past tense, since the date has passed and the chain has halted. The `source_chain_killed` halt flags are already set and unchanged; this is wording-only.

## Audit outcome (no change needed)

The remaining ~71 tooltips were reviewed and kept:
- **Dead-chain notices** (Evmos, Stargaze, e-Money, Router, MilkyWay, OmniFlix, PundiX, Onomy, etc.): persist while the asset is listed and halted.
- **Ongoing situations** (Gravity Bridge compromised, Quicksilver halted): keep until resolved.
- **Comdex / Sei** notices: mention a past date but describe a standing state that is still accurate; kept as-is.
- **BADKID** "NOT affiliated" disclaimer: permanent.
- **$VERONA** (XION rebrand): already carries an expiry (2026-09-15) from its own PR.

## Testing

- `osmosis.zone_assets.json` parses (858 assets); $wstETH expiry matches the schema date pattern.
- `check_tooltip_expiry.mjs --dry-run` against current data: 0 mutations (wstETH correctly future-dated).
- Simulated a 2026-07-01 run: $wstETH correctly decays to the "support ended" message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing tooltip copy and optional decay metadata only; no trading, routing, or halt logic changes beyond aligning NIL wording with existing kill flags.
> 
> **Overview**
> Updates **Osmosis zone asset tooltips** after a tooltip audit—copy and metadata only in `osmosis.zone_assets.json`, no halt-flag changes except where wording reflects an already-halted chain.
> 
> **$TX (Coreum):** Removes the Coreum→TX rebrand tooltip; the notice is no longer considered useful.
> 
> **Neutron wstETH:** Adds the first production use of **`tooltip_expiry_date`** (`2026-06-30`) and **`tooltip_decay_message`** so the “supported through June 30 2026” notice can auto-switch to past-tense “support ended” after that date.
> 
> **$NIL (Nillion):** Rewords the tooltip to past tense (chain halted 23 March 2026); existing `source_chain_killed` deposit/withdraw halts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64c3cbde7a2bd0279e3bd865d5b640d3171ae02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->