### PR TITLE
chore(assetlist): drop STARS.old override (HOLD for chain-registry STARS.og rename)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -299,10 +299,6 @@
       "categories": [
         "nft_protocol"
       ],
-      "override_properties": {
-        "name": "Stargaze (old)",
-        "symbol": "STARS.old"
-      },
       "_comment": "Stargaze (old) $STARS.old",
       "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. This is the old STARS; deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
       "osmosis_unstable": true,


### PR DESCRIPTION
> [!WARNING]
> **DRAFT / DO NOT MERGE YET.** Merge only **after** the cosmos/chain-registry rename of old Stargaze STARS → `STARS.og` has landed and synced into the `chain-registry` submodule.

## What

Removes the `override_properties` block (`name: "Stargaze (old)"`, `symbol: "STARS.old"`) on `stargaze`/`ustars` so the asset inherits its symbol and name directly from the chain registry.

## Why hold

The generator applies `override_properties.symbol` with absolute precedence (`setSymbol` in `generate_assetlist_functions.mjs` short-circuits before reading chain-registry). So today the override is what produces `STARS.old`.

**Chain-registry currently still publishes `symbol: "STARS"` / `name: "Stargaze"` for `ustars`** — the `STARS.og` rename has not merged upstream. If this PR merges before that rename:
- the asset would render as plain **`STARS`**, colliding with the migrated Cosmos Hub STARS, and
- the dead-chain distinction would be lost.

Once chain-registry renames it to `STARS.og`, removing the override lets the asset inherit `STARS.og` (and whatever name upstream sets) cleanly, with no further manual override to maintain.

## Merge checklist

- [ ] cosmos/chain-registry has merged the old-STARS → `STARS.og` rename
- [ ] the `chain-registry` submodule in this repo has synced to include it (verify `chain-registry/stargaze/assetlist.json` shows `symbol: STARS.og` for `ustars`)
- [ ] then un-draft and merge; confirm the next generated `assetlist.json` shows `STARS.og`

## Unchanged

The `source_chain_killed` tooltip and the deposit/withdrawal halts on this entry are kept as-is; this PR only drops the symbol/name override.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Asset display depends on chain-registry timing; merging before the STARS.og rename could mislabel the dead-chain token as plain STARS.
> 
> **Overview**
> Removes the **`override_properties`** block on the legacy Stargaze `ustars` IBC entry in `osmosis.zone_assets.json`, so **`name`** and **`symbol`** come from chain-registry on the next assetlist generation instead of the hard-coded **"Stargaze (old)"** / **`STARS.old`**.
> 
> Deposit/withdrawal halts, **`source_chain_killed`** flags, and the migration tooltip are unchanged. This is intended to merge only after upstream chain-registry renames old `ustars` to **`STARS.og`**; merging sooner would drop the override while registry may still expose plain **`STARS`**, risking confusion with Hub STARS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0a68f049527f6b51cbb5bac7af1d00f5aad5ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->