### PR TITLE
fix(lifecycle): killed source chain takes precedence over manual-inherit

### DIFF
--- a/.github/workflows/utility/check_ibc_clients.mjs
+++ b/.github/workflows/utility/check_ibc_clients.mjs
@@ -689,7 +689,15 @@ async function main() {
         // transient Active reading. A human must clear it deliberately.
         // Pre-existing entries are never converted here — only newly created
         // ones — so this can't silently rewrite a curator's existing choice.
-        if (isNewEntry && manualHaltChains.has(fa.chainName)) {
+        //
+        // Killed takes precedence over manual: when the source chain is
+        // status="killed" in the registry, a new asset is a dead-chain asset,
+        // so it must get the script-owned `source_chain_killed` reason (set on
+        // the normal path below), not `manual`. Otherwise a killed chain that
+        // also happens to be in the manual-halt set (e.g. a chain we flagged
+        // manually before the registry caught up) would mislabel its backfilled
+        // assets as a curator decision and lock them against auto-clear.
+        if (isNewEntry && manualHaltChains.has(fa.chainName) && !chainKilled) {
           zoneAsset.osmosis_unstable = true;
           zoneAsset.osmosis_unstable_reason = 'manual';
           zoneAsset.osmosis_halt_deposits = true;


### PR DESCRIPTION
## What

In `check_ibc_clients.mjs`, the "manual-inherit" guard for newly-created assets now also requires the source chain **not** to be `status: killed`:

```diff
-if (isNewEntry && manualHaltChains.has(fa.chainName)) {
+if (isNewEntry && manualHaltChains.has(fa.chainName) && !chainKilled) {
```

## Why

When the killed-chain backfill creates a stub for an asset on a chain that is **both** in our manual-halt set **and** `status: killed` upstream, the manual-inherit guard fired first and stamped the asset `manual` (deposit + withdrawal halt reasons), short-circuiting the normal path that would have stamped the script-owned `source_chain_killed`.

This is wrong on two counts:
- **Inaccurate reason:** a dead-chain asset should read `source_chain_killed`, not `manual` (which implies a curator decision and drives a different banner).
- **Locks against auto-clear:** `manual` + the inherit tooltip make every `canModify*` gate short-circuit forever, so if the chain ever revived, automation could never clear the halt.

This surfaced with Stargaze: we flagged it `source_chain_killed` manually a few days ago; upstream then flipped `stargaze` to `killed` (cosmos/chain-registry #7739) and renamed STARS → STARS.legacy. The next daily run's killed-chain backfill created stubs for Stargaze's long-existing tokenfactory assets (GAZE et al., which were already in the generated frontend assetlist) and mislabelled them `manual` instead of `source_chain_killed`.

With this change, killed chains fall through to the normal bridge-down path and get `source_chain_killed`. The guard's original purpose — locking newly-appeared assets on a manually-halted-but-still-live chain — is unchanged (it only stops applying when the chain is registry-killed).

## Verification

Repo has no unit-test harness, so verified the branch logic directly across the cases:

| isNewEntry | manualHalted | chainKilled | reason |
|---|---|---|---|
| true | true | **true** | `source_chain_killed` ✓ (was `manual`) |
| true | true | false | `manual` ✓ (guard preserved) |
| true | false | true | `source_chain_killed` ✓ |
| false | true | true | `source_chain_killed` ✓ |

Syntax checked (`node --check`).

## Follow-up (separate PR)

This fixes future runs. The ~11 Stargaze entries already mislabelled `manual` by the previous run will be corrected (manual → source_chain_killed) in the Stargaze cleanup PR, alongside the STARS.legacy / suffix-override work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional and comments in the IBC lifecycle script; behavior change is narrowly scoped to new assets on killed+manual-halt chains, with no auth or data-store impact.
> 
> **Overview**
> Fixes **priority between two halt paths** in `check_ibc_clients.mjs` when the script creates a **new** zone asset on bridge-down.
> 
> The manual-inherit guard (new assets on a chain where every listed asset is curator-locked) now runs only when the source chain is **not** registry-`killed` (`&& !chainKilled`). If the chain is both in the manual-halt set and `status: killed`, new stubs skip manual stamping and follow the normal bridge-down path with script-owned **`source_chain_killed`** reasons instead of **`manual`** plus the inherit tooltip.
> 
> That avoids mislabeling dead-chain backfills as curator decisions and prevents those entries from being permanently locked against automation auto-clear. **Live** chains that are fully manually halted still get manual-inherit for newly appearing assets; pre-existing rows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff522dc2eecb05c426f0e97a72387d25c432c1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->