### PR TITLE
docs: drop unverified Numia chain-registry-assetlist consumer line

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,6 @@ Apps, interfaces, and tools that consume data from this repository:
   - `generated/frontend/assetlist.json`
 - **Numia Data Services**:
   - `generated/frontend/assetlist.json`
-  - `generated/chain-registry/assetlist.json`
 
 ### Data Providers (Bidirectional Dependencies)
 External services that provide data TO this repository:


### PR DESCRIPTION
## What

Removes one line from the README "Data Consumers" section:

```diff
 - **Numia Data Services**:
   - `generated/frontend/assetlist.json`
-  - `generated/chain-registry/assetlist.json`
```

## Why

The section claimed Numia consumes this repo's **generated** `chain-registry/assetlist.json` (a chain-registry-*format* file we produce), not the canonical `cosmos/chain-registry`. That line was written from memory when the Data Consumers section was first added, and isn't a verified integration — a data provider would normally consume either the frontend assetlist or the canonical chain registry, not our derived registry-format output.

Rather than assert an unverified alternative, this just drops the unverified entry and leaves the `frontend/assetlist.json` line.

If someone confirms with the Numia integration owner exactly which file(s) they pull, the list can be made precise then.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no effect on generated artifacts or runtime behavior.
> 
> **Overview**
> Updates the README **Data Consumers** section so Numia is no longer listed as consuming `generated/chain-registry/assetlist.json`.
> 
> The **Numia Data Services** bullet still documents consumption of `generated/frontend/assetlist.json` only, aligning the doc with a verified integration rather than an unconfirmed derived registry-format output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e2f9afcc08f37bebf1c31427c943eda5d7527b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->