### PR TITLE
Update Stargaze asset details and comments

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11549,7 +11549,7 @@
       "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. Deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/"
     },
     {
-      "chainName": "cosmoshub",
+      "chain_name": "cosmoshub",
       "base_denom": "factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
       "path": "transfer/channel-0/factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
       "categories": [

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -300,9 +300,10 @@
         "nft_protocol"
       ],
       "override_properties": {
-        "symbol": "STARS.legacy"
+        "symbol": "STARS.og",
+        "name": "Stargaze (Original)"
       },
-      "_comment": "Stargaze (Stargaze) $STARS.legacy",
+      "_comment": "Stargaze (Original) $STARS.og",
       "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. This is the old STARS; deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "source_chain_killed",
@@ -11546,6 +11547,14 @@
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed",
       "tooltip_message": "The Stargaze chain has shut down as the project migrated to the Cosmos Hub. Deposits and withdrawals are closed. Migrate your assets via https://automigration.stargaze.zone/"
+    },
+    {
+      "chainName": "cosmoshub",
+      "base_denom": "factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
+      "path": "transfer/channel-0/factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
+      "categories": [
+        "nft_protocol"
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only changes to asset labels and a new listing entry; no application logic or security-sensitive code.
> 
> **Overview**
> Updates Osmosis zone asset metadata for the Stargaze shutdown / Cosmos Hub migration.
> 
> The legacy IBC **Stargaze** `ustars` entry is rebranded from **`STARS.legacy`** to **`STARS.og`** with override name **Stargaze (Original)** and matching `_comment` text; halt/unstable flags and the automigration tooltip stay as-is.
> 
> A new **`cosmoshub`** asset is added for **`factory/.../ustars`** over **`transfer/channel-0`**, categorized as **`nft_protocol`**, representing migrated STARS on the Hub.
> 
> Also fixes the JSON file terminator (proper closing `}` and newline at EOF).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c064cf9bf0ca4c6ace1a445da241a185b424923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->