### PR TITLE
data: flag STARS staking derivatives as source_chain_killed

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1514,7 +1514,8 @@
       ],
       "_comment": "Stride Staked STARS $stSTARS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "source_chain_killed",
+      "tooltip_message": "The Stargaze chain has shut down and migrated to the Cosmos Hub. This is a liquid-staked derivative of the old STARS; the underlying stake can no longer be unbonded on Stargaze. Redeem or unwind via Stride and migrate STARS via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "juno",
@@ -1939,12 +1940,12 @@
       ],
       "_comment": "Quicksilver Liquid Staked STARS $qSTARS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "This is a liquid-staked derivative of the old STARS. The Stargaze chain has shut down and migrated to the Cosmos Hub, so the underlying stake can no longer be unbonded on Stargaze. The Quicksilver chain is also currently halted; deposits and withdrawals are disabled. Migrate STARS via https://automigration.stargaze.zone/"
     },
     {
       "chain_name": "juno",


### PR DESCRIPTION
@
## What changed

The Stargaze chain has been killed and STARS migrated to the Cosmos Hub. `STARS.legacy` and the Stargaze-native factory tokens were already flagged `source_chain_killed`, but the two **listed** STARS liquid-staking derivatives were not aligned. This PR fixes that.

| Asset | Before | After |
|---|---|---|
| **stSTARS** (Stride, `stustars`) | `osmosis_unstable_reason: "market"`, no tooltip, transfers open | `source_chain_killed` + migration tooltip; transfers left open so holders can still unwind via Stride (warn-only) |
| **qSTARS** (Quicksilver, `uqstars`) | `osmosis_unstable_reason: "manual"` for the separate Quicksilver chain halt | `source_chain_killed`; tooltip now covers both the STARS death and the live Quicksilver halt. Existing deposit and withdrawal halts preserved. |

## Why

When STARS was killed, the source-chain-killed treatment was applied to STARS itself and its native factory tokens but not to the liquid-staking derivatives, so stSTARS in particular showed only a generic low-liquidity warning with no context that the underlying stake can no longer be unbonded.

## Scope notes

- **stkSTARS** (pSTAKE) is not listed in `zone_assets.json` and is already deprecated upstream, so no change here.
- **OLDbglSTARS** is a Stargaze-native factory token (not an LST of STARS) and is already halted as `source_chain_killed`.
- qSTARS keeps its existing Quicksilver-halt protections; only the reason code and tooltip were updated.

## Behaviour / automation

- Both assets now render the `unstable.source_chain_killed` tooltip plus the custom `tooltip_message`.
- Adding `tooltip_message` engages the curator lock in `check_extended_halts.mjs` and `check_market_health.mjs`, so the automation will not auto-halt or auto-clear these entries. Any future halt is a deliberate curator edit.
- No transfer behaviour changes for stSTARS (warn-only). No frontend code change is required; the warning/halt mechanism and the `source_chain_killed` localization keys already exist.
@

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only curator edits in zone assets; no application logic or transfer halt behavior changes beyond user-facing labels and tooltips for stSTARS.
> 
> **Overview**
> Aligns **stSTARS** (`stustars`) and **qSTARS** (`uqstars`) in `osmosis.zone_assets.json` with the Stargaze shutdown treatment already applied to legacy STARS and native factory tokens.
> 
> **stSTARS** changes `osmosis_unstable_reason` from `market` to `source_chain_killed` and adds a `tooltip_message` about unmaintainable Stargaze stake and the automigration link; IBC transfers stay open (warn-only).
> 
> **qSTARS** changes `osmosis_unstable_reason` from `manual` to `source_chain_killed`, expands the tooltip to cover both Stargaze migration and the ongoing Quicksilver halt, and **keeps** existing deposit/withdrawal halts unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfee5aea26e1c35d5af4700fe8758ed63331b750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->