### PR TITLE
feat(osmosis-1): verify STARS (Cosmos Hub tokenfactory)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11557,6 +11557,7 @@
       "chain_name": "cosmoshub",
       "base_denom": "factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
       "path": "transfer/channel-0/factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars",
+      "osmosis_verified": true,
       "categories": [
         "nft_protocol"
       ],


### PR DESCRIPTION
## Description

Upgrade **STARS** to Verified status.

This is the **Cosmos Hub tokenfactory** STARS (`factory/cosmos1s8qx0zvz8yd6e4x0mqmqf7fr9vvfn6226hkvrq/ustars`, reaching Osmosis as `ibc/68BAF19F76BAC04C4CEA06325EF91D43E8637AE43EAC7887CE6211B4B99E1EC0`), which replaced the original Stargaze-chain STARS after that chain was shut down. It is the live, stable STARS, distinct from the now-dead `STARS.og`.

The diff is a single field: `osmosis_verified: true` on the cosmoshub STARS entry in `osmosis-1/osmosis.zone_assets.json`. Generated files are produced by the daily run, not in this PR.

## Checklist

### Upgrading Asset to Verified

- [x] Asset is defined at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry) (origin chain `cosmoshub`, which is live, not `killed`).
- [x] `osmosis_verified` set to `true`.
- [x] Meaningful `description` / `extended_description`, `socials` (website, twitter), and a square logo < 250 KB at the canonical hosting path (maintainer to confirm at Chain Registry, unless meme/variant).
- [x] **Liquidity / Pool ID for validation: `3471`** Transmuter pool

### 'Verified' Status Validation Checklist (Osmosis Zone maintainers)

- [x] Verify appearance and metadata
- [x] Accurate Price
- [x] Trading and routing functionality
  - [x] $50 USDC offer yields at least $49-worth of STARS
- [x] Withdraw and Deposit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean flag in the asset registry with no changes to trading, IBC, or authentication logic.
> 
> **Overview**
> Marks **STARS** on Cosmos Hub (`factory/.../ustars`, IBC on Osmosis) as **Verified** in `osmosis.zone_assets.json` by setting `osmosis_verified: true` on that asset entry—the post-migration token that replaced the halted Stargaze-chain STARS.
> 
> No routing, contract, or app logic changes; only Zone listing metadata until generated assets refresh on the daily pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8798da6c74099a7ff0f4ddea279175b549f29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->