### PR TITLE
chore(workflows): surface more change types in daily PR summary

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -152,6 +152,11 @@ jobs:
           jq -r '.assets[].symbol' osmosis-1/generated/frontend/assetlist.json | sort > /tmp/assets-after.txt
           comm -13 /tmp/assets-before.txt /tmp/assets-after.txt > new-assets.txt
           echo "NEW_ASSETS_COUNT=$(wc -l < new-assets.txt)" >> $GITHUB_ENV
+          # Removed/delisted assets: symbols present before but gone after. A
+          # rename also lands here (old symbol on this side, new symbol in
+          # new-assets.txt), so this doubles as the rename's removal half.
+          comm -23 /tmp/assets-before.txt /tmp/assets-after.txt > removed-assets.txt
+          echo "REMOVED_ASSETS_COUNT=$(wc -l < removed-assets.txt)" >> $GITHUB_ENV
 
       - name: Detect Newly Verified Assets
         run: |
@@ -179,6 +184,9 @@ jobs:
           jq -r '.chains[].chain_name' osmosis-1/generated/frontend/chainlist.json | sort > /tmp/chains-after.txt
           comm -13 /tmp/chains-before.txt /tmp/chains-after.txt > new-chains.txt
           echo "NEW_CHAINS_COUNT=$(wc -l < new-chains.txt)" >> $GITHUB_ENV
+          # Removed chains: present before but gone after (delisted/pruned).
+          comm -23 /tmp/chains-before.txt /tmp/chains-after.txt > removed-chains.txt
+          echo "REMOVED_CHAINS_COUNT=$(wc -l < removed-chains.txt)" >> $GITHUB_ENV
 
       - name: Extract per-mutation symbol lists
         run: |
@@ -228,6 +236,71 @@ jobs:
                       ((($a.osmosis_halt_deposits // false) == true)
                         and (($a.osmosis_deposit_halt_reason // "") == "planned_shutdown")
                         and (($b.osmosis_deposit_halt_reason // "") != "planned_shutdown")),
+                    # Script-owned halts not already covered by the extended /
+                    # planned-shutdown rows above: check_ibc_clients sets these
+                    # with reason `bridge_down` or `source_chain_killed` when a
+                    # bridge goes down or a source chain is killed. Both
+                    # directions are tracked independently because a chain death
+                    # closes withdrawals (funds-out), which is higher
+                    # consequence than deposits and was previously unsurfaced.
+                    # Set = newly halted this run; cleared = was halted with one
+                    # of these reasons, now no longer. The reason fields below
+                    # let the summary report which.
+                    depositHaltReason: ($a.osmosis_deposit_halt_reason // ""),
+                    withdrawalHaltReason: ($a.osmosis_withdrawal_halt_reason // ""),
+                    bridgeOrKillDepositSet:
+                      ((($a.osmosis_halt_deposits // false) == true)
+                        and (["bridge_down", "source_chain_killed"] | index($a.osmosis_deposit_halt_reason // "") != null)
+                        and ((($b.osmosis_halt_deposits // false) != true)
+                          or (["bridge_down", "source_chain_killed"] | index($b.osmosis_deposit_halt_reason // "") == null))),
+                    bridgeOrKillDepositCleared:
+                      ((($a.osmosis_halt_deposits // false) != true)
+                        and (($b.osmosis_halt_deposits // false) == true)
+                        and (["bridge_down", "source_chain_killed"] | index($b.osmosis_deposit_halt_reason // "") != null)),
+                    bridgeOrKillWithdrawalSet:
+                      ((($a.osmosis_halt_withdrawals // false) == true)
+                        and (["bridge_down", "source_chain_killed"] | index($a.osmosis_withdrawal_halt_reason // "") != null)
+                        and ((($b.osmosis_halt_withdrawals // false) != true)
+                          or (["bridge_down", "source_chain_killed"] | index($b.osmosis_withdrawal_halt_reason // "") == null))),
+                    bridgeOrKillWithdrawalCleared:
+                      ((($a.osmosis_halt_withdrawals // false) != true)
+                        and (($b.osmosis_halt_withdrawals // false) == true)
+                        and (["bridge_down", "source_chain_killed"] | index($b.osmosis_withdrawal_halt_reason // "") != null)),
+                    # Unstable reason changed while the asset stayed unstable
+                    # (e.g. market → bridge_down, or manual → source_chain_killed
+                    # on a chain death). The ibcFlagged/ibcCleared rows only fire
+                    # on the boolean flipping, so a reason shift underneath an
+                    # already-flagged asset was previously silent. Old→new is
+                    # carried so the summary can show the transition.
+                    unstableReasonChanged:
+                      ((($a.osmosis_unstable // false) == true)
+                        and (($b.osmosis_unstable // false) == true)
+                        and (($a.osmosis_unstable_reason // "") != ($b.osmosis_unstable_reason // ""))),
+                    unstableReasonOld: ($b.osmosis_unstable_reason // ""),
+                    # Symbol / display-name change. zone_assets carries the human
+                    # label in `_comment` ("Pretty (Chain) $SYMBOL"); a rebrand
+                    # (XION→VERONA) or a .legacy/.old re-suffix shows up here as a
+                    # comment edit, which the symbol-list comm diff can miss.
+                    nameChanged:
+                      (($b._comment != null)
+                        and ($a._comment != null)
+                        and ($a._comment != $b._comment)),
+                    nameOld: ($b._comment // ""),
+                    nameNew: ($a._comment // ""),
+                    # Tooltip text changed this run. Covers curator edits in a
+                    # human PR and the script-driven decay/expiry from
+                    # check_tooltip_expiry. Classified into added (empty→text),
+                    # removed (text→empty, e.g. an expired notice), and changed
+                    # (text→different text, e.g. a decayed message). A missing
+                    # field reads as empty so add/remove are symmetric.
+                    tooltipAdded:
+                      ((($b.tooltip_message // "") == "") and (($a.tooltip_message // "") != "")),
+                    tooltipRemoved:
+                      ((($b.tooltip_message // "") != "") and (($a.tooltip_message // "") == "")),
+                    tooltipChanged:
+                      ((($b.tooltip_message // "") != "")
+                        and (($a.tooltip_message // "") != "")
+                        and (($a.tooltip_message // "") != ($b.tooltip_message // ""))),
                   }
               ) as $rows
             | $rows
@@ -237,9 +310,22 @@ jobs:
           # carries a third column with the unstable reason so the summary can
           # report what each asset was flagged for.
           jq -r '.[] | select(.ibcFlagged == true) | "\(.chain)|\(.symbol)|\(.reason)"' /tmp/lifecycle-diff.json > /tmp/lc-ibcFlagged.txt
-          for kind in ibcCleared extendedHaltSet extendedHaltCleared plannedShutdownSet; do
+          for kind in ibcCleared extendedHaltSet extendedHaltCleared plannedShutdownSet tooltipAdded tooltipRemoved tooltipChanged; do
             jq -r --arg k "$kind" '.[] | select(.[$k] == true) | "\(.chain)|\(.symbol)"' /tmp/lifecycle-diff.json > /tmp/lc-${kind}.txt
           done
+
+          # Bridge-down / source-chain-killed halts carry the responsible reason
+          # in a third column (symbol_reason render), so the glance shows whether
+          # it was a bridge outage or a chain death.
+          jq -r '.[] | select(.bridgeOrKillDepositSet == true) | "\(.chain)|\(.symbol)|\(.depositHaltReason)"' /tmp/lifecycle-diff.json > /tmp/lc-bridgeOrKillDepositSet.txt
+          jq -r '.[] | select(.bridgeOrKillWithdrawalSet == true) | "\(.chain)|\(.symbol)|\(.withdrawalHaltReason)"' /tmp/lifecycle-diff.json > /tmp/lc-bridgeOrKillWithdrawalSet.txt
+          jq -r '.[] | select(.bridgeOrKillDepositCleared == true) | "\(.chain)|\(.symbol)"' /tmp/lifecycle-diff.json > /tmp/lc-bridgeOrKillDepositCleared.txt
+          jq -r '.[] | select(.bridgeOrKillWithdrawalCleared == true) | "\(.chain)|\(.symbol)"' /tmp/lifecycle-diff.json > /tmp/lc-bridgeOrKillWithdrawalCleared.txt
+
+          # Reason-shift and rename rows carry "old → new" in the third column so
+          # the transition is legible (rendered via the symbol_reason mode).
+          jq -r '.[] | select(.unstableReasonChanged == true) | "\(.chain)|\(.symbol)|\(.unstableReasonOld) → \(.reason)"' /tmp/lifecycle-diff.json > /tmp/lc-unstableReasonChanged.txt
+          jq -r '.[] | select(.nameChanged == true) | "\(.chain)|\(.symbol)|\(.nameOld) → \(.nameNew)"' /tmp/lifecycle-diff.json > /tmp/lc-nameChanged.txt
 
           # Capture summary counts from the lifecycle script logs.
           if [ -f extended-halts.log ]; then
@@ -411,8 +497,26 @@ jobs:
 
           emit_row "🆕" "New Chains" new-chains.txt name
           emit_row "🆕" "New Assets" new-assets.txt name
+          # Removed/delisted entries. A rename surfaces as a removed old symbol
+          # plus a new symbol above; the rename row below names the pairing.
+          emit_row "🗑️" "Removed Chains" removed-chains.txt name
+          emit_row "🗑️" "Removed Assets" removed-assets.txt name
+          # Symbol / display-name changes (rebrands, .legacy/.old re-suffix).
+          emit_row "🏷️" "Renamed assets" /tmp/lc-nameChanged.txt symbol_reason
+          # Newly verified assets (verified flipped false→true this run). The
+          # detail list lives in Assetlist Generation below; hoist the glance
+          # here so a verification change is visible without scrolling.
+          emit_row "✅" "Assets verified" newly-verified.txt name
           emit_row "🔴" "IBC flagged unstable" /tmp/lc-ibcFlagged.txt symbol_reason
           emit_row "🟢" "IBC cleared" /tmp/lc-ibcCleared.txt symbol
+          # Unstable reason changed underneath an already-flagged asset.
+          emit_row "🔁" "Unstable reason changed" /tmp/lc-unstableReasonChanged.txt symbol_reason
+          # Bridge-down / source-chain-killed halts, per direction. Set rows
+          # carry the reason; cleared rows just name the asset.
+          emit_row "⛔" "Deposit halt set (bridge/chain)" /tmp/lc-bridgeOrKillDepositSet.txt symbol_reason
+          emit_row "⛔" "Withdrawal halt set (bridge/chain)" /tmp/lc-bridgeOrKillWithdrawalSet.txt symbol_reason
+          emit_row "🔓" "Deposit halt cleared (bridge/chain)" /tmp/lc-bridgeOrKillDepositCleared.txt symbol
+          emit_row "🔓" "Withdrawal halt cleared (bridge/chain)" /tmp/lc-bridgeOrKillWithdrawalCleared.txt symbol
 
           # Manual halts: list chain names of assets that were manually flagged
           # (operator-driven, e.g. a bridge compromise) as distinct from
@@ -443,6 +547,13 @@ jobs:
           emit_row "⏸️" "Extended halt set" /tmp/lc-extendedHaltSet.txt symbol
           emit_row "▶️" "Extended halt cleared" /tmp/lc-extendedHaltCleared.txt symbol
           emit_row "⏰" "Planned shutdown set" /tmp/lc-plannedShutdownSet.txt symbol
+
+          # Tooltip text changes (curator PR edits + script-driven decay/expiry).
+          # Each is a quiet zone_assets edit that otherwise produces no summary
+          # line, so surface add/remove/change distinctly.
+          emit_row "💬" "Tooltips added" /tmp/lc-tooltipAdded.txt symbol
+          emit_row "💬" "Tooltips changed" /tmp/lc-tooltipChanged.txt symbol
+          emit_row "🚫" "Tooltips removed" /tmp/lc-tooltipRemoved.txt symbol
 
           # If every category was empty, leave a single line so the section is
           # never just a bare header.


### PR DESCRIPTION
## What

Extends the `[AUTO]` PR Quick summary (the `Generate Workflow Summary` step in `generate_all_files.yml`) to classify several change types that the lifecycle scripts and generators can produce but that previously landed with a near-empty glance.

Auditing the last ~2 weeks of `[AUTO]` PRs showed high-consequence events going unreported: #3610 stamped `bridge_down` halts on both directions, and #3614 (Stargaze chain shutdown) flipped a batch to `source_chain_killed` plus renames, with the Quick summary showing essentially "nothing notable."

## Added coverage

Reuses the existing `zone-before.json` vs current diff and `emit_row` machinery (plus `comm -23` for removals):

1. **bridge_down / source_chain_killed halts**, per direction (deposit + withdrawal), set and cleared, with the responsible reason. Previously only `extended_unstable_market` and `planned_shutdown` deposit halts were classified.
2. **Withdrawal-halt transitions** - withdrawals were never diffed for change events.
3. **Symbol / display-name renames** - diffs `_comment`; catches rebrands and `.legacy`/`.old` re-suffixes the symbol-list `comm` can miss.
4. **Removed / delisted assets and chains** - `comm -23` (detection was added-only before).
5. **Unstable-reason changes** under an already-flagged asset (e.g. `market` -> `bridge_down`), which the boolean-flip rows don't catch.

## Behaviour

Empty categories still print nothing (existing `emit_row` skip), so quiet metadata-only days are unchanged.

## Testing

- Workflow YAML parses.
- Classification jq run against fixtures modeling #3610, #3614, #3601, plus a clear case and an unchanged case: all classifiers produced the expected results with no false positive on an asset whose reason stayed constant.
