### PR TITLE
fix(osmosis): correct alloy external connectors and is_alloyed flags

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6276,10 +6276,10 @@
       },
       "transfer_methods": [
         {
-          "name": "Int3face Bridge",
+          "name": "Thesis",
           "type": "external_interface",
-          "deposit_url": "https://app.int3face.zone/bridge",
-          "withdraw_url": "https://app.int3face.zone/bridge"
+          "deposit_url": "https://ton.thesis.io/",
+          "withdraw_url": "https://ton.thesis.io/"
         }
       ],
       "osmosis_unstable": true,
@@ -6984,12 +6984,6 @@
           "type": "external_interface",
           "deposit_url": "https://sologenic.org/bridge/coreum-bridge",
           "withdraw_url": "https://sologenic.org/bridge/coreum-bridge"
-        },
-        {
-          "name": "Int3face Bridge",
-          "type": "external_interface",
-          "deposit_url": "https://app.int3face.zone/bridge?fromChain=xrpl&toChain=osmosis&fromToken=XRP",
-          "withdraw_url": "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=xrpl&fromToken=XRP.int3"
         }
       ],
       "_comment": "Ripple $XRP"
@@ -8131,6 +8125,7 @@
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1524q4dt7ckx25daydfd0ya0hyu6t26ch5509nvmxm4gcvuhk0fvs8qzl5q/alloyed/allTRUMP",
       "osmosis_verified": true,
+      "is_alloyed": true,
       "categories": [
         "meme"
       ],
@@ -8154,6 +8149,7 @@
       "chain_name": "osmosis",
       "base_denom": "factory/osmo10nu66efsxxkdgh70xs8xur9mygrg79m5ht7zcmzsrdzxkhz7hpssz9hg9k/alloyed/allPENGU",
       "osmosis_verified": true,
+      "is_alloyed": true,
       "categories": [
         "meme"
       ],
@@ -8288,6 +8284,7 @@
       "chain_name": "osmosis",
       "base_denom": "factory/osmo1twk0c4kcwnhkyn6pzxe0qsk6a3nrye2w2sy309d60sljfysugagsd7e3mn/alloyed/allZEC",
       "osmosis_verified": true,
+      "is_alloyed": true,
       "categories": [
         "privacy"
       ],


### PR DESCRIPTION
## What

Corrects external bridge connectors on alloyed assets and adds three missing `is_alloyed` flags in `osmosis-1/osmosis.zone_assets.json`.

## Why

Some alloys listed an Int3face connector for a leg that is no longer a constituent of the alloy's transmuter pool, so the frontend would surface a bridge route for an asset the pool no longer holds. Separately, three real alloys were missing the `is_alloyed` flag, so alloy-scoped tooling skipped them.

## Verification

Each alloy's constituents were checked onchain via the transmuter `list_asset_configs` smart query, and each constituent's IBC denom was resolved back to its assetlist leg before changing any connector.

## Changes

- **allTON**: removed `Int3face Bridge` (the only constituent is `TON.orai`); added `Thesis`, which is that constituent's bridge and was not surfaced on the alloy.
- **allXRP**: removed `Int3face Bridge` (constituents are `XRP.coreum` and `XRP.xrplevm`; no Int3 leg in the pool). `Sologenic TX Bridge` retained for `XRP.coreum`.
- **allTRUMP, allPENGU, allZEC**: added `"is_alloyed": true`. These are real `/alloyed/` transmuter alloys that lacked the flag. Their `Int3face Bridge` connectors are correct and kept.

Int3face remains on `allDOGE`, `allLTC`, `allBCH`, `allTRUMP`, `allPENGU`, `allZEC`, each confirmed to hold a live `*.int3` constituent.

## Notes / out of scope

- `XRP.xrplevm` is bridged via native IBC (the frontend models it as `type: "ibc"`, "Osmosis IBC Transfer"), so it correctly has no external connector. It is currently flagged `bridge_down`; that halt status is a separate operational concern and is not touched here.
- `USDT.eth.inj` rides the native Skip/IBC deposit/withdraw flow (Osmosis to Injective); the onward Injective to Ethereum hop is not an Osmosis-edge connector, so no `transfer_methods` entry is added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static asset-list metadata only; no runtime code, auth, or on-chain logic changes.
> 
> **Overview**
> Updates **`osmosis.zone_assets.json`** so bridge routes and alloy metadata match current transmuter pool constituents.
> 
> **TON** transfer method switches from **Int3face Bridge** to **Thesis** (`ton.thesis.io`), matching the sole pool leg (`TON.orai`).
> 
> **allXRP** drops the **Int3face Bridge** entry; **Sologenic TX Bridge** stays for the Coreum XRP leg (no Int3 constituent in the pool).
> 
> **allTRUMP**, **allPENGU**, and **allZEC** gain **`"is_alloyed": true`** so alloy-aware tooling treats them like other `/alloyed/` transmuter assets; their Int3face connectors are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85bcd294a19ec9454d4f03b7a08befbc8c25b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->