### PR TITLE
fix: require SQS liquidity confirmation before clearing extended market halt

### DIFF
--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -14,10 +14,12 @@
 //
 //   Reason-vocabulary contract: this script owns reasons
 //   {extended_unstable_market, planned_shutdown}. Clearing rules:
-//     • extended_unstable_market: cleared on a single passing market run.
-//       (Note: check_market_health also implements this clearing path for
-//       the market-recovery flow; both are safe because they're guarded by
-//       the same reason check.)
+//     • extended_unstable_market: cleared on a single run where BOTH the Numia
+//       market signal passes AND SQS independently confirms on-chain liquidity
+//       >= the floor (see canClearExtendedHalt). Fail-closed: if SQS is
+//       unavailable or the asset has no real pool, the halt stays. (Note:
+//       check_market_health also implements this clearing path for the
+//       market-recovery flow; both share the same cross-source guard.)
 //     • planned_shutdown: cleared when planned_shutdown_date is absent or
 //       > 14 days in the future, AND no curator tooltip_message is present.
 //       (Once a curator documents the shutdown with a tooltip, the halt is
@@ -35,8 +37,10 @@ import * as path from 'path';
 
 import { calculateIbcHash } from './assetlist_functions.mjs';
 import {
+  canClearExtendedHalt,
   fetchAlloyConstituentMap,
   fetchNumia,
+  fetchSqsLiquidityMap,
   loadJSON,
   resolveMarket,
 } from './lifecycle_helpers.mjs';
@@ -75,6 +79,10 @@ async function main() {
       .map((a) => a.coinMinimalDenom)
   );
   const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
+
+  // On-chain liquidity per denom, the independent second source the clearing
+  // path cross-checks against Numia. Empty on SQS error → clears fail closed.
+  const sqsLiquidityByDenom = await fetchSqsLiquidityMap();
 
   const zoneByOrigin = new Map();
   for (const a of zoneData.assets) {
@@ -148,18 +156,26 @@ async function main() {
       }
     }
 
-    // ── Trigger A clearing: market recovered (single passing run) ──────────
+    // ── Trigger A clearing: market recovered, cross-source confirmed ───────
+    // Numia "passing" alone is not enough: SQS must independently confirm
+    // on-chain liquidity >= the floor before the deposit halt clears. Guards
+    // against a phantom Numia liquidity reading reopening deposits on an asset
+    // whose real pool is near-empty. Fail-closed when SQS is missing (halt
+    // stays). Mirrors the same guard on check_market_health.mjs's recovery
+    // path; both share the canClearExtendedHalt contract.
     if (
       zoneAsset.osmosis_halt_deposits === true &&
       zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
       !zoneAsset.tooltip_message
     ) {
       const market = resolveMarket(numia, constituentToAlloy, coinMinimalDenom);
-      const passing =
-        !!market &&
-        (market.liquidity >= LOW_LIQUIDITY_USD ||
-          market.volume24h >= LOW_VOLUME_24H_USD);
-      if (passing) {
+      const canClear = canClearExtendedHalt({
+        market,
+        sqsLiquidity: sqsLiquidityByDenom.get(coinMinimalDenom),
+        lowLiquidityUsd: LOW_LIQUIDITY_USD,
+        lowVolumeUsd: LOW_VOLUME_24H_USD,
+      });
+      if (canClear) {
         delete zoneAsset.osmosis_halt_deposits;
         delete zoneAsset.osmosis_deposit_halt_reason;
         mutations.push({

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -3,8 +3,9 @@
 //   asset that isn't already unstable, run a market-health check; on 7 consecutive
 //   failing daily runs, flag it unstable with reason="market" and stamp
 //   state.lastDowntimeDate. Owns recovery for market-unstable assets too:
-//     • 1 consecutive passing run → clear osmosis_halt_deposits if reason
-//       is extended_unstable_market (and no tooltip).
+//     • clear osmosis_halt_deposits (reason extended_unstable_market, no
+//       tooltip) on the first passing run where SQS on-chain liquidity ALSO
+//       confirms recovery (cross-source guard; see canClearExtendedHalt).
 //     • 7 consecutive passing runs → clear osmosis_unstable AND wipe state
 //       history fields, only if osmosis_unstable_reason === "market".
 //
@@ -17,8 +18,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {
+  canClearExtendedHalt,
   fetchAlloyConstituentMap,
   fetchNumia,
+  fetchSqsLiquidityMap,
   findStateAsset,
   loadJSON,
   materialiseStateAsset,
@@ -89,6 +92,11 @@ async function main() {
   );
   const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
 
+  // On-chain liquidity per denom, the independent second source the extended-
+  // halt clearing path cross-checks against Numia. Empty on SQS error → clears
+  // fail closed (halt stays).
+  const sqsLiquidityByDenom = await fetchSqsLiquidityMap();
+
   const nowIso = new Date().toISOString();
   const nowMs = new Date(nowIso).getTime();
   const mutations = [];
@@ -158,12 +166,29 @@ async function main() {
         const rstreak = (stateAsset?.marketHealthRecoveryStreak ?? 0) + 1;
         writeState().marketHealthRecoveryStreak = rstreak;
 
-        // 1-day clear of extended-market-driven halt
+        // Clear the extended-market-driven halt on the first run where BOTH
+        // sources confirm recovery. Cross-source guarded: Numia "passing"
+        // (this branch) is not enough on its own — SQS must independently
+        // confirm on-chain liquidity >= the floor. This blocks a clear driven
+        // by a phantom Numia liquidity reading for an asset whose real pool is
+        // near-empty. Fail-closed when SQS is missing.
+        //
+        // `rstreak >= 1` (rather than `=== 1`) so that if SQS withheld
+        // confirmation on the first passing run, a later run where SQS agrees
+        // can still clear the deposit halt early, instead of waiting for the
+        // full 7-run recovery to clear it as a side effect. The
+        // `osmosis_halt_deposits === true` guard keeps this idempotent.
         if (
-          rstreak === 1 &&
+          rstreak >= 1 &&
           zoneAsset.osmosis_halt_deposits === true &&
           zoneAsset.osmosis_deposit_halt_reason === 'extended_unstable_market' &&
-          !zoneAsset.tooltip_message
+          !zoneAsset.tooltip_message &&
+          canClearExtendedHalt({
+            market,
+            sqsLiquidity: sqsLiquidityByDenom.get(asset.coinMinimalDenom),
+            lowLiquidityUsd: LOW_LIQUIDITY_USD,
+            lowVolumeUsd: LOW_VOLUME_24H_USD,
+          })
         ) {
           delete zoneAsset.osmosis_halt_deposits;
           delete zoneAsset.osmosis_deposit_halt_reason;

--- a/.github/workflows/utility/lifecycle_helpers.mjs
+++ b/.github/workflows/utility/lifecycle_helpers.mjs
@@ -64,6 +64,12 @@ export async function fetchNumia({ hardFail = true } = {}) {
 
 export const SQS_POOLS_URL = 'https://sqs.osmosis.zone/pools?filter%5Btype%5D=3';
 
+// Unfiltered pools endpoint. Used to cross-check Numia's liquidity reading
+// against on-chain pool value before clearing an extended deposit halt. The
+// type=3 filter above is alloy-only and would miss the balancer/CL pools most
+// thin assets actually sit in, so the liquidity cross-check needs every pool.
+export const SQS_ALL_POOLS_URL = 'https://sqs.osmosis.zone/pools';
+
 // Mainnet alloyed-transmuter contract code ids. Mirrors the frontend's
 // getAlloyedPoolCodeIds(false) constant in packages/pools/src/pool-constants.ts.
 // Update this set when a new alloyed-transmuter code id is instantiated on
@@ -141,6 +147,94 @@ export function resolveMarket(numia, constituentToAlloy, coinMinimalDenom) {
     volume24h: Math.max(self?.volume24h ?? 0, alloy?.volume24h ?? 0),
     mcap: self?.mcap ?? alloy?.mcap ?? 0,
   };
+}
+
+// ── SQS on-chain liquidity cross-check ───────────────────────────────────────
+
+/**
+ * Build a Map of coinMinimalDenom -> on-chain liquidity (USD), summed from the
+ * whole-pool `liquidity_cap` of every pool the denom appears in. Pools whose
+ * cap could not be computed (`liquidity_cap_error` set) are skipped, as are
+ * non-positive caps.
+ *
+ * This is a deliberately coarse UPPER bound on a denom's real depth: it sums
+ * whole-pool caps rather than the denom's share, so it can only overstate
+ * liquidity. That bias is safe for its sole purpose — a floor cross-check on
+ * the extended-halt clearing path (see canClearExtendedHalt). Overstating
+ * makes the guard more willing to clear, never less, so a pass here is a
+ * genuine "there is at least this much pooled value" signal.
+ *
+ * Pass the parsed SQS /pools body ({ data: [...] }). Returns an empty Map when
+ * the body is missing or malformed; callers treat an absent denom as 0 and
+ * fail closed.
+ */
+export function buildSqsLiquidityMap(sqsPoolsBody) {
+  const byDenom = new Map();
+  for (const pool of sqsPoolsBody?.data ?? []) {
+    if (pool?.liquidity_cap_error) continue; // unreliable cap, skip
+    const cap = Number(pool?.liquidity_cap ?? 0);
+    if (!Number.isFinite(cap) || cap <= 0) continue;
+    for (const b of pool?.balances ?? []) {
+      if (!b?.denom) continue;
+      byDenom.set(b.denom, (byDenom.get(b.denom) ?? 0) + cap);
+    }
+  }
+  return byDenom;
+}
+
+/**
+ * Fetch the unfiltered SQS pools list and reduce it to a per-denom liquidity
+ * map via buildSqsLiquidityMap. Returns an empty Map on any error so callers
+ * degrade to "no SQS confirmation" — which, on the clearing path, means the
+ * halt stays (fail-closed). This matches the curator-funds-safety bias: a
+ * flaky SQS run keeps deposits halted rather than reopening them on Numia
+ * alone.
+ */
+export async function fetchSqsLiquidityMap() {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    const res = await fetch(SQS_ALL_POOLS_URL, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!res.ok) {
+      console.error(`SQS returned HTTP ${res.status}; liquidity cross-check disabled (halts stay)`);
+      return new Map();
+    }
+    const body = await res.json();
+    return buildSqsLiquidityMap(body);
+  } catch (err) {
+    console.error(`SQS liquidity fetch failed (${err.message}); cross-check disabled (halts stay)`);
+    return new Map();
+  }
+}
+
+/**
+ * Decide whether an extended-market deposit halt may be cleared this run.
+ *
+ * Two independent sources must BOTH agree the asset has recovered:
+ *   1. Numia market signal "passing" (liquidity >= floor OR volume >= floor),
+ *      the same condition the original single-source clear used.
+ *   2. SQS on-chain liquidity >= the liquidity floor.
+ *
+ * Fail-closed: a missing Numia market (undefined) or a missing/zero SQS
+ * liquidity reading both block the clear. This is the guard against the
+ * failure mode where one source reports phantom liquidity for a denom that
+ * has no real pool (e.g. Numia reporting stale ~$300k for an asset whose only
+ * pool holds ~$22). Setting the halt is unaffected; this gates clearing only.
+ *
+ * Pure function (no I/O) so it is unit-testable with fixture inputs.
+ */
+export function canClearExtendedHalt({
+  market,
+  sqsLiquidity,
+  lowLiquidityUsd,
+  lowVolumeUsd,
+}) {
+  const numiaPassing =
+    !!market &&
+    (market.liquidity >= lowLiquidityUsd || market.volume24h >= lowVolumeUsd);
+  const sqsConfirms = Number(sqsLiquidity ?? 0) >= lowLiquidityUsd;
+  return numiaPassing && sqsConfirms;
 }
 
 // ── Misc ─────────────────────────────────────────────────────────────────────

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2938,7 +2938,9 @@
       ],
       "_comment": "Tether USD (Ethereum via Wormhole) $USDT.eth.wh",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "gateway",


### PR DESCRIPTION
## What

1. Require an independent SQS onchain-liquidity confirmation before an `extended_unstable_market` deposit halt can be auto-cleared.
2. Re-instate the USDT.eth.wh extended deposit halt that #3634 cleared on phantom data.

## Why

In the daily auto-update (#3634), the extended deposit halt on **USDT.eth.wh** (gateway, denom `ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C`) was cleared. The asset has no real market:

- It is **not** in any alloy (`isAlloyed: false`, present in 0 type-3 pools).
- Its only onchain home is a single balancer pool (1131) holding ~9.69 USDT.eth.wh + ~10.36 USDC.axl, which SQS values at a **$22** `liquidity_cap`.
- Numia, however, reports `liquidity: 303812`, with `price: null` and `volume_24h: 0`. That liquidity figure is stale/notional, not tradeable depth.

The clear is decided in `check_market_health.mjs` (recovery path). Its pass/fail test is:

```js
const failing = liquidity < 1000 && volume24h < 100; // needs BOTH
const passing = !failing;
```

Numia's phantom $303,812 clears the $1,000 liquidity floor, so `failing` is false and one passing run drops the deposit halt (`marketHealthRecoveryStreak` 0 to 1). The real onchain liquidity ($22) is well below the floor, so had a second source been consulted the halt would have stayed.

This is asymmetric and biased toward reopening deposits: setting the extended halt takes 60 days, clearing it took one run off a single, wrong number. `check_extended_halts.mjs` has an identical clearing path with the same hole.

## Fix

Two independent sources must agree before clearing:

1. Numia market signal passing (liquidity OR volume above floor), the prior condition.
2. SQS onchain liquidity at or above the liquidity floor.

New pure helper `canClearExtendedHalt()` in `lifecycle_helpers.mjs` encodes the rule; `fetchSqsLiquidityMap()` / `buildSqsLiquidityMap()` derive per-denom onchain liquidity from the unfiltered SQS `/pools` endpoint (summing whole-pool `liquidity_cap`, skipping pools with a `liquidity_cap_error`). Both `check_market_health.mjs` and `check_extended_halts.mjs` now gate their clear on this helper.

**Fail-closed:** if SQS is unreachable, or the asset is in no pool, the second source reads 0 and the halt stays. A flaky probe keeps deposits halted rather than reopening them on Numia alone.

Notes:
- This gates **clearing** only. The halt-setting paths are unchanged.
- The unfiltered `/pools` endpoint is required: the existing `SQS_POOLS_URL` is `type=3` (alloy-only) and would miss the balancer/CL pools thin assets actually sit in.
- `check_market_health.mjs` changes `rstreak === 1` to `rstreak >= 1` so that if SQS withheld confirmation on the first passing run, a later run where SQS agrees can still clear the deposit halt early instead of waiting for the full 7-run recovery. The `osmosis_halt_deposits === true` guard keeps it idempotent.
- The SQS `liquidity_cap` is a whole-pool value, so summing it slightly overstates a denom's share. That bias is safe here: it can only make the guard more willing to clear, and even being generous, USDT.eth.wh ($22) stays below the floor.

## Revert of the bad clear

`osmosis.zone_assets.json` re-adds `osmosis_halt_deposits: true` + `osmosis_deposit_halt_reason: extended_unstable_market` to USDT.eth.wh.

This is a **source-only** revert. The generated `assetlist.json` and `state.json` are intentionally not hand-edited (don't edit derived files directly); the regeneration pipeline reproduces them from the reverted source. The next daily `[AUTO]` run will regenerate the frontend assetlist with the halt re-applied, and with this guard in place it will no longer re-clear. The stale `marketHealthRecoveryStreak: 1` left in `state.json` by #3634 self-heals on that run (asset is still failing, so the recovery streak resets).

## Risk / behaviour change

- Assets with genuine Numia-reported liquidity that SQS cannot corroborate (no pool, or all their pools carry a `liquidity_cap_error`) will no longer auto-clear and will sit halted until SQS confirms or a curator clears via tooltip. This is the intended safer default.
- One extra SQS call per run in each script (cached map, built once).
- Brief window between merge and the next regeneration where the source carries the halt but the generated assetlist does not. The deposit halt is the safe direction to lag toward, and the window closes at the next cron.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deposit-halt automation for all assets with extended_unstable_market clears—assets Numia passes but SQS cannot corroborate stay halted until SQS or a curator acts, which is intentional but affects operational behavior.
> 
> **Overview**
> Auto-clearing **`extended_unstable_market`** deposit halts now needs **both** a passing Numia market signal **and** SQS on-chain liquidity at or above the $1k floor via shared **`canClearExtendedHalt()`** in `lifecycle_helpers.mjs`. **`fetchSqsLiquidityMap()`** / **`buildSqsLiquidityMap()`** pull unfiltered SQS `/pools` data (not alloy-only); SQS errors or missing pool depth **fail closed** and keep halts in place.
> 
> **`check_market_health.mjs`** and **`check_extended_halts.mjs`** use that guard on their clear paths; market health also widens recovery from **`rstreak === 1`** to **`rstreak >= 1`** so a later run can clear the deposit halt if SQS was unavailable on the first passing day.
> 
> **`osmosis.zone_assets.json`** restores **`osmosis_halt_deposits`** on USDT.eth.wh after a bad clear driven by phantom Numia liquidity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5721a1f9af9058cd60c57cd4ef370892eec47d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->