### PR TITLE
fix(workflows): explorer links for shutdown-proposal report; halt ELYS deposits

### DIFF
--- a/.github/workflows/utility/report_dead_chains.mjs
+++ b/.github/workflows/utility/report_dead_chains.mjs
@@ -194,6 +194,27 @@ const HEIGHT_PATTERN = /\b(?:block\s+)?height[:\s]+#?([\d,]{5,})\b/gi;
 // noisy description can't blow up the PR body.
 const MAX_TARGETS_PER_PROPOSAL = 4;
 
+// Per-proposal deep-link builders, matched on the explorer's HOST (not its
+// chain-registry `kind`: the `kind` field is unreliable — several non-ping.pub
+// explorers in the registry are tagged kind "ping.pub"). Each entry takes the
+// chain path lifted from the explorer `url` and the proposal id and returns the
+// proposal detail URL. Order is preference order: the first matching explorer a
+// chain lists wins. Without one of these, the report falls back to the chain's
+// generic explorer landing page (it never emits a bare `#id`, which GitHub
+// would auto-link to an issue/PR in THIS repo).
+const PROPOSAL_LINK_BUILDERS = [
+  {
+    host: 'mintscan.io',
+    // https://www.mintscan.io/<path>  ->  https://www.mintscan.io/<path>/proposals/<id>
+    build: (chainPath, id) => `https://www.mintscan.io/${chainPath}/proposals/${id}`,
+  },
+  {
+    host: 'ping.pub',
+    // https://ping.pub/<path>  ->  https://ping.pub/<path>/gov/<id>
+    build: (chainPath, id) => `https://ping.pub/${chainPath}/gov/${id}`,
+  },
+];
+
 // ── Args ─────────────────────────────────────────────────────────────────────
 
 const args = process.argv.slice(2);
@@ -907,6 +928,63 @@ async function runPart2(state, chainlist, zoneAssets) {
 
 // ── Report rendering ─────────────────────────────────────────────────────────
 
+/**
+ * Markdown link to a chain's governance proposal, built from the chain-registry
+ * `explorers` list. The Proposal column previously rendered a bare `#<id>`,
+ * which GitHub auto-links to issue/PR #<id> in THIS repo — a wrong, confusing
+ * link. Instead:
+ *   • Prefer a known per-proposal deep link (mintscan, then ping.pub), matched
+ *     on the explorer host and built from the chain path in its `url`.
+ *   • Else fall back to the chain's first explorer landing page, with the id as
+ *     link text, so the reader still gets a real explorer to open.
+ *   • Else (no explorers at all) render the id as plain text `#<id>` wrapped in a
+ *     backtick code span, so GitHub does NOT auto-link it.
+ * Returns a markdown string for the Proposal cell.
+ */
+function proposalLink(chainName, proposalId) {
+  const idLabel = `#${proposalId}`;
+  const explorers = getFileProperty(chainName, 'chain', 'explorers');
+  if (!Array.isArray(explorers) || explorers.length === 0) {
+    // No explorer to link to — render as a code span so GitHub leaves the `#id`
+    // alone instead of auto-linking it to a repo issue/PR.
+    return `\`${idLabel}\``;
+  }
+
+  // Lift the chain path from an explorer URL of the form
+  // https://[www.]host/<path>[/] — the first path segment, URL-decoded for the
+  // label only (the link itself keeps the original encoding so it resolves).
+  const pathFromUrl = (url) => {
+    try {
+      const u = new URL(url);
+      const seg = u.pathname.replace(/^\/+/, '').split('/')[0];
+      return seg || null;
+    } catch {
+      return null;
+    }
+  };
+
+  // Preferred per-proposal deep link, matched on host.
+  for (const builder of PROPOSAL_LINK_BUILDERS) {
+    const match = explorers.find(
+      (e) => typeof e?.url === 'string' && e.url.includes(builder.host)
+    );
+    if (match) {
+      const chainPath = pathFromUrl(match.url);
+      if (chainPath) {
+        return `[${idLabel}](${builder.build(chainPath, proposalId)})`;
+      }
+    }
+  }
+
+  // No known deep-link explorer — link the id to the first explorer landing
+  // page that has a url, so the reader still gets somewhere real to click.
+  const fallback = explorers.find((e) => typeof e?.url === 'string' && e.url);
+  if (fallback) {
+    return `[${idLabel}](${fallback.url})`;
+  }
+  return `\`${idLabel}\``;
+}
+
 function renderReport({ part1, part2, part3 }) {
   const lines = [];
   lines.push('## ⚰️ Dead chain candidates');
@@ -1114,7 +1192,7 @@ function renderReport({ part1, part2, part3 }) {
         ? m.targets.map((t) => `\`${t.replace(/\|/g, '\\|')}\``).join('<br>')
         : '-';
       lines.push(
-        `| ${m.chainName} | #${m.proposalId} | ${m.submitTime || '-'} | ${targets} | ` +
+        `| ${m.chainName} | ${proposalLink(m.chainName, m.proposalId)} | ${m.submitTime || '-'} | ${targets} | ` +
           `\`${m.matchedKeyword}\` | ${m.inTitle ? 'yes' : 'no'} | ${status} | ` +
           `${m.title.replace(/\|/g, '\\|')} |`
       );

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -7077,7 +7077,10 @@
       "osmosis_verified": true,
       "_comment": "Elys Network $ELYS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "Elys Network governance has approved sunsetting the chain (proposal 103, passed). Deposits are halted; withdraw any ELYS to your Elys wallet while the chain is still operating."
     },
     {
       "chain_name": "aaronetwork",


### PR DESCRIPTION
Two unrelated changes, one branch, two commits.

## 1. `fix(workflows)`: link dead-chain report proposals to explorers

The "Possible planned shutdowns" table in the dead-chain report rendered each proposal as a bare `#<id>`. On the daily `[AUTO]` PR body, GitHub auto-links `#<id>` to an issue/PR of that number in this repo, which is a wrong and confusing link (run #3636 surfaced `#103` and `#28` this way).

Now `proposalLink()` builds a real explorer deep link from the chain-registry `explorers` list:

- Prefer a known per-proposal URL: mintscan (`/<path>/proposals/<id>`), then ping.pub (`/<path>/gov/<id>`), matched on the explorer **host** (not its `kind`, since several non-ping.pub explorers in the registry are mis-tagged `kind: "ping.pub"`).
- Else fall back to the chain's first explorer landing page, with the id as link text.
- Else (no explorers) render the id in a code span so GitHub leaves it un-linked.

Verified against live registry data:

| Chain | Renders as |
|-------|-----------|
| elys #103 | `https://ping.pub/elys/gov/103` (no mintscan listed) |
| osmosis / cosmoshub / stargaze | mintscan `/proposals/<id>` |
| hippoprotocol #28 | its only explorer landing page (no mintscan/ping.pub) |
| unknown chain | `` `#id` `` code span, no auto-link |

Report-only script, weekly path only. `node --check` passes.

## 2. `feat(osmosis)`: halt ELYS deposits ahead of chain sunset

Elys Network governance passed [proposal 103](https://ping.pub/elys/gov/103) to permanently sunset the chain (cease block production at height 13204000, approx 2026-06-27 08:45 UTC). Osmosis lists one ELYS asset (`uelys` via `channel-91017`), previously `osmosis_unstable` with reason `market` and deposits open.

This halts deposits on that asset:

```json
"osmosis_halt_deposits": true,
"osmosis_deposit_halt_reason": "planned_shutdown",
"tooltip_message": "Elys Network governance has approved sunsetting the chain (proposal 103, passed). Deposits are halted; withdraw any ELYS to your Elys wallet while the chain is still operating."
```

Decisions:

- **Reason `planned_shutdown`** (a valid `osmosis_deposit_halt_reason` enum value, with an existing frontend localization). Not `source_chain_killed`: as of this writing the chain is still producing blocks past the halt height, so it is scheduled to die, not yet dead.
- **Deposits only; withdrawals stay open** so holders can exit, matching the repo's notify-only-on-withdrawals convention.
- **Direct curator halt with a `tooltip_message`** (which locks it from the `check_extended_halts` cron) rather than `planned_shutdown_date`. The governance halt height already passed, and the cron only pre-empts dates within the next 14 days, so a past `planned_shutdown_date` would not trigger the auto-halt and would only generate daily past-due noise.
- Exposure is negligible: about 337.3K ELYS bridged onto Osmosis at roughly $0.00102 each, so on the order of $340 total.

Full-document validation against `zone_assets.schema.json` passes.

### Follow-up

When ELYS actually stops producing blocks, flip the asset to `source_chain_killed` on both deposit and withdrawal directions (the evmos / starname pattern).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> ELYS deposit halts affect live user flows on Osmosis; the workflow change is report-only and low blast radius.
> 
> **Overview**
> **Dead-chain report:** The “Possible planned shutdowns” table no longer prints bare `#<id>` proposal IDs (which GitHub wrongly linked to issues/PRs in this repo). **`proposalLink()`** now builds markdown links from chain-registry **`explorers`**: Mintscan and ping.pub deep URLs when the host matches, otherwise the first explorer landing page, or a backtick-wrapped `#id` when there is no explorer.
> 
> **ELYS (`uelys`):** Deposits are halted ahead of the approved chain sunset—**`osmosis_halt_deposits`**, **`osmosis_deposit_halt_reason`: `planned_shutdown`**, and a **`tooltip_message`** pointing users to withdraw while the chain still runs. Withdrawals stay open; **`osmosis_unstable_reason`** remains **`market`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da328a8e9a9fef605956de5f8f2a30d44e0ef556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->