### PR TITLE
fix(osmosis): remove dead PBJ/BSKT bridge connectors, halt both directions

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4103,19 +4103,14 @@
         "chain_name": "solana",
         "base_denom": "6gnCPhXtLnUD76HjQuSYPENLSZdG8RvDB1pTLM5aLSJA"
       },
-      "transfer_methods": [
-        {
-          "name": "Bskt.fi Wormhole Bridge",
-          "type": "external_interface",
-          "deposit_url": "https://www.bskt.fi/wormhole",
-          "withdraw_url": "https://www.bskt.fi/wormhole"
-        }
-      ],
+      "transfer_methods": [],
       "_comment": "Basket $BSKT",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "market",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "extended_unstable_market"
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "aioz",
@@ -5771,19 +5766,14 @@
         "chain_name": "solana",
         "base_denom": "ANu4Wuq86WzRU8tykszQUJ66eQzFNfkwap2HcQ5UaFaU"
       },
-      "transfer_methods": [
-        {
-          "name": "Sandwichswap Wormhole Portal Bridge",
-          "type": "external_interface",
-          "deposit_url": "http://wormhole.bridge.sandwichswap.io/pumpfunosmo/pbj/deposit",
-          "withdraw_url": "http://wormhole.bridge.sandwichswap.io/pumpfunosmo/pbj/withdraw"
-        }
-      ],
+      "transfer_methods": [],
       "_comment": "Pepe Bruce Jenner $PBJ",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "market",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "extended_unstable_market"
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "bridge_down"
     },
     {
       "chain_name": "noble",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4110,7 +4110,8 @@
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "The Bskt.fi bridge for this asset is no longer available and the Osmosis Wormhole page does not support it, so there is no working route to deposit or withdraw BSKT. Deposits and withdrawals are halted."
     },
     {
       "chain_name": "aioz",
@@ -5773,7 +5774,8 @@
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down"
+      "osmosis_withdrawal_halt_reason": "bridge_down",
+      "tooltip_message": "The Sandwichswap bridge for this asset is no longer available and the Osmosis Wormhole page does not support it, so there is no working route to deposit or withdraw PBJ. Deposits and withdrawals are halted."
     },
     {
       "chain_name": "noble",


### PR DESCRIPTION
## What

For **PBJ** and **BSKT** in `osmosis-1/osmosis.zone_assets.json`:
- Remove the `external_interface` transfer method (the dead third-party Wormhole bridge connector).
- Set `osmosis_halt_deposits` + `osmosis_halt_withdrawals` to `true` with reason `bridge_down`.
- Add a curator `tooltip_message` to each (see "Why the tooltip" below).

Source-only change; generated files are produced by CI.

## Why

| | PBJ (Sandwichswap Wormhole Portal Bridge) | BSKT (Bskt.fi Wormhole Bridge) |
| -- | -- | -- |
| Bridge site | `wormhole.bridge.sandwichswap.io` — does not load | `bskt.fi/wormhole` — does not load |
| Verified | no | no |
| Unstable | yes | yes |
| In any alloy | no | no |
| On-chain supply (Osmosis) | ~129.2M | **0** |
| Value | SQS price = 0 (illiquid pool 3313); no CoinGecko id | $0 (zero supply) |

Both connectors point at third-party operator sites that no longer resolve, for unverified + unstable tokens with negligible on-chain value. Surfacing a dead bridge clickout is worse than nothing. Removing the connector + halting the direction greys the native flow instead of routing users to a broken site.

The **IBC transfer method remains** on both, so any residual holder still has an exit path — removing the external_interface does not strand anyone.

## Why the tooltip (important)

`check_ibc_clients.mjs` **owns** the `bridge_down` halt reason: when gateway IBC reads Active, it auto-clears both halt flags on the next routine run, which would re-enable native PBJ/BSKT transfers despite the dead third-party bridges. The script treats a non-empty `tooltip_message` as a curator lock (`canModifyHalt` / `canModifyUnstable` return `false` when it is set), so a tooltip is the documented way to make these halts durable. Each tooltip also tells the user why the flow is greyed: the third-party bridge is gone and the Osmosis Wormhole page does not support these assets, so there is no working route.

## Scope

- Two asset entries only; source file edited, no generated outputs hand-touched (CI regenerates). `validate_zone_data.mjs` passes.
- Pairs with osmosis-frontend #4395, which drops the now-removed connectors from the frontend logo map.