### PR TITLE
fix(osmosis): rename TON connector Thesis -> OBridge, repoint to OraiDEX

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6248,10 +6248,10 @@
       },
       "transfer_methods": [
         {
-          "name": "Thesis",
+          "name": "OBridge",
           "type": "external_interface",
-          "deposit_url": "https://ton.thesis.io/",
-          "withdraw_url": "https://ton.thesis.io/"
+          "deposit_url": "https://app.oraidex.io/bridge?token=ton",
+          "withdraw_url": "https://app.oraidex.io/bridge?token=ton"
         }
       ],
       "osmosis_unstable": true,
@@ -6272,10 +6272,10 @@
       },
       "transfer_methods": [
         {
-          "name": "Thesis",
+          "name": "OBridge",
           "type": "external_interface",
-          "deposit_url": "https://ton.thesis.io/",
-          "withdraw_url": "https://ton.thesis.io/"
+          "deposit_url": "https://app.oraidex.io/bridge?token=ton",
+          "withdraw_url": "https://app.oraidex.io/bridge?token=ton"
         }
       ],
       "osmosis_unstable": true,


### PR DESCRIPTION
## What

The TON external bridge connector was labelled **Thesis** and pointed at `ton.thesis.io`. It is operated by **OBridge**. Rename it and repoint deposit/withdraw to `https://app.oraidex.io/bridge?token=ton`.

Applied to both entries that carry this connector:
- **TON.orai** (`oraichain` Oraichain Labs TON Bridge variant)
- **allTON** (the alloy entry)

## Changes

`osmosis-1/osmosis.zone_assets.json` — on both entries:
- `name`: `Thesis` → `OBridge`
- `deposit_url` / `withdraw_url`: `https://ton.thesis.io/` → `https://app.oraidex.io/bridge?token=ton`

Source-only; generated files produced by CI. `validate_zone_data.mjs` passes.

## Related

- Pairs with the connector-logo PR (#3639), which attaches an `obridge.svg` logo to this connector. The logo's `logo_uri` is on the same method object, so it follows this rename (the frontend resolves it via `logoUri`).
- osmosis-frontend #4386 surfaces the allTON external connector via the TON.orai member; #4395 renders connector logos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only label and URL updates for TON bridge UI; no contract, auth, or IBC routing changes.
> 
> **Overview**
> Updates TON **external_interface** transfer metadata so the UI shows the correct bridge operator and sends users to the live OraiDEX bridge instead of the old Thesis URL.
> 
> In `osmosis.zone_assets.json`, both **TON.orai** (Oraichain Labs TON Bridge) and **allTON** (alloyed TON) now use connector name **OBridge** with `deposit_url` / `withdraw_url` set to `https://app.oraidex.io/bridge?token=ton` (replacing **Thesis** and `https://ton.thesis.io/`). No IBC paths or asset denoms change—only the external deposit/withdraw links and label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407b4b8be9a29405e57c8ffb9f1b640d417e69c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->