### PR TITLE
Configure PHMN asset on Osmosis

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11576,6 +11576,17 @@
       "osmosis_deposit_halt_reason": "source_chain_killed",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "source_chain_killed"
+    },
+    {
+      "chain_name": "cosmoshub",
+      "base_denom": "factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN",
+      "path": "transfer/channel-0/factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN",
+      "osmosis_verified": false,
+      "categories": [
+        "defi"
+      ],
+      "listing_date_time_utc": "2026-06-30T00:00:00Z",
+      "_comment": "POSTHUMAN $PHMN"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add Osmosis Zone source configuration for the new PHMN Cosmos Hub TokenFactory asset.

The generated frontend assetlist already detects this PHMN denom from Chain Registry. This PR adds an explicit zone asset config entry so the listing is tracked in `osmosis.zone_assets.json`.

## Asset
- Source chain: `cosmoshub`
- Base denom: `factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN`
- Osmosis path: `transfer/channel-0/factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN`
- Osmosis denom: `ibc/243B3934C4462EE254C84AA31AF42E34F1869418194D3E4161E4A659A01AC6E6`

## Notes
- `osmosis_verified` is set to `false` for initial listing, matching the repository guidance.
- Category: `defi`.

## Validation
- JSON parsed successfully.
