### PR TITLE
fix(osmosis): remove Omnity connector from allDOGE

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6750,12 +6750,6 @@
           "type": "external_interface",
           "deposit_url": "https://app.int3face.zone/bridge",
           "withdraw_url": "https://app.int3face.zone/bridge"
-        },
-        {
-          "name": "Omnity Bridge",
-          "type": "external_interface",
-          "deposit_url": "https://bridge.omnity.network/doge",
-          "withdraw_url": "https://bridge.omnity.network/doge"
         }
       ],
       "_comment": "Dogecoin $DOGE"


### PR DESCRIPTION
## What

Removes the **Omnity Bridge** `external_interface` connector from the **allDOGE** alloy entry in `osmosis-1/osmosis.zone_assets.json`. The alloy keeps its **Int3face Bridge** connector.

## Why

Omnity (ChainKey) variants are being removed from the alloys under the Prop 816 moderation subDAO mandate (MTN-160, Omnity Bridge phaseout). This removes the alloy-level Omnity clickout for allDOGE.

## Scope

- **Only the allDOGE alloy** connector is removed here. The Omnity connectors on the **ckBTC**, **ICP**, and **ckDOGE** variant entries are left untouched (out of scope — this PR covers the alloy).
- Source-only change; generated files are produced by CI. `validate_zone_data.mjs` passes.
- Pairs with assetlists #3639, which drops the Omnity connector *logo* wiring.

Refs MTN-160.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Source-only zone asset metadata update; no auth, trading logic, or generated runtime artifacts in this diff.
> 
> **Overview**
> Removes the **Omnity Bridge** `external_interface` entry from **allDOGE**’s `transfer_methods` in `osmosis.zone_assets.json`, leaving **Int3face Bridge** as the sole alloy-level deposit/withdraw clickout. This aligns the alloy metadata with the Omnity phaseout (MTN-160); Omnity connectors on separate variant assets (e.g. ckDOGE) are unchanged in this diff.
> 
> Also adjusts the file’s closing brace newline (no functional schema change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47db0b8bdc7cd88a981ee2e41b235a7f90290df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->