### PR TITLE
Verify PHMN (Cosmos Hub) on Osmosis

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11571,7 +11571,7 @@
       "chain_name": "cosmoshub",
       "base_denom": "factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN",
       "path": "transfer/channel-0/factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "categories": [
         "defi"
       ],


### PR DESCRIPTION
Verifies the new PHMN (POSTHUMAN) asset on Osmosis by flipping `osmosis_verified` to `true` for the Cosmos Hub TokenFactory PHMN entry.

Resolves #3648.

## Asset

- **Origin chain:** Cosmos Hub (`cosmoshub`)
- **Base denom:** `factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN`
- **Osmosis IBC denom:** `ibc/243B3934C4462EE254C84AA31AF42E34F1869418194D3E4161E4A659A01AC6E6`

This is the new PHMN, migrated from the legacy Juno CW20 token to a Cosmos Hub TokenFactory asset. The legacy Juno PHMN entry is left unchanged.

## Pool for validation

**Pool ID 3477** (PHMN / allBTC)

## Verification checks

- **IBC denom shape:** `sha256("transfer/channel-0/factory/cosmos146.../PHMN")` = `243B3934C4462EE254C84AA31AF42E34F1869418194D3E4161E4A659A01AC6E6`, matching the listed path and the live frontend denom.
- **Chain Registry metadata:** complete: `name` POSTHUMAN, `symbol` PHMN, `display` phmn, exponent 6, `type_asset` sdk.coin, logo, `description`, `extended_description`, and `socials` (website + X).
- **Liquidity (pool 3477):** ~$9.0k PHMN side and ~$9.0k allBTC side (~$18k TVL), both well above the $1,000/side minimum.
- **Quote depth:** a ~$50 swap quotes >= $49 in both directions (PHMN->allBTC $49.19, allBTC->PHMN $49.17).
- **Origin chain status:** Cosmos Hub is active (not killed).

## Note for reviewer

Pool 3477 is a weighted (xyk) pool with a 1% swap fee. It satisfies the verified-tier liquidity/depth requirements, but does not meet the separate "Full Integration" recommendation (CL/Stableswap/PCL and >= $10k). Verification only requires the former, so this is not a blocker, flagging it for awareness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single boolean metadata change in the asset list; no application or on-chain logic is modified.
> 
> **Overview**
> Marks **POSTHUMAN (PHMN)** on Cosmos Hub as Osmosis-verified by setting `osmosis_verified` to `true` for the existing TokenFactory entry (`factory/cosmos146s5j3t7gh2g37ywm47dp8avhesu2htvjjaxq7z55e7xj0rq0k8q5qnjjy/PHMN` via `transfer/channel-0/...`) in `osmosis.zone_assets.json`. No other fields on that asset (path, categories, listing date) are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a06cebecb775527f9808df83aacdff1a373f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->