### PR TITLE
fix(verify): look up liquidity and depth by full Osmosis denom

### DIFF
--- a/.github/workflows/utility/checkVerificationCriteria.mjs
+++ b/.github/workflows/utility/checkVerificationCriteria.mjs
@@ -984,10 +984,10 @@ async function checkLogo(chainName, baseDenom) {
  * Per LISTING.md line 43
  *
  * @param {string} chainName - Chain name
- * @param {string} baseDenom - Base denomination
+ * @param {string} fullDenom - Full denom as it appears on Osmosis (Numia's key: ibc/HASH for IBC assets, base_denom for Osmosis-native)
  * @param {Map} numiaTokens - Token liquidity data from Numia API
  */
-async function checkPoolLiquidity(chainName, baseDenom, numiaTokens) {
+async function checkPoolLiquidity(chainName, fullDenom, numiaTokens) {
   try {
     if (!numiaTokens) {
       return {
@@ -996,7 +996,7 @@ async function checkPoolLiquidity(chainName, baseDenom, numiaTokens) {
       };
     }
 
-    const tokenData = numiaTokens.get(baseDenom);
+    const tokenData = numiaTokens.get(fullDenom);
 
     if (!tokenData) {
       return {
@@ -1059,10 +1059,10 @@ async function checkPoolLiquidity(chainName, baseDenom, numiaTokens) {
  * Per LISTING.md lines 44-47
  *
  * @param {string} chainName - Chain name
- * @param {string} baseDenom - Base denomination
+ * @param {string} fullDenom - Full denom as it appears on Osmosis (Numia's pair key: ibc/HASH for IBC assets, base_denom for Osmosis-native)
  * @param {Array} numiaPairs - Pool/pair data from Numia API
  */
-async function checkBidDepth(chainName, baseDenom, numiaPairs) {
+async function checkBidDepth(chainName, fullDenom, numiaPairs) {
   try {
     if (!numiaPairs) {
       return {
@@ -1072,7 +1072,7 @@ async function checkBidDepth(chainName, baseDenom, numiaPairs) {
     }
 
     // Find the largest pool containing this asset
-    const largestPool = findLargestPoolForAsset(baseDenom, numiaPairs);
+    const largestPool = findLargestPoolForAsset(fullDenom, numiaPairs);
 
     if (!largestPool) {
       return {
@@ -1262,8 +1262,8 @@ async function verifyAsset(zoneAsset, numiaTokens, numiaPairs, alloyMembersMap) 
   results.checks.extendedDescription = await checkExtendedDescription(chain_name, base_denom, isMeme);
   results.checks.socials = await checkSocials(chain_name, base_denom, isMeme);
   results.checks.logo = await checkLogo(chain_name, base_denom);
-  results.checks.poolLiquidity = await checkPoolLiquidity(chain_name, base_denom, numiaTokens);
-  results.checks.bidDepth = await checkBidDepth(chain_name, base_denom, numiaPairs);
+  results.checks.poolLiquidity = await checkPoolLiquidity(chain_name, fullDenom, numiaTokens);
+  results.checks.bidDepth = await checkBidDepth(chain_name, fullDenom, numiaPairs);
   results.checks.chainStatus = await checkChainStatus(chain_name, isMeme);
 
   // Determine overall pass/fail


### PR DESCRIPTION
## Problem

`checkVerificationCriteria.mjs` (the manual `Check Asset Verification Criteria` workflow) reported **0 assets ready for verification** and flagged **488 of 528** unverified assets as `"Asset not found in Numia data"` on the liquidity check.

Root cause: `checkPoolLiquidity` and `checkBidDepth` looked up Numia by the source-chain `base_denom` (e.g. `uatom`, `factory/cosmos146s.../PHMN`), but Numia's `tokens/v2/all` and `pairs/v2/summary` key IBC assets by their **Osmosis `ibc/HASH` denom**. So every cross-chain asset failed both checks regardless of its real liquidity, and no IBC asset could ever be surfaced as a verification candidate.

The script already computes the correct denom via `getFullDenom(zoneAsset)` (used for the alloy transmuter check) — it just wasn't passed to these two checks.

## Fix

Pass `fullDenom` instead of `base_denom` to `checkPoolLiquidity` and `checkBidDepth`, and rename the param accordingly. 8 lines changed, no behavioural change for Osmosis-native assets (where `fullDenom === base_denom`).

```
- numiaTokens.get(baseDenom)         + numiaTokens.get(fullDenom)
- findLargestPoolForAsset(baseDenom) + findLargestPoolForAsset(fullDenom)
```

## Verified locally (before → after), `node checkVerificationCriteria.mjs osmosis-1`

| Metric | Before | After |
| --- | --- | --- |
| `"Asset not found in Numia data"` failures | 488 | **0** |
| Assets passing liquidity ($1k+) | 8 | **19** |
| Ready for verification | 0 | **1** |

The single "ready" asset is **PHMN** (cosmoshub), which now correctly resolves pool 3477 and passes all 8 checks, independently confirming the manual verification in #3649.

## Known follow-up (out of scope here)

Depth still passes only 5 of the 19 liquidity-passers. Some are genuinely thin (e.g. SHIDO, $0.56 at 2%), but several report a healthy pool while Numia's depth API returns 400/500 or omits the pool entirely (e.g. BABA and Fost both show an ~$11.5k pool but the depth endpoint 500'd). That is a Numia depth-feed sparsity issue, not something this denom fix can address. A future change could fall back to an on-chain / SQS depth probe when the Numia depth API is unavailable.

## Notes

- Report-only tool — the auto-flip block remains commented out, so running it changes no verification flags.
- The generated report under `osmosis-1/generated/verification_reports/` is gitignored; only the script fix is committed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parameter fix in a report-only utility script; aligns Numia lookups with existing `getFullDenom` behavior without changing on-chain or auth paths.
> 
> **Overview**
> Fixes false **"Asset not found in Numia data"** failures for IBC assets in the manual verification criteria workflow.
> 
> **Pool liquidity** and **bid depth** now key Numia’s tokens and pairs APIs with the Osmosis **`fullDenom`** (`ibc/HASH` from `getFullDenom(zoneAsset)`) instead of the source-chain `base_denom`. Alloy transmuter logic already used `fullDenom`; only these two checks were still using the wrong key.
> 
> Osmosis-native assets are unchanged when `fullDenom` equals `base_denom`. Report-only behavior—no automatic verification flag updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950c2ea6a48e01b10f7830724b5ce24d8e55a507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->