### PR TITLE
feat(osmosis): mark ELYS source_chain_killed after chain halt

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -7061,10 +7061,12 @@
       "osmosis_verified": true,
       "_comment": "Elys Network $ELYS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market",
+      "osmosis_unstable_reason": "source_chain_killed",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "Elys Network governance has approved sunsetting the chain (proposal 103, passed). Deposits are halted; withdraw any ELYS to your Elys wallet while the chain is still operating."
+      "osmosis_deposit_halt_reason": "source_chain_killed",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "source_chain_killed",
+      "tooltip_message": "The Elys Network chain has been permanently shut down by governance (proposal 103) and is no longer producing blocks, having halted at block 13381279 on 2026-07-07. Deposits and withdrawals are disabled."
     },
     {
       "chain_name": "aaronetwork",


### PR DESCRIPTION
## Summary

Elys Network (chain-id `elys-1`) has halted. Flip the one ELYS asset Osmosis lists from the interim `planned_shutdown` deposit halt (merged in #3637) to the terminal `source_chain_killed` state on both deposit and withdrawal directions.

## Why

The chain stopped producing blocks:

- Last committed block: **13381279** at **2026-07-07 07:14:57 UTC**.
- Two independent RPC providers (`rpc.elys.network`, `elys-rpc.publicnode.com`) agree on that frozen height and timestamp, and the node reports 13381279 as the current tip (height 13381280 does not exist). So this is a genuine consensus halt, not a single lagging endpoint.
- The active set had been a 7-validator, equal-weight committee running at 5/7 signing (71.43%) for about 6 days, one validator above the two-thirds liveness threshold. A sixth validator went dark just after block 13381279, dropping the live set to 4/7 (57.14%), below two-thirds, so consensus could no longer commit.

This completes the governance-approved sunset (proposal 103), which had targeted halt height 13204000 on 2026-06-27; validators kept the chain alive well past that before the set finally fell below threshold.

## Change

The `elys` / `uelys` zone_asset (`osmosis-1/osmosis.zone_assets.json`):

```json
"osmosis_unstable_reason": "source_chain_killed",
"osmosis_halt_deposits": true,
"osmosis_deposit_halt_reason": "source_chain_killed",
"osmosis_halt_withdrawals": true,
"osmosis_withdrawal_halt_reason": "source_chain_killed",
"tooltip_message": "The Elys Network chain has been permanently shut down by governance (proposal 103) and is no longer producing blocks, having halted at block 13381279 on 2026-07-07. Deposits and withdrawals are disabled."
```

Withdrawals are now halted in addition to deposits: with the chain dead, funds cannot move in either direction, so leaving withdrawals open would only mislead. This matches the evmos / starname pattern for a killed source chain. All three `source_chain_killed` banner strings already exist in the frontend localizations, so the deposit, withdrawal, and unstable banners all render.

## Exposure

Small. About 337K ELYS are bridged onto Osmosis (roughly $340 at the last traded price), and deposits have been halted since #3637, so nothing new flowed in.

## Validation

- JSON parses and validates against `zone_assets.schema.json` (all reason values are in the allowed enums).
- Diff is scoped to the single ELYS entry.

## Risk

If the chain were somehow restarted by a coordinated validator effort, this would need reverting. Given it is a governance-approved sunset that has now actually halted, a restart is not expected, but the halt was confirmed ~4 hours after the last block rather than after a multi-day settle, so that is the one residual uncertainty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON metadata entry for a halted chain; no app logic changes. Revert only if the chain unexpectedly restarts.
> 
> **Overview**
> Updates the **Elys Network** (`uelys`) zone asset now that the chain has stopped producing blocks, moving it from the interim **planned shutdown** deposit halt to the terminal **`source_chain_killed`** state used for dead source chains (e.g. Evmos, Starname).
> 
> **Unstable** reason changes from `market` to `source_chain_killed`; **deposit** halt reason changes from `planned_shutdown` to `source_chain_killed`. **Withdrawals** are newly halted with `osmosis_halt_withdrawals` and `source_chain_killed`, since IBC out is no longer possible. The **tooltip** is rewritten to state permanent shutdown (governance proposal 103), final block height, and that both directions are disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55651cb692f11a1659a9a69619cda655f8c8c28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->