### PR TITLE
feat(osmosis): halt USDN deposits for Noble maintenance mode

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8032,7 +8032,10 @@
       ],
       "_comment": "Noble Dollar $USDN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "planned_shutdown",
+      "tooltip_message": "Noble is transitioning USDN to maintenance mode and closing the USDC-USDN swaps pool on Noble. Deposits to Osmosis are halted. Withdraw and redeem your USDN via Noble while the redemption window is open. Source: https://x.com/noble_xyz/status/2074478458353430896"
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## What

Halts deposits of USDN (Noble Dollar) to Osmosis and adds an on-hover tooltip explaining why.

## Why

Noble is transitioning USDN to maintenance mode and closing the USDC-USDN swaps pool on Noble, so the redemption path is time-sensitive. We should stop new USDN flowing in while that window is open.

Source (no official blog post yet, Twitter is the only announcement): https://x.com/noble_xyz/status/2074478458353430896

> Important update on Noble Dollar (USDN). As of today, USDN is transitioning to maintenance mode on Noble. The USDC-USDN swaps pool on Noble will be closing soon.
> — Noble (@noble_xyz) July 7, 2026

## Change

Single edit to the source `osmosis-1/osmosis.zone_assets.json` USDN entry (generated files are produced by the pipeline in CI):

- `osmosis_halt_deposits: true` — greys the asset-page Deposit button and blocks the deposit direction in the bridge flow
- `osmosis_deposit_halt_reason: "planned_shutdown"`
- `osmosis_unstable_reason` changed from `market` to `manual` (the halt is a curator action, not market instability)
- `tooltip_message` with curator context and the source link

**Withdrawals are intentionally left open** so holders can still bridge USDN back to Noble and redeem while the swaps pool is open. This mirrors the pSTAKE halt pattern (deposits halted, withdrawals open).

## Scope

Deposit halt only. Removing USDN from the USD (small) alloy is a separate task tracked in the same issue and is not included here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single curated asset-metadata change with no application logic; low blast radius aside from deposit UX for one IBC asset.
> 
> **Overview**
> **Noble USDN (`uusdn`) on Osmosis** is updated so **deposits are halted** while Noble moves USDN into maintenance mode and winds down the USDC–USDN pool.
> 
> The USDN asset entry in `osmosis.zone_assets.json` now sets **`osmosis_halt_deposits: true`** with **`osmosis_deposit_halt_reason: "planned_shutdown"`**, which should grey out deposit in the UI and block deposit in the bridge flow. **`osmosis_unstable_reason`** is changed from **`market`** to **`manual`** to reflect a curator halt rather than market instability. A **`tooltip_message`** explains the situation and links Noble’s announcement. **Withdrawals are not changed** so users can still bridge out and redeem on Noble.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20587dba0be8417c73ddb55eb90842a4199f0bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->