### PR TITLE
feat(osmosis): add cbDOGE.axl with Squid transfer methods

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11710,6 +11710,21 @@
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
       "tooltip_message": "This asset appeared on a source chain whose transfers are manually halted. Deposits and withdrawals are halted pending manual review."
+    },
+    {
+      "chain_name": "axelar",
+      "base_denom": "cbdoge-satoshi",
+      "path": "transfer/channel-208/cbdoge-satoshi",
+      "osmosis_verified": false,
+      "_comment": "Coinbase Wrapped DOGE (Base via Axelar) $cbDOGE.axl",
+      "transfer_methods": [
+        {
+          "name": "Squid",
+          "type": "external_interface",
+          "deposit_url": "https://app.squidrouter.com/?fromChain=base&toChain=osmosis&fromToken=cbdoge&toToken=cbdoge.axl",
+          "withdraw_url": "https://app.squidrouter.com/?fromChain=osmosis&toChain=base&fromToken=cbdoge.axl&toToken=cbdoge"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds cbDOGE.axl (Coinbase Wrapped DOGE, Base via Axelar) to zone_assets with Squid deposit/withdraw deep links.

- Axelar gateway denom: `cbdoge-satoshi` over channel-208; ~150 cbDOGE already bridged to Osmosis on `ibc/D6ED8CCF01DE2F86D0D8A9605A8535A66C930697E986616227506EBDE8B8AC91`
- Depends on cosmos/chain-registry#7802; the "Validate against Chain Registry" check pulls latest registry master, so it will stay red until that merges
- Starts `osmosis_verified: false` (no pool yet), matching how cbBTC.axl was introduced