### PR TITLE
Verify Nether ($NTHR)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11416,7 +11416,7 @@
       "chain_name": "cosmoshub",
       "base_denom": "factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
       "path": "transfer/channel-0/factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "categories": [
         "nft_protocol"
       ],


### PR DESCRIPTION
## Description

Upgrading token to Verified: **Nether (NTHR)** from chain **Cosmos Hub** (`factory/cosmos1wdja2gcsesyl07raq9jm3rcvu0sse5zkev0h8m/Nether`, `ibc/EFAAE3AD05AA79647A1587E363A11B6126CC83C8C0593171BB1892A39EB550DF` on Osmosis).

See NTHR/ATOM **Pool 3442**.

## Checklist

### Upgrading Asset to Verified

- [x] Asset is defined thoroughly at the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry).
   - [x] A meaningful `description` (and `extended_description`).
   - [x] Associated `socials`, including `website` and `twitter`.
   - [x] **Logo Image** has a square Aspect Ratio, < 250 KB file size, and appropriate visual contrast with Osmosis Zone's colors.
- [x] **Liquidity**: This pool meets the liquidity requirements, and has a +-2% depth of $50 (~$5k full range liq.) (Provide Pool ID): **3442**

'Verified' Status Validation Checklist (to be completed by Osmosis Zone maintainers):
- [x] Verify appearance and metadata
- [x] Accurate Price
- [x] Trading and routing functionality
   - [x] $50 USDC offer yields at least $49-worth of this Asset
- [x] Withdraw and Deposit
   - [x] Deposit Transaction URL (if in-app)
