### PR TITLE
Update Quicksilver and USDN halt metadata; clarify standing-halt summary

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -524,7 +524,9 @@ jobs:
           # counts as manual if ANY of its three reason fields is "manual":
           # the overall unstable reason, or the per-direction deposit/withdrawal
           # halt reason (a curator may halt one direction without flagging the
-          # asset unstable). Distinct chains, sorted.
+          # asset unstable). Distinct chains, sorted. This bare chain-name set
+          # feeds the added-this-run delta and the persisted manualHaltChains
+          # state; the display variant below carries the per-chain detail.
           MANUAL_HALT_CHAINS=$(jq -r '
             .assets
             | map(select(
@@ -542,7 +544,43 @@ jobs:
           comm -13 /tmp/manual-halts-prev.txt /tmp/lc-manualHalts.txt \
             > /tmp/lc-manualHaltsNew.txt 2>/dev/null || touch /tmp/lc-manualHaltsNew.txt
           emit_row "🆕" "Manual halts added this run" /tmp/lc-manualHaltsNew.txt name
-          emit_row "⚠️" "Manual halts in effect" /tmp/lc-manualHalts.txt name
+
+          # Standing row, display variant: say how much of each chain's
+          # listing is halted and name the impacted symbols (with the bridge
+          # hop when the halt is really the hop's problem), so a single-asset
+          # halt (e.g. PSTAKE routed via a compromised Gravity Bridge) cannot
+          # read as a whole-chain halt of its origin chain.
+          jq -r --slurpfile fe osmosis-1/generated/frontend/assetlist.json '
+            ($fe[0].assets
+              | map({ key: (.chainName + "|" + .sourceDenom), value: . })
+              | from_entries) as $byOrigin
+            | (.assets | group_by(.chain_name)
+              | map({ key: .[0].chain_name, value: length })
+              | from_entries) as $totals
+            | [ .assets[]
+                | select(
+                    (.osmosis_unstable_reason == "manual")
+                    or (.osmosis_deposit_halt_reason == "manual")
+                    or (.osmosis_withdrawal_halt_reason == "manual")
+                  ) ]
+            | group_by(.chain_name)
+            | .[]
+            | ([ .[]
+                 | . as $a
+                 | ($byOrigin[$a.chain_name + "|" + $a.base_denom]) as $f
+                 | ([ ($f.counterparty // [])[]
+                      | select(.chainType == "cosmos" and .chainName != $a.chain_name)
+                      | .chainName ] | first) as $hop
+                 | ($f.symbol // $a.base_denom)
+                   + (if $hop then " (via \($hop))" else "" end)
+               ]
+               | if length > 6 then .[0:6] + ["+\(length - 6) more"] else . end
+               | join(", ")) as $names
+            | "\(.[0].chain_name) — \(length) of \($totals[.[0].chain_name] // 0) listed: \($names)"
+          ' osmosis-1/osmosis.zone_assets.json 2>/dev/null \
+            > /tmp/lc-manualHaltsDisplay.txt \
+            || cp /tmp/lc-manualHalts.txt /tmp/lc-manualHaltsDisplay.txt 2>/dev/null || true
+          emit_row "⚠️" "Manual halts in effect" /tmp/lc-manualHaltsDisplay.txt name
 
           emit_row "⏸️" "Extended halt set" /tmp/lc-extendedHaltSet.txt symbol
           emit_row "▶️" "Extended halt cleared" /tmp/lc-extendedHaltCleared.txt symbol
@@ -757,39 +795,75 @@ jobs:
             echo "" >> workflow-summary.md
           fi
 
-          # Manual halts currently in effect (visibility for drift detection)
-          echo "## Manual halts currently in effect" >> workflow-summary.md
+          # Manual and planned-shutdown halts currently in effect (visibility
+          # for drift detection). Both are standing state the daily scripts
+          # will not clear on their own: "manual" is the curator lock, and
+          # planned-shutdown halts are normally tooltip-locked until the
+          # curator releases them. Surfacing both every run keeps forgotten
+          # halts visible.
+          echo "## Manual & planned-shutdown halts currently in effect" >> workflow-summary.md
           echo "" >> workflow-summary.md
 
-          # Select assets manually flagged on ANY of the three reason fields
-          # (unstable / deposit-halt / withdrawal-halt), then report each
-          # halted direction with its cause from the *_halt_reason fields.
-          MANUAL_HALTS=$(jq -r '
-            .assets
+          # Select assets flagged manual or planned_shutdown on ANY of the
+          # three reason fields (unstable / deposit-halt / withdrawal-halt),
+          # enriched with the display symbol and bridge hop from the generated
+          # frontend assetlist (joined on chainName|sourceDenom), plus the
+          # chain's total listed-asset count. The hop is the first counterparty
+          # cosmos chain that is not the origin itself, so a halt caused by the
+          # hop (e.g. PSTAKE routed via a compromised Gravity Bridge) is
+          # attributable at a glance instead of reading as an origin-chain
+          # problem.
+          STANDING_HALTS=$(jq --slurpfile fe osmosis-1/generated/frontend/assetlist.json '
+            ($fe[0].assets
+              | map({ key: (.chainName + "|" + .sourceDenom), value: . })
+              | from_entries) as $byOrigin
+            | (.assets | group_by(.chain_name)
+              | map({ key: .[0].chain_name, value: length })
+              | from_entries) as $totals
+            | .assets
             | map(select(
                 (.osmosis_unstable_reason == "manual")
+                or (.osmosis_unstable_reason == "planned_shutdown")
                 or (.osmosis_deposit_halt_reason == "manual")
+                or (.osmosis_deposit_halt_reason == "planned_shutdown")
                 or (.osmosis_withdrawal_halt_reason == "manual")
+                or (.osmosis_withdrawal_halt_reason == "planned_shutdown")
               ))
+            | map(. as $a
+                | ($byOrigin[$a.chain_name + "|" + $a.base_denom]) as $f
+                | . + {
+                    symbol: ($f.symbol // $a._comment // $a.base_denom),
+                    hop: ([ ($f.counterparty // [])[]
+                            | select(.chainType == "cosmos" and .chainName != $a.chain_name)
+                            | .chainName ] | first),
+                    chain_total: ($totals[$a.chain_name] // 0)
+                  })
           ' osmosis-1/osmosis.zone_assets.json)
-          MANUAL_HALT_COUNT=$(echo "$MANUAL_HALTS" | jq 'length')
+          STANDING_HALT_COUNT=$(echo "$STANDING_HALTS" | jq 'length')
 
-          if [ "$MANUAL_HALT_COUNT" -eq 0 ]; then
+          if [ "$STANDING_HALT_COUNT" -eq 0 ]; then
             echo "_None._" >> workflow-summary.md
           else
             # This is standing state (it repeats every run while the halts are
             # in effect), so the default view is one compact row per chain and
             # the full per-asset/per-direction breakdown lives inside a
-            # <details>. The per-chain row collapses assets, halted directions,
-            # and reasons into sets so the reader sees "which chains, why, how
-            # many" at a glance instead of scrolling 50+ near-identical rows.
-            echo "| Chain | Assets halted | Directions | Reason(s) |" >> workflow-summary.md
-            echo "|-------|--------------:|------------|-----------|" >> workflow-summary.md
-            echo "$MANUAL_HALTS" | jq -r '
+            # <details>. "Assets halted" reads "X of Y" against the chain's
+            # full listing so a single-asset halt (e.g. USDN on noble) cannot
+            # read as a whole-chain halt, and the impacted symbols are named
+            # right in the row.
+            echo "| Chain | Assets halted | Impacted assets | Directions | Reason(s) |" >> workflow-summary.md
+            echo "|-------|---------------|-----------------|------------|-----------|" >> workflow-summary.md
+            echo "$STANDING_HALTS" | jq -r '
               group_by(.chain_name)
               | map({
                   chain: .[0].chain_name,
-                  count: length,
+                  halted: length,
+                  total: .[0].chain_total,
+                  assets: (
+                    [ .[] | .symbol + (if .hop then " (via \(.hop))" else "" end) ]
+                    | if length > 8 then .[0:8] + ["+\(length - 8) more"] else . end
+                    | join(", ")
+                  ),
                   directions: (
                     [ .[]
                       | ( if .osmosis_halt_deposits == true then "deposit" else empty end ),
@@ -807,37 +881,24 @@ jobs:
                   )
                 })
               | .[]
-              | "| \(.chain) | \(.count) | \(.directions) | \(.reasons) |"
+              | "| \(.chain) | \(.halted) of \(.total) | \(.assets) | \(.directions) | \(.reasons) |"
             ' >> workflow-summary.md
 
             echo "" >> workflow-summary.md
-            echo "<details><summary>Full manual-halt breakdown (${MANUAL_HALT_COUNT} asset(s), per direction)</summary>" >> workflow-summary.md
+            echo "<details><summary>Full standing-halt breakdown (${STANDING_HALT_COUNT} asset(s), per direction)</summary>" >> workflow-summary.md
             echo "" >> workflow-summary.md
-            # Resolve Symbol and Route from the generated frontend assetlist,
-            # joined on chainName|sourceDenom. Route is the asset's listed origin
-            # chain, plus "via <hop>" when the asset reaches Osmosis through an
-            # intermediary cosmos chain (the first counterparty cosmos chain that
-            # is not the origin itself). So a native Gravity asset reads
-            # "gravitybridge", while a Persistence asset bridged in via Gravity
-            # reads "persistence via gravitybridge".
+            # Symbol and hop were resolved in the enrichment pass above; Route
+            # renders as the origin chain plus "via <hop>" when present, so a
+            # native Gravity asset reads "gravitybridge" while a Persistence
+            # asset bridged in via Gravity reads "persistence via
+            # gravitybridge".
             echo "| Symbol | Route | Base denom | Direction | Reason | Tooltip |" >> workflow-summary.md
             echo "|--------|-------|-----------|-----------|--------|---------|" >> workflow-summary.md
-            echo "$MANUAL_HALTS" | jq -r --slurpfile fe osmosis-1/generated/frontend/assetlist.json '
-              ($fe[0].assets
-                | map({ key: (.chainName + "|" + .sourceDenom), value: . })
-                | from_entries) as $byOrigin
-              | .[]
+            echo "$STANDING_HALTS" | jq -r '
+              .[]
               | . as $a
-              | ($byOrigin[$a.chain_name + "|" + $a.base_denom]) as $f
-              | ($f.symbol // $a._comment // $a.base_denom) as $sym
-              | (
-                  [ ($f.counterparty // [])[]
-                    | select(.chainType == "cosmos" and .chainName != $a.chain_name)
-                    | .chainName ] as $hops
-                  | if ($hops | length) > 0
-                    then $a.chain_name + " via " + $hops[0]
-                    else $a.chain_name end
-                ) as $route
+              | ($a.symbol) as $sym
+              | (if $a.hop then $a.chain_name + " via " + $a.hop else $a.chain_name end) as $route
               | [
                   (if .osmosis_halt_deposits == true then
                      "| \($sym) | \($route) | \(.base_denom) | deposit | \(.osmosis_deposit_halt_reason // "") | \(.tooltip_message // "") |"
@@ -846,9 +907,9 @@ jobs:
                      "| \($sym) | \($route) | \(.base_denom) | withdrawal | \(.osmosis_withdrawal_halt_reason // "") | \(.tooltip_message // "") |"
                    else empty end)
                 ]
-              # Fallback: an asset can be manually flagged unstable without
-              # either direction halted. Emit one row so the asset is still
-              # listed and the table never shows bare headers.
+              # Fallback: an asset can be flagged unstable without either
+              # direction halted. Emit one row so the asset is still listed
+              # and the table never shows bare headers.
               | (if length == 0 then
                    ["| \($sym) | \($route) | \($a.base_denom) | none | \($a.osmosis_unstable_reason // "") | \($a.tooltip_message // "") |"]
                  else . end)

--- a/RUNBOOKS.md
+++ b/RUNBOOKS.md
@@ -1025,7 +1025,7 @@ Two changes from an auto-set halt:
 1. The `*_halt_reason` is set to `manual`. Script-owned reasons get auto-cleared on recovery; `manual` does not.
 2. `tooltip_message` is non-empty. Any tooltip locks the asset against all automation. The one sanctioned exception is a curator-set expiry: if you also set `tooltip_expiry_date`, `check_tooltip_expiry.mjs` will clear or decay the tooltip on that date (see RB009).
 
-Commit and let the daily cron run. Verify the asset is now ignored by automation by checking the next workflow summary's "Manual halts currently in effect" section.
+Commit and let the daily cron run. Verify the asset is now ignored by automation by checking the next workflow summary's "Manual & planned-shutdown halts currently in effect" section.
 
 #### Release the override
 

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -1973,7 +1973,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "This is a liquid-staked derivative of the old STARS. The Stargaze chain has shut down and migrated to the Cosmos Hub, so the underlying stake can no longer be unbonded on Stargaze. The Quicksilver chain is also currently halted; deposits and withdrawals are disabled. Migrate STARS via https://automigration.stargaze.zone/"
+      "tooltip_message": "This is a liquid-staked derivative of the old STARS; the Stargaze chain has shut down and migrated to the Cosmos Hub. The Quicksilver protocol is also being wound down following an exploit; deposits and withdrawals are disabled. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "juno",
@@ -2130,7 +2130,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "comdex",
@@ -2162,7 +2162,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "juno",
@@ -2186,7 +2186,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "arkh",
@@ -2216,7 +2216,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "noble",
@@ -2892,7 +2892,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "passage",
@@ -4924,7 +4924,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -4941,7 +4941,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -4958,7 +4958,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -4975,7 +4975,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "composable",
@@ -7287,7 +7287,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -7304,7 +7304,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -7321,7 +7321,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -7338,7 +7338,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -7355,7 +7355,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "quicksilver",
@@ -7372,7 +7372,7 @@
       "osmosis_deposit_halt_reason": "manual",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "The Quicksilver chain is currently halted and not producing blocks. Deposits and withdrawals are temporarily disabled until the chain resumes."
+      "tooltip_message": "The Quicksilver protocol is being wound down following an exploit. Deposits and withdrawals are disabled while IBC connectivity is restored. Keep qAssets in your wallet: a fixed redemption route on Osmosis is being prepared, and instructions will be published before any action is needed. Source: https://app.quicksilver.zone"
     },
     {
       "chain_name": "osmosis",
@@ -8118,7 +8118,7 @@
       ],
       "_comment": "Noble Dollar $USDN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
+      "osmosis_unstable_reason": "planned_shutdown",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "planned_shutdown",
       "tooltip_message": "Noble is transitioning USDN to maintenance mode and closing the USDC-USDN swaps pool on Noble. Deposits to Osmosis are halted. Withdraw and redeem your USDN via Noble while the redemption window is open. Source: https://x.com/noble_xyz/status/2074478458353430896"

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -54,8 +54,14 @@
         },
         "osmosis_unstable_reason": {
           "type": "string",
-          "enum": ["ibc_client", "source_chain_killed", "market", "manual"],
-          "description": "Closed-set reason for the unstable flag. Each has a localization key in the frontend. Curator-written context for any halt/unstable state lives in the existing `tooltip_message` field."
+          "enum": [
+            "ibc_client",
+            "source_chain_killed",
+            "market",
+            "planned_shutdown",
+            "manual"
+          ],
+          "description": "Closed-set reason for the unstable flag. Drives the localized banner in the frontend; values without a dedicated localization key fall back to a generic unstable string. Curator-written context for any halt/unstable state lives in the existing `tooltip_message` field."
         },
         "osmosis_disabled": {
           "type": "boolean",


### PR DESCRIPTION
## What

Two commits:

**1. `fix(osmosis)`: Quicksilver sunset tooltips + USDN reclassification** (`osmosis.zone_assets.json`, `zone_assets.schema.json`)

- Quicksilver announced a protocol sunset following an exploit. The chain is producing blocks again (verified: height advancing, not catching up), but it came back specifically so the team can wind down: IBC connectivity is still being restored and a fixed redemption route on Osmosis is being prepared. All 16 q-asset halts therefore stay in place; only the stale "chain halted and not producing blocks" tooltips are replaced with sunset guidance telling holders to keep qAssets in their wallets until redemption instructions are published (source: https://app.quicksilver.zone). qSTARS keeps its `source_chain_killed` reason and gets a combined Stargaze-migration + sunset tooltip.
- USDN's `osmosis_unstable_reason` changes from `manual` to `planned_shutdown`, matching its deposit-halt reason: the halt is a planned Noble maintenance-mode wind-down, not an operator incident hold. The schema enum for `osmosis_unstable_reason` gains `planned_shutdown`. No script fights this: `check_market_health` only clears `market` reasons, `check_ibc_clients` leaves `planned_shutdown`/`manual` alone, and the tooltip locks the halt. The frontend renders unknown unstable reasons with a generic fallback string ("Unstable, exercise caution."), and the curator tooltip carries the specific message; adding a dedicated `unstable.planned_shutdown` localization is a possible frontend follow-up.

**2. `ci(generate-all)`: clearer standing-halt summary** (`generate_all_files.yml`, `RUNBOOKS.md`)

The "Manual halts currently in effect" section listed only chain names and counts, so a single-asset halt read like a whole-chain halt (noble looked halted when only USDN is; persistence looked halted when only PSTAKE is, and that is Gravity Bridge's problem, not Persistence's). Now:

- Section renamed to "Manual & planned-shutdown halts currently in effect" and also selects `planned_shutdown` reasons, keeping USDN and the comdex shutdown visible as standing state.
- The chain table reads "X of Y" against the chain's full listing, names impacted symbols (capped at 8 with "+N more"), and attributes bridge hops. Rendered against current data:

| Chain | Assets halted | Impacted assets | Directions | Reason(s) |
|-------|---------------|-----------------|------------|-----------|
| comdex | 3 of 3 | CMDX, CMST, HARBOR | deposit | market, planned_shutdown |
| gravitybridge | 11 of 11 | GRAV, WBTC.eth.grv, ETH.grv, USDC.eth.grv, DAI.grv, USDT.eth.grv, PAGE, PAXG.grv, +3 more | deposit, withdrawal | bridge_down, manual |
| noble | 1 of 5 | USDN | deposit | planned_shutdown |
| persistence | 1 of 4 | PSTAKE (via gravitybridge) | deposit | bridge_down, manual |
| quicksilver | 16 of 16 | qSTARS, qATOM, qREGEN, QCK, qOSMO, qSOMM, qJUNO, qSAGA, +8 more | deposit, withdrawal | manual, source_chain_killed |

- The quick-summary chip sub-bullets get the same per-chain detail via a display-variant file (e.g. `persistence — 1 of 4 listed: PSTAKE (via gravitybridge)`). The bare chain-name set is unchanged; it feeds the added-this-run delta and the persisted `manualHaltChains` state.
- The per-asset `<details>` breakdown reuses the same enriched selection instead of re-deriving symbol and route.

## Verification

- Full `jsonschema` validation of `osmosis.zone_assets.json` against the updated schema passes (same validator CI uses).
- Workflow YAML parses; `bash -n` passes on all 26 run blocks.
- Every new jq program was executed against the real edited data; outputs above are the actual renders.
- Quicksilver liveness double-probed via cosmos.directory before deciding halt treatment (blocks advancing, `catching_up: false`).

## Follow-up

When the Quicksilver redemption route on Osmosis ships, deposits will likely need reopening so holders can reach it; the current halts should be revisited at that point.