### PR TITLE
Revert USDN unstable reason to manual

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -32252,7 +32252,7 @@
       "isAlloyed": false,
       "verified": true,
       "unstable": true,
-      "unstableReason": "planned_shutdown",
+      "unstableReason": "manual",
       "disabled": false,
       "haltDeposits": true,
       "depositHaltReason": "planned_shutdown",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8118,7 +8118,7 @@
       ],
       "_comment": "Noble Dollar $USDN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "planned_shutdown",
+      "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
       "osmosis_deposit_halt_reason": "planned_shutdown",
       "tooltip_message": "Noble is transitioning USDN to maintenance mode and closing the USDC-USDN swaps pool on Noble. Deposits to Osmosis are halted. Withdraw and redeem your USDN via Noble while the redemption window is open. Source: https://x.com/noble_xyz/status/2074478458353430896"

--- a/zone_assets.schema.json
+++ b/zone_assets.schema.json
@@ -54,14 +54,8 @@
         },
         "osmosis_unstable_reason": {
           "type": "string",
-          "enum": [
-            "ibc_client",
-            "source_chain_killed",
-            "market",
-            "planned_shutdown",
-            "manual"
-          ],
-          "description": "Closed-set reason for the unstable flag. Drives the localized banner in the frontend; values without a dedicated localization key fall back to a generic unstable string. Curator-written context for any halt/unstable state lives in the existing `tooltip_message` field."
+          "enum": ["ibc_client", "source_chain_killed", "market", "manual"],
+          "description": "Closed-set reason for the unstable flag. Each has a localization key in the frontend. Curator-written context for any halt/unstable state lives in the existing `tooltip_message` field."
         },
         "osmosis_disabled": {
           "type": "boolean",


### PR DESCRIPTION
## What

Reverts USDN's `osmosis_unstable_reason` from `planned_shutdown` back to `manual`, in both `osmosis.zone_assets.json` and the generated frontend assetlist, and restores the `osmosis_unstable_reason` schema enum to the original closed set.

## Why

`planned_shutdown` is only a valid **deposit-halt** reason. The frontend's `unstableReason` contract is the closed set `ibc_client | source_chain_killed | market | manual` with a localization key per value, so `planned_shutdown` fell through to the generic unknown fallback banner. The daily auto-update (#3671) had already propagated the value into the generated file, hence the fix in both.

The `planned_shutdown` deposit-halt reasons on USDN and Comdex are valid and untouched; the curator tooltip still carries the Noble wind-down specifics.