### PR TITLE
fix(osmosis): mark KYVE unstable for intermittent relayer

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -12178,9 +12178,11 @@
       "name": "KYVE",
       "isAlloyed": false,
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
-      "preview": false
+      "preview": false,
+      "tooltipMessage": "KYVE transfers over channel-767 may be delayed due to intermittent relayer activity on this route."
     },
     {
       "chainName": "kava",

--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -12182,7 +12182,7 @@
       "unstableReason": "manual",
       "disabled": false,
       "preview": false,
-      "tooltipMessage": "KYVE transfers over channel-767 may be delayed due to intermittent relayer activity on this route."
+      "tooltipMessage": "KYVE transfers may be delayed due to intermittent relayer activity on this route."
     },
     {
       "chainName": "kava",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2841,7 +2841,7 @@
       ],
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "tooltip_message": "KYVE transfers over channel-767 may be delayed due to intermittent relayer activity on this route.",
+      "tooltip_message": "KYVE transfers may be delayed due to intermittent relayer activity on this route.",
       "_comment": "KYVE $KYVE"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2839,6 +2839,9 @@
       "categories": [
         "dweb"
       ],
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "tooltip_message": "KYVE transfers over channel-767 may be delayed due to intermittent relayer activity on this route.",
       "_comment": "KYVE $KYVE"
     },
     {


### PR DESCRIPTION
KYVE ($KYVE, channel-767) shows intermittent transfer reliability:
the height monitor recorded a stall run (dead_chain_heights stallRuns=1,
below the FROZEN_HEIGHT_RUNS=2 auto-report threshold) while endpoint
validation still passes, so no automated script flags it.

Set osmosis_unstable with reason "manual" plus a tooltip_message so the
frontend surfaces a warning banner while keeping transfers enabled. The
manual reason + non-empty tooltip locks the flag against automation until
a curator clears it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ny2fBCit54gr117K1XhY9R