### PR TITLE
Verify cbDOGE.axl (Axelar)

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -45184,7 +45184,7 @@
       "variantGroupKey": "factory/osmo10pk4crey8fpdyqd62rsau0y02e3rk055w5u005ah6ly7k849k5tsf72x40/alloyed/allDOGE",
       "name": "Coinbase Wrapped DOGE (Axelar)",
       "isAlloyed": false,
-      "verified": false,
+      "verified": true,
       "unstable": false,
       "disabled": false,
       "preview": false,

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -11732,7 +11732,7 @@
       "chain_name": "axelar",
       "base_denom": "cbdoge-satoshi",
       "path": "transfer/channel-208/cbdoge-satoshi",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "_comment": "Coinbase Wrapped DOGE (Axelar) $cbDOGE.axl",
       "transfer_methods": [
         {


### PR DESCRIPTION
## What

Promotes **cbDOGE.axl** (Coinbase Wrapped DOGE, Axelar) to verified status.

- Source: `osmosis-1/osmosis.zone_assets.json` — `osmosis_verified: false → true`
- Generated: `osmosis-1/generated/frontend/assetlist.json` — `verified: false → true` (edited in place to avoid a full pipeline regeneration; the next `Generate All Files` run reproduces the same output)

## Why it qualifies

cbDOGE.axl is a member of the **verified allDOGE transmuter pool**, so it meets verification via the alloy auto-verification path in `checkVerificationCriteria.mjs` (the documented "new bridge variant added to an existing verified transmuter pool" case).

Confirmed on-chain:

- **allDOGE is verified** — `factory/osmo10pk4crey8fpdyqd62rsau0y02e3rk055w5u005ah6ly7k849k5tsf72x40/alloyed/allDOGE`, `osmosis_verified: true`, `is_alloyed: true`. cbDOGE.axl's `variantGroupKey` points at exactly this denom.
- **cbDOGE.axl is a live pool member** — the transmuter contract's `get_total_pool_liquidity` returns `ibc/D6ED8CCF01DE2F86D0D8A9605A8535A66C930697E986616227506EBDE8B8AC91` at 132,637,128,841 satoshi (~1,326 cbDOGE).

Data integrity checks (all pass):

- IBC hash: `SHA256(transfer/channel-208/cbdoge-satoshi)` = `D6ED8CCF…8AC91`, matches the generated `coinMinimalDenom` and the live denom trace on the Osmosis LCD.
- Decimals: 8, consistent across Base ERC20 (`0xcbD06E…B510`) → Axelar (`cbdoge-satoshi` exp 0 → `cbdoge` exp 8) → Osmosis frontend.
- Osmosis total supply ~167,943 cbDOGE (real, live balance).

## Notes

- Only the two files above are changed; the `chain-registry` submodule pointer was intentionally left untouched.