### PR TITLE
fix(osmosis): revert KYVE unstable flag

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -12180,11 +12180,9 @@
       "name": "KYVE",
       "isAlloyed": false,
       "verified": true,
-      "unstable": true,
-      "unstableReason": "manual",
+      "unstable": false,
       "disabled": false,
-      "preview": false,
-      "tooltipMessage": "KYVE transfers may be delayed due to intermittent relayer activity on this route."
+      "preview": false
     },
     {
       "chainName": "kava",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -2841,9 +2841,6 @@
       "categories": [
         "dweb"
       ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "tooltip_message": "KYVE transfers may be delayed due to intermittent relayer activity on this route.",
       "_comment": "KYVE $KYVE"
     },
     {


### PR DESCRIPTION
## What

Reverts the manual `unstable` flag on KYVE added in #3675.

Removes from the KYVE entry in `osmosis-1/osmosis.zone_assets.json`:
- `osmosis_unstable: true`
- `osmosis_unstable_reason: "manual"`
- `tooltip_message: "KYVE transfers may be delayed due to intermittent relayer activity on this route."`

and the corresponding regenerated `unstable: false` / removed `unstableReason` / removed `tooltipMessage` in `osmosis-1/generated/frontend/assetlist.json`.

## Why

The flag was added on the premise of intermittent relayer activity on the KYVE route. Onchain data does not support this:

- **Osmosis to KYVE** (recv on KYVE `channel-0`): 802 packets relayed since 2026-03-07, median gap between relays ~53 min, rising to record weekly volume in July. Only 13 gaps over 24h in 4.5 months, nearly all during an old Apr to May lull.
- **KYVE to Osmosis** (recv on Osmosis `channel-767`): median gap ~25 min, longest gap 15.75h, zero gaps over 24h.
- Same operator (`kyve13x942…` / `osmo13x942…`) running consistently on both legs. IBC clients Active on both sides, channel OPEN.

The user report that prompted the original flag was most consistent with normal ~25 min relay latency, not a broken route. The user-facing warning is therefore unwarranted and is reverted here.

## Scope

KYVE-only. The daily generator folded in unrelated data churn (a MUC delisting, a timestamp); those were discarded so this diff is purely the KYVE revert. The daily auto-generation PR will pick up the unrelated changes separately.