### PR TITLE
fix(lifecycle): require SQS agreement before halting on a Numia zero, apply 54 withheld halts

### DIFF
--- a/.github/workflows/utility/check_extended_halts.mjs
+++ b/.github/workflows/utility/check_extended_halts.mjs
@@ -5,7 +5,11 @@
 //
 //     • 60 days since state.lastDowntimeDate AND osmosis_unstable=true AND
 //       market check still failing → halt_deposits with reason
-//       "extended_unstable_market".
+//       "extended_unstable_market". "Still failing" is cross-source: Numia
+//       below both floors AND SQS on-chain liquidity below the liquidity
+//       floor (see isMarketGenuinelyFailing). Numia alone cannot tell a dead
+//       market from a denom it does not price, and it prices only a minority
+//       of listed denoms. If SQS is unavailable, no new halt is set this run.
 //
 //     • planned_shutdown_date within 14 days → halt_deposits with reason
 //       "planned_shutdown". This set path does NOT honour the tooltip_message
@@ -41,6 +45,7 @@ import {
   fetchAlloyConstituentMap,
   fetchNumia,
   fetchSqsLiquidityMap,
+  isMarketGenuinelyFailing,
   loadJSON,
   resolveMarket,
 } from './lifecycle_helpers.mjs';
@@ -80,9 +85,21 @@ async function main() {
   );
   const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
 
-  // On-chain liquidity per denom, the independent second source the clearing
-  // path cross-checks against Numia. Empty on SQS error → clears fail closed.
+  // On-chain liquidity per denom, the independent second source both the
+  // setting and the clearing path cross-check against Numia. Empty on SQS
+  // error → clears fail closed.
   const sqsLiquidityByDenom = await fetchSqsLiquidityMap();
+  // An empty map is indistinguishable from "every denom has zero liquidity",
+  // which on the SETTING path would rubber-stamp every Numia zero instead of
+  // challenging it. So treat an empty map as "no second source this run" and
+  // set no new halts, rather than reading it as agreement.
+  const sqsAvailable = sqsLiquidityByDenom.size > 0;
+  if (!sqsAvailable) {
+    console.error(
+      'SQS liquidity unavailable; no new extended halts will be set this run ' +
+        '(clearing remains fail-closed).'
+    );
+  }
 
   const zoneByOrigin = new Map();
   for (const a of zoneData.assets) {
@@ -139,10 +156,20 @@ async function main() {
       const downtimeMs = nowMs - new Date(stateAsset.lastDowntimeDate).getTime();
       if (downtimeMs >= SIXTY_DAYS_MS) {
         const market = resolveMarket(numia, constituentToAlloy, coinMinimalDenom);
-        const failing =
-          !!market &&
-          market.liquidity < LOW_LIQUIDITY_USD &&
-          market.volume24h < LOW_VOLUME_24H_USD;
+        // Cross-source guard, same contract as the clearing path below: a
+        // Numia zero is only trusted as "illiquid" when SQS independently
+        // agrees. Numia prices a minority of denoms and reports liquidity 0
+        // for the rest, so Numia alone cannot distinguish a dead market from
+        // an unpriced one. When SQS is unavailable the check is skipped and
+        // no new halt is set this run (fail-closed on mutation).
+        const failing = sqsAvailable
+          ? isMarketGenuinelyFailing({
+              market,
+              sqsLiquidity: sqsLiquidityByDenom.get(coinMinimalDenom),
+              lowLiquidityUsd: LOW_LIQUIDITY_USD,
+              lowVolumeUsd: LOW_VOLUME_24H_USD,
+            })
+          : false;
         if (failing) {
           zoneAsset.osmosis_halt_deposits = true;
           zoneAsset.osmosis_deposit_halt_reason = 'extended_unstable_market';

--- a/.github/workflows/utility/check_market_health.mjs
+++ b/.github/workflows/utility/check_market_health.mjs
@@ -2,12 +2,21 @@
 //   Independent market-health track. Daily cron. For each verified non-disabled
 //   asset that isn't already unstable, run a market-health check; on 7 consecutive
 //   failing daily runs, flag it unstable with reason="market" and stamp
-//   state.lastDowntimeDate. Owns recovery for market-unstable assets too:
+//   state.lastDowntimeDate. A run only counts as failing when Numia AND SQS
+//   agree the asset is illiquid (see isMarketGenuinelyFailing): Numia reports
+//   liquidity 0 for every denom it does not price, so on its own it cannot
+//   distinguish a dead market from an unpriced one. Owns recovery for
+//   market-unstable assets too, where advancing the streak and both clearing
+//   mutations require the same cross-source agreement (SQS available AND
+//   canClearExtendedHalt), so nothing reopens or unflags on Numia alone:
 //     • clear osmosis_halt_deposits (reason extended_unstable_market, no
-//       tooltip) on the first passing run where SQS on-chain liquidity ALSO
-//       confirms recovery (cross-source guard; see canClearExtendedHalt).
-//     • 7 consecutive passing runs → clear osmosis_unstable AND wipe state
-//       history fields, only if osmosis_unstable_reason === "market".
+//       tooltip) on the first confirmed-passing run.
+//     • 7 consecutive confirmed-passing runs → clear osmosis_unstable AND wipe
+//       state history fields, only if osmosis_unstable_reason === "market".
+//   Resetting is the exception: a Numia-only failing run may zero
+//   marketHealthRecoveryStreak unaided, since discarding unconfirmed progress
+//   is the safe direction. So a passing-but-unconfirmed run neither advances
+//   nor resets the streak (it holds), while a failing run resets it outright.
 //
 //   Reason-vocabulary contract: this script owns reasons {market}.
 //
@@ -23,6 +32,7 @@ import {
   fetchNumia,
   fetchSqsLiquidityMap,
   findStateAsset,
+  isMarketGenuinelyFailing,
   loadJSON,
   materialiseStateAsset,
   resolveMarket,
@@ -96,6 +106,15 @@ async function main() {
   // halt clearing path cross-checks against Numia. Empty on SQS error → clears
   // fail closed (halt stays).
   const sqsLiquidityByDenom = await fetchSqsLiquidityMap();
+  // Also required before the flagging path may conclude "illiquid": an empty
+  // map would otherwise agree with every Numia zero. See the note on
+  // isMarketGenuinelyFailing.
+  const sqsAvailable = sqsLiquidityByDenom.size > 0;
+  if (!sqsAvailable) {
+    console.error(
+      'SQS liquidity unavailable; no new unstable flags will be set this run.'
+    );
+  }
 
   const nowIso = new Date().toISOString();
   const nowMs = new Date(nowIso).getTime();
@@ -127,7 +146,38 @@ async function main() {
       !marketMissing &&
       market.liquidity < LOW_LIQUIDITY_USD &&
       market.volume24h < LOW_VOLUME_24H_USD;
+    // Numia-only recovery signal. Kept as-is for the streak_reset / recovery
+    // _reset branches, where it only ever makes recovery harder.
     const passing = !marketMissing && !failing;
+    // Recovery that MUTATES (advancing the streak, clearing the halt, clearing
+    // osmosis_unstable) requires the same cross-source agreement as the
+    // deposit-halt clear. Numia can report liquidity for a denom with no real
+    // pool (axlUSDT: $162k reported, $0 pooled), and without this an asset
+    // could accumulate 7 passing runs and lose osmosis_unstable while
+    // canClearExtendedHalt still correctly refuses to reopen its deposits —
+    // inconsistent state from a single unverified source. Fail-closed: no SQS
+    // this run means no recovery progress.
+    const passingConfirmed =
+      passing &&
+      sqsAvailable &&
+      canClearExtendedHalt({
+        market,
+        sqsLiquidity: sqsLiquidityByDenom.get(asset.coinMinimalDenom),
+        lowLiquidityUsd: LOW_LIQUIDITY_USD,
+        lowVolumeUsd: LOW_VOLUME_24H_USD,
+      });
+    // The flagging path needs the stricter reading: Numia failing AND SQS
+    // agreeing, so an unpriced-but-liquid asset (Numia liquidity 0 because
+    // price is null) is not flagged unstable on absent data. Skipped entirely
+    // when SQS is unavailable, so no new flag is set on a single source.
+    const failingConfirmed =
+      sqsAvailable &&
+      isMarketGenuinelyFailing({
+        market,
+        sqsLiquidity: sqsLiquidityByDenom.get(asset.coinMinimalDenom),
+        lowLiquidityUsd: LOW_LIQUIDITY_USD,
+        lowVolumeUsd: LOW_VOLUME_24H_USD,
+      });
 
     if (marketMissing) {
       mutations.push({ kind: 'market_missing', asset: asset.symbol, denom: asset.coinMinimalDenom });
@@ -141,7 +191,7 @@ async function main() {
       // matching the contract used by the recovery path below and by
       // check_ibc_clients's canModifyUnstable().
       if (zoneAsset.tooltip_message) continue;
-      if (failing) {
+      if (failingConfirmed) {
         const streak = (stateAsset?.marketHealthStreak ?? 0) + 1;
         writeState().marketHealthStreak = streak;
         if (streak >= REQUIRED_CONSECUTIVE_RUNS) {
@@ -162,7 +212,10 @@ async function main() {
       }
     } else if (zoneAsset.osmosis_unstable_reason === 'market') {
       // ── Currently market-unstable: track recovery ──
-      if (passing) {
+      // Cross-source gated: the streak only advances on a run where SQS also
+      // confirms real on-chain liquidity, so neither the deposit-halt clear
+      // below nor the osmosis_unstable clear can be reached on Numia alone.
+      if (passingConfirmed) {
         const rstreak = (stateAsset?.marketHealthRecoveryStreak ?? 0) + 1;
         writeState().marketHealthRecoveryStreak = rstreak;
 
@@ -214,11 +267,17 @@ async function main() {
           mutations.push({ kind: 'market_recovered', asset: asset.symbol, chain: asset.chainName });
         }
       } else if (failing) {
+        // Numia-only on purpose: this only RESETS progress, so the stricter
+        // reading would be the unsafe direction (it would let a phantom
+        // recovery survive a genuinely failing run).
         if (stateAsset?.marketHealthRecoveryStreak) {
           stateAsset.marketHealthRecoveryStreak = 0;
           mutations.push({ kind: 'recovery_reset', asset: asset.symbol });
         }
       }
+      // Middle state — Numia passing but SQS unconfirmed — intentionally hits
+      // neither branch: the streak holds rather than advancing or resetting, so
+      // a later run where SQS agrees resumes from where it left off.
     }
     // If unstable but reason !== "market", this script does nothing; the flag
     // is owned by check_ibc_clients or manual.

--- a/.github/workflows/utility/lifecycle_helpers.mjs
+++ b/.github/workflows/utility/lifecycle_helpers.mjs
@@ -237,6 +237,62 @@ export function canClearExtendedHalt({
   return numiaPassing && sqsConfirms;
 }
 
+/**
+ * Decide whether a market signal is a trustworthy "this asset is illiquid"
+ * reading, or merely an absence of Numia price coverage.
+ *
+ * Numia prices only a small subset of the denoms it lists (151 of 2891 as of
+ * 2026-07-28). For every other token it returns `price: null`, and a null
+ * price forces `liquidity: 0` and `volume_24h: 0`. Those zeroes are
+ * indistinguishable from a genuinely dead market by value alone, so the
+ * failing condition (`liquidity < floor && volume < floor`) is satisfied by
+ * missing data. NTRN is the canonical example: `price: null`, liquidity 0,
+ * yet 20 live Osmosis pools.
+ *
+ * SQS is therefore consulted as the second source before any *negative*
+ * conclusion is drawn, mirroring canClearExtendedHalt's cross-source contract
+ * on the positive side. SQS liquidity is the whole-pool `liquidity_cap` sum
+ * from buildSqsLiquidityMap: a deliberate upper bound, which is the correct
+ * bias here — overstating depth makes this guard more willing to spare an
+ * asset, never more willing to halt one.
+ *
+ * Returns true only when BOTH sources agree the asset is illiquid, so a halt
+ * or unstable flag rests on measurement rather than on absent coverage.
+ *
+ * Absent vs unavailable — the two cases must not be conflated:
+ *
+ *   • Denom missing from a POPULATED map: a real observation. The denom is in
+ *     no pool with a usable liquidity cap, which is the strongest evidence of
+ *     illiquidity there is, so it counts as agreement. Treating it as "no
+ *     opinion" would make the most obviously dead assets (listed, but in zero
+ *     pools) permanently un-haltable.
+ *   • Map EMPTY because the SQS fetch failed: no opinion at all. Callers must
+ *     detect this and skip the check entirely — see `sqsAvailable` at the call
+ *     sites. This function cannot distinguish it from a per-denom miss, which
+ *     is exactly why that caller-side gate exists.
+ *
+ * A non-finite value (NaN from a malformed payload) is never agreement: bad
+ * data must not drive a mutation.
+ *
+ * Pure function (no I/O) so it is unit-testable with fixture inputs.
+ */
+export function isMarketGenuinelyFailing({
+  market,
+  sqsLiquidity,
+  lowLiquidityUsd,
+  lowVolumeUsd,
+}) {
+  const numiaFailing =
+    !!market &&
+    market.liquidity < lowLiquidityUsd &&
+    market.volume24h < lowVolumeUsd;
+  // undefined/null → 0: "in no pool" is a measurement, not missing data.
+  // A non-finite reading is discarded rather than coerced.
+  const sqsReading = Number(sqsLiquidity ?? 0);
+  const sqsAgrees = Number.isFinite(sqsReading) && sqsReading < lowLiquidityUsd;
+  return numiaFailing && sqsAgrees;
+}
+
 // ── Misc ─────────────────────────────────────────────────────────────────────
 
 export function loadJSON(p, fallback) {

--- a/.github/workflows/utility/lifecycle_helpers.test.mjs
+++ b/.github/workflows/utility/lifecycle_helpers.test.mjs
@@ -1,0 +1,232 @@
+// Unit tests for the pure cross-source market guards in lifecycle_helpers.mjs.
+// Run with:  node --test .github/workflows/utility/
+//
+// Focus is isMarketGenuinelyFailing, the guard that stops a Numia "liquidity 0"
+// reading from being treated as measured illiquidity when it actually means
+// "Numia does not price this denom". canClearExtendedHalt is covered alongside
+// it to pin the intended asymmetry between setting and clearing.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildSqsLiquidityMap,
+  canClearExtendedHalt,
+  isMarketGenuinelyFailing,
+} from './lifecycle_helpers.mjs';
+
+const FLOORS = { lowLiquidityUsd: 1000, lowVolumeUsd: 100 };
+
+// ── isMarketGenuinelyFailing ────────────────────────────────────────────────
+
+test('both sources agree the market is dead → failing', () => {
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 0 },
+      sqsLiquidity: 30,
+      ...FLOORS,
+    }),
+    true
+  );
+});
+
+test('unpriced-but-liquid asset is NOT failing (the NTRN case)', () => {
+  // Numia returns price:null → liquidity 0, volume 0, indistinguishable from
+  // a dead market. SQS shows real pooled value, so no halt.
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 0 },
+      sqsLiquidity: 46848,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('SQS exactly at the floor is not "below" it → not failing', () => {
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 0 },
+      sqsLiquidity: 1000,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('SQS one cent under the floor → failing', () => {
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 0 },
+      sqsLiquidity: 999.99,
+      ...FLOORS,
+    }),
+    true
+  );
+});
+
+test('Numia passing on liquidity → not failing regardless of SQS', () => {
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 5000, volume24h: 0 },
+      sqsLiquidity: 0,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('Numia passing on volume alone → not failing', () => {
+  // SAGA's shape: liquidity 0 but real 24h volume. Volume above the floor is
+  // enough to spare it, matching the original single-source condition.
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 167.58 },
+      sqsLiquidity: 0,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('missing market (no Numia entry) → not failing', () => {
+  // Absent data must never be a reason to mutate.
+  assert.equal(
+    isMarketGenuinelyFailing({ market: undefined, sqsLiquidity: 0, ...FLOORS }),
+    false
+  );
+});
+
+test('denom absent from a populated map is an observation → failing', () => {
+  // "In no pool at all" is the strongest evidence of illiquidity, not missing
+  // data. The 14 zero-pool assets in the 2026-07-28 batch (SHIB.axl, UNI.axl,
+  // the int3face set, maxBTC…) rely on this to remain haltable. Whole-map
+  // unavailability is a caller concern (sqsAvailable), not this function's.
+  for (const absent of [undefined, null]) {
+    assert.equal(
+      isMarketGenuinelyFailing({
+        market: { liquidity: 0, volume24h: 0 },
+        sqsLiquidity: absent,
+        ...FLOORS,
+      }),
+      true,
+      `expected true for sqsLiquidity=${String(absent)}`
+    );
+  }
+});
+
+test('non-finite SQS readings never drive a mutation → not failing', () => {
+  for (const bad of [NaN, Infinity, -Infinity, 'abc']) {
+    assert.equal(
+      isMarketGenuinelyFailing({
+        market: { liquidity: 0, volume24h: 0 },
+        sqsLiquidity: bad,
+        ...FLOORS,
+      }),
+      false,
+      `expected false for sqsLiquidity=${String(bad)}`
+    );
+  }
+});
+
+test('numeric strings are honoured', () => {
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 0 },
+      sqsLiquidity: '30',
+      ...FLOORS,
+    }),
+    true
+  );
+  assert.equal(
+    isMarketGenuinelyFailing({
+      market: { liquidity: 0, volume24h: 0 },
+      sqsLiquidity: '5000',
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+// ── canClearExtendedHalt: the intended asymmetry ────────────────────────────
+
+test('clearing requires BOTH sources positive', () => {
+  assert.equal(
+    canClearExtendedHalt({
+      market: { liquidity: 5000, volume24h: 0 },
+      sqsLiquidity: 5000,
+      ...FLOORS,
+    }),
+    true
+  );
+  // Numia positive, SQS silent → stays halted (phantom-liquidity guard).
+  assert.equal(
+    canClearExtendedHalt({
+      market: { liquidity: 5000, volume24h: 0 },
+      sqsLiquidity: 0,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('phantom Numia liquidity cannot confirm recovery (the axlUSDT case)', () => {
+  // Live shape 2026-07-28: Numia reports $162,830 liquidity for a denom with
+  // $0 of pooled value in SQS. This is the predicate the market-health
+  // recovery path now gates on, so such an asset can neither reopen deposits
+  // nor lose osmosis_unstable on Numia's word alone.
+  assert.equal(
+    canClearExtendedHalt({
+      market: { liquidity: 162830.91, volume24h: 0 },
+      sqsLiquidity: 0,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('recovery is blocked when the SQS reading is absent entirely', () => {
+  assert.equal(
+    canClearExtendedHalt({
+      market: { liquidity: 5000, volume24h: 500 },
+      sqsLiquidity: undefined,
+      ...FLOORS,
+    }),
+    false
+  );
+});
+
+test('setting and clearing are not mutually exhaustive', () => {
+  // An asset Numia does not price but SQS shows as liquid must neither be
+  // halted nor auto-cleared: both guards return false. This is the deliberate
+  // "no confident conclusion" middle ground.
+  const input = {
+    market: { liquidity: 0, volume24h: 0 },
+    sqsLiquidity: 46848,
+    ...FLOORS,
+  };
+  assert.equal(isMarketGenuinelyFailing(input), false);
+  assert.equal(canClearExtendedHalt(input), false);
+});
+
+// ── buildSqsLiquidityMap: the whole-pool-cap convention ─────────────────────
+
+test('whole-pool caps are summed per denom, error pools skipped', () => {
+  const map = buildSqsLiquidityMap({
+    data: [
+      { liquidity_cap: 100, balances: [{ denom: 'a' }, { denom: 'b' }] },
+      { liquidity_cap: 50, balances: [{ denom: 'a' }] },
+      { liquidity_cap: 900, liquidity_cap_error: 'x', balances: [{ denom: 'a' }] },
+      { liquidity_cap: 0, balances: [{ denom: 'c' }] },
+    ],
+  });
+  // 'a' gets the FULL cap of each pool it appears in, not its share.
+  assert.equal(map.get('a'), 150);
+  assert.equal(map.get('b'), 100);
+  assert.equal(map.has('c'), false);
+});
+
+test('malformed SQS body yields an empty map, not a throw', () => {
+  assert.equal(buildSqsLiquidityMap(undefined).size, 0);
+  assert.equal(buildSqsLiquidityMap({}).size, 0);
+});

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -137,7 +137,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "cosmoshub",
@@ -1044,7 +1046,9 @@
       ],
       "_comment": "JunoSwap $RAW",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "meme",
@@ -1217,7 +1221,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -1262,7 +1268,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "kujira",
@@ -1396,7 +1404,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -1418,7 +1428,9 @@
       ],
       "_comment": "GKey $GKEY",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "crescent",
@@ -1659,7 +1671,9 @@
       ],
       "_comment": "USK $USK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "unification",
@@ -1955,7 +1969,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "canto",
@@ -1995,7 +2011,9 @@
       ],
       "_comment": "Wynd DAO Governance Token $WYND",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -2016,7 +2034,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -2037,7 +2057,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "mars",
@@ -2091,7 +2113,9 @@
       ],
       "_comment": "Stride Staked LUNA $stLUNA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "stride",
@@ -2103,7 +2127,9 @@
       ],
       "_comment": "Stride Staked EVMOS $stEVMOS",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -2295,7 +2321,9 @@
       ],
       "_comment": "Nature Carbon Ton $NCT",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -2394,7 +2422,9 @@
       ],
       "_comment": "Silk $SILK",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -2430,7 +2460,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -2456,7 +2488,9 @@
       ],
       "_comment": "Shade $SHD",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "bluzelle",
@@ -2487,7 +2521,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -2562,7 +2598,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -2587,7 +2625,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -2612,7 +2652,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -2637,7 +2679,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "gitopia",
@@ -2668,7 +2712,9 @@
       ],
       "_comment": "Stride Staked UMEE $stUMEE",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -2832,7 +2878,9 @@
       "osmosis_verified": true,
       "_comment": "EmpowerChain $MPWR",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -2924,7 +2972,9 @@
       ],
       "_comment": "Stride Staked SOMM $stSOMM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "gateway",
@@ -3046,7 +3096,9 @@
       ],
       "_comment": "MantaDAO $MNTA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "juno",
@@ -3657,7 +3709,9 @@
       ],
       "_comment": "Newt $NEWT",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -3941,7 +3995,9 @@
       ],
       "_comment": "Apollo DAO $APOLLO",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "stride",
@@ -3975,7 +4031,9 @@
       "osmosis_verified": true,
       "_comment": "Stride Staked SAGA $stSAGA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "stride",
@@ -3987,7 +4045,9 @@
       "osmosis_verified": true,
       "_comment": "Stride Staked INJ $stINJ",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "injective",
@@ -4040,7 +4100,9 @@
       ],
       "_comment": "Astroport token (Terra) $ASTRO.terra",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -4213,7 +4275,9 @@
       "osmosis_verified": true,
       "_comment": "Stride Staked DYM $stDYM",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "odin",
@@ -4545,7 +4609,9 @@
       "osmosis_verified": true,
       "_comment": "Hava Coin $HAVA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -4588,7 +4654,9 @@
       "osmosis_verified": true,
       "_comment": "Astroport token $ASTRO",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "neutron",
@@ -5761,7 +5829,9 @@
       ],
       "_comment": "Ethereum (Arbitrum via Axelar) $ETH.arb.axl",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -5779,7 +5849,9 @@
       ],
       "_comment": "Ethereum (Base via Axelar) $ETH.base.axl",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -5797,7 +5869,9 @@
       ],
       "_comment": "Ethereum (Polygon via Axelar) $ETH.matic.axl",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "stride",
@@ -6045,7 +6119,9 @@
       "osmosis_verified": true,
       "_comment": "Cosmo $COSMO",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "stride",
@@ -6123,7 +6199,9 @@
       ],
       "_comment": "Optimism (Axelar) $OP.axl",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -6232,7 +6310,9 @@
       ],
       "_comment": "Deenar $DEEN",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -6319,7 +6399,9 @@
         "built_on_osmosis"
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "oraichain",
@@ -6591,7 +6673,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -6686,7 +6770,9 @@
       ],
       "_comment": "Bitcoin Cash (Int3) $BCH.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "int3face",
@@ -6704,7 +6790,9 @@
       ],
       "_comment": "Litecoin (Int3) $LTC.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -6725,7 +6813,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -6746,7 +6836,9 @@
         }
       ],
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "axelar",
@@ -7138,7 +7230,9 @@
       },
       "_comment": "Toncoin (Int3) $TON.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "fetchhub",
@@ -7266,7 +7360,9 @@
       ],
       "_comment": "dTIA $dTIA",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "injective",
@@ -7687,7 +7783,9 @@
       ],
       "_comment": "Movement (Ethereum via Axelar) $MOVE.eth.axl",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -7797,7 +7895,9 @@
       ],
       "_comment": "Initia $INIT",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "milkyway",
@@ -7916,7 +8016,9 @@
       "osmosis_verified": true,
       "_comment": "Vidulum $VDL",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "osmosis",
@@ -8209,7 +8311,9 @@
       ],
       "_comment": "Pudgy Penguins (Int3) $PENGU.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "int3face",
@@ -8230,7 +8334,9 @@
       ],
       "_comment": "Official Trump (Int3) $TRUMP.int3",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "qfs",
@@ -8592,7 +8698,9 @@
       "osmosis_verified": true,
       "_comment": "maxBTC $maxBTC",
       "osmosis_unstable": true,
-      "osmosis_unstable_reason": "market"
+      "osmosis_unstable_reason": "market",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "extended_unstable_market"
     },
     {
       "chain_name": "emoney",


### PR DESCRIPTION
## Why

PR #3688 reported `check_extended_halts` hitting the mutation cap at 17 source chains (limit 10), so the diff was withheld. Investigating that surfaced a data-correctness bug underneath it.

**Numia prices 151 of 2891 listed denoms.** For the other 2740 it returns `price: null`, which forces `liquidity: 0` and `volume_24h: 0`. The market gate's failing condition is `liquidity < $1000 && volume < $100`, so **missing price coverage satisfied it**. The gate was measuring whether Numia happens to price an asset, not whether the asset is illiquid.

NTRN is the clearest case: Numia reports liquidity 0, while SQS shows 20 live Osmosis pools. It was two days from a 60-day deposit halt. dATOM, LBTC, DYM.dym, PEPE.axl ($46.8k pooled), KAVA, KUJI and SAGA were in the same batch.

## The fix

Setting a deposit halt or an unstable flag now requires **Numia and SQS to agree**, mirroring the cross-source contract `canClearExtendedHalt` already enforces on the clearing side. The asymmetry was that clearing was guarded and setting was not.

- `lifecycle_helpers.mjs` — new pure `isMarketGenuinelyFailing`, using the existing whole-pool-cap convention from `buildSqsLiquidityMap`. Its upper-bound bias is the right one here: overstating depth spares assets, never halts them.
- `check_extended_halts.mjs` — cross-source guard on the halt-setting path.
- `check_market_health.mjs` — same guard on the upstream flagging path, which is where `osmosis_unstable` and `lastDowntimeDate` are set. Fixing only the halt script would leave phantom flags accumulating 60 days upstream.

Recovery is gated the same way. Advancing `marketHealthRecoveryStreak` and both clearing mutations now need SQS confirmation, closing a mirror-image gap: **axlUSDT** reports $162,830 Numia liquidity against **$0** pooled, so it could have shed `osmosis_unstable` after 7 runs while its deposit halt correctly refused to clear. Resetting the streak stays Numia-only, since discarding unconfirmed progress is the safe direction.

Fail-closed throughout: no SQS this run means no new halts, no new flags, no recovery progress. A denom absent from a *populated* map still counts as agreement, because "in no pool" is a measurement rather than absent data. That distinction keeps the 14 zero-pool assets in this batch haltable.

## The withheld halts

The cap fires on chain **count**, and even the corrected diff spans 14 chains, so this batch could never self-apply. It needed a one-time `--force`.

**54 deposit halts applied** (`extended_unstable_market`), taking the total 468 → 522. Withdrawals stay open, so holders can always exit.

Every asset was reviewed against live Numia and SQS readings. Only 3 of the original 61 had meaningful real exit depth:

| Asset | Real quote depth | Outcome |
|---|---|---|
| YieldETH | $16,804 (pool 1213) | deposits left open |
| stkOSMO | $2,149 (79,192 OSMO, pool 1323) | spared by the new gate |
| ROAR | $981 (36,149 OSMO, $19 under floor) | deposits left open |

34 of the batch sit under $10 of real depth, and 14 are in no pool at all.

**COSMO was applied by hand.** SQS reports $301k under the whole-pool convention, but that cap is self-referential: pool 2781's entire quote side is 369.5 OSMO (~$10), and Numia carries `price: null` for it. The automated gate spares it while the real exit liquidity is dust, so it needed a manual halt.

## Root cause of the synchronised trigger

All 54 share `lastDowntimeDate: 2026-05-28`, a bulk backfill stamp from `75349f1ce` following the lifecycle migration. 2026-05-28 + 60 days = 2026-07-27, the run date, and every row read exactly 60-61 days. The 60-day clock that triggered them is an artifact; the liquidity readings underneath are live and were verified on 2026-07-28.

The forward queue is small: 11 assets cross on 2026-07-29, then single-asset days into September. Re-stamping the backfilled dates from real observations is **not** in this PR and remains outstanding.

## Testing

- 16 unit tests via `node:test`, no new dependency: `node --test .github/workflows/utility/lifecycle_helpers.test.mjs`. Covers the NTRN unpriced case, the axlUSDT phantom-recovery case, floor boundaries, volume-only passing, non-finite readings, and the zero-pool assets that must stay haltable.
- `node --check` on all four touched scripts.
- Dry-run before/after: 61 mutations / 17 chains → 53 / 14.
- Market-health dry-run: informational mutations only, no flags or clears, so the new gate blocks nothing legitimate.
- Verified semantically against `HEAD`: 884 assets before and after, 54 newly halted, **no non-halt field touched on any asset**.

## Notes for review

- Generated files are deliberately **not** included. Regenerating locally pulled in unrelated `chain-registry` submodule drift (a `channel-1` → `channel-108157` change and new assets), since this worktree's submodule is ahead of the committed pointer. CI regenerates these anyway.
- Two commits, separable: the gate fix, then the halt application.
- The recovery gate makes clearing `osmosis_unstable` stricter (7 consecutive SQS-confirmed runs). axlUSDT is currently the only asset showing the phantom pattern, so practical impact is small, but recovery is slower for anything SQS covers intermittently.
