### PR TITLE
chore(gravity): reactivate GRAV transfers, keep bridged assets halted

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -679,11 +679,7 @@
       "_comment": "Gravity Bridge $GRAV",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "bridge_down",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "bridge_down",
-      "tooltip_message": "Gravity Bridge has been compromised. Deposits and withdrawals are halted while the situation is assessed."
+      "tooltip_message": "Gravity Bridge suffered an exploit in May 2026 and its Ethereum bridge remains out of service. GRAV transfers over IBC are working again, but assets bridged from Ethereum through Gravity cannot currently be redeemed."
     },
     {
       "chain_name": "decentr",


### PR DESCRIPTION
## Description

Re-enables deposits and withdrawals for **GRAV** (`ugraviton`) only. The ten Ethereum-backed `.grv` assets stay fully halted.

Gravity Bridge restarted on **12 July 2026** (chain halted at height 22,709,471 on 30 May, resumed at 22,709,472) and Osmosis [prop 1036](https://www.mintscan.io/osmosis/proposals/1036) recovered the expired IBC client on **2 August**, replacing `07-tendermint-1737` with substitute `07-tendermint-3737`. That path is verifiably working: the client is live and tracking, `channel-144` is `STATE_OPEN`, and packets have been flowing since the vote closed.

GRAV is a native Cosmos token moving over IBC, so it needs no Ethereum leg and is safe to reopen.

### Why the bridged assets stay halted

The Ethereum side of the bridge is still not functional:

- Last `submitBatch` on `Gravity.sol` (`0xa4108aA1Ec4967F8b52220a4f7e94A8201F2D906`) was **30 May 2026**, hours into the exploit.
- Orchestrators have not attested a deposit since the halt: newest `MsgSendToCosmosClaim` is at height 22,707,133 (30 May), so `sendToCosmos` deposits made in June and July are sitting uncredited.
- Every token movement on the contract since the exploit is **inbound, with none outbound**.
- One withdrawal is stuck in the queue (pending batch nonce 41579).

A deposit into any `.grv` asset today would be a claim on a bridge nobody is operating, so `WBTC.eth.grv`, `ETH.grv`, `USDC.eth.grv`, `DAI.grv`, `USDT.eth.grv`, `PAGE`, `PAXG.grv`, `PSTAKE.grv`, `sDAI.grv` and `OCC.grv` keep both kill switches with reason `bridge_down`. Withdrawals stay halted too: sending a `.grv` asset back to Gravity would just move value to where it is equally stuck, so this is not an exit-window situation.

Four of the exploited contracts (USDC, USDT, WETH, PAXG) are exactly assets listed here, so they carry the highest residual uncertainty until there is a postmortem. There has been no postmortem, no compensation plan, and no fund recovery: the stolen ~$5.4M went through Tornado Cash and the attacker addresses now hold only residue.

### GRAV state after this change

`osmosis_unstable: true` is retained (warning-only, does not gate transfers per the schema) with a new tooltip:

> Gravity Bridge suffered an exploit in May 2026 and its Ethereum bridge remains out of service. GRAV transfers over IBC are working again, but assets bridged from Ethereum through Gravity cannot currently be redeemed.

### Verification

- `validate_zone_data.mjs` exits 0.
- Ran `generate_assetlist.mjs` and confirmed the generated frontend output: GRAV emits `unstable: true` with **no** `haltDeposits`/`haltWithdrawals` keys, while `ETH.grv` still emits `haltDeposits: true` / `haltWithdrawals: true`.
- Generated files are intentionally **not** included: regeneration pulled in unrelated upstream drift (a gonka channel id, a limonata testnet channel, a pARTy asset removal, a `state.json` newline strip). The `[AUTO] Asset and Chain Update` workflow regenerates these.

## Checklist

- [x] Changes are limited to `osmosis-1/osmosis.zone_assets.json`.
- [x] No new assets or chains added.
- [x] Halt reasons use existing schema enum values (`bridge_down`, `manual`).
