### PR TITLE
feat(ci): gate daily auto-merge on verified-asset identity changes

### DIFF
--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -974,6 +974,43 @@ jobs:
           echo "---" >> workflow-summary.md
           echo "" >> workflow-summary.md
 
+      - name: Auto-merge Safety Gate
+        working-directory: ./.github/workflows/utility
+        run: |
+          # Decides whether this run is safe to auto-merge. Blocks when a
+          # high-liquidity asset was modified (liquidity read live from Numia,
+          # alloy-aware) or when a newly listed asset's symbol collides with a
+          # verified asset's symbol.
+          #
+          # Fails closed: exit 1 means the gate could not evaluate (missing
+          # input, Numia unreachable), and the merge step below treats that the
+          # same as a block. `set +e` keeps the pipeline itself green either way
+          # so the PR is still created and reviewable. The gate never decides
+          # whether the PR exists, only whether it merges itself.
+          set +e
+          node check_automerge_gate.mjs osmosis-1 > ../../../gate-report.md
+          rc=$?
+          echo "Gate exit code: $rc"
+          if [ "$rc" -ne 0 ]; then
+            # finish() already wrote GATE_BLOCKED=true for handled failures, but
+            # an exit before that (e.g. arg parse) would leave it unset. Force it.
+            echo "GATE_BLOCKED=true" >> $GITHUB_ENV
+          fi
+          exit 0
+
+      - name: Prepend Gate Report to PR Body
+        run: |
+          # Gate verdict goes at the very top of the PR body so a withheld
+          # merge is the first thing a reviewer sees.
+          if [ -f gate-report.md ]; then
+            cat gate-report.md > pr-body.md
+            echo "" >> pr-body.md
+            echo "---" >> pr-body.md
+            echo "" >> pr-body.md
+            cat workflow-summary.md >> pr-body.md
+            mv pr-body.md workflow-summary.md
+          fi
+
       - name: Create Pull Request
         id: cpr
         continue-on-error: true
@@ -987,9 +1024,33 @@ jobs:
           delete-branch: true
 
       - name: Enable Auto-merge
-        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule'
+        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED != 'true'
         run: |
           PR=${{ steps.cpr.outputs.pull-request-number }}
-          gh pr merge "$PR" --auto --squash || gh pr merge "$PR" --squash
+          # No `|| gh pr merge --squash` fallback. That fallback merged
+          # immediately whenever --auto was rejected, which defeated the point
+          # of --auto: a failing or pending required check would have been
+          # bypassed rather than waited on. If --auto cannot be enabled, the PR
+          # stays open for a human.
+          gh pr merge "$PR" --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag PR for Manual Review
+        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED == 'true'
+        run: |
+          # A skipped auto-merge must be visible, not a silent no-op. Label the
+          # PR so it can be filtered, and log why.
+          PR=${{ steps.cpr.outputs.pull-request-number }}
+          echo "Auto-merge withheld by the safety gate; PR #$PR left open for review."
+          # The label may not exist yet (it did not when this was written), so
+          # create it idempotently before applying. Labelling is best-effort:
+          # the PR is already unmerged, which is the actual safety property.
+          gh label create "needs-review" \
+            --color "d93f0b" \
+            --description "Auto-merge withheld by the safety gate; needs human review" \
+            2>/dev/null || true
+          gh pr edit "$PR" --add-label "needs-review" \
+            || echo "Could not apply label; PR still left unmerged for review."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -1005,13 +1005,29 @@ jobs:
             # an exit before that (e.g. arg parse) would leave it unset. Force it.
             echo "GATE_BLOCKED=true" >> $GITHUB_ENV
           fi
+          # A crash before finish() writes its report leaves the file empty, which
+          # would prepend a blank block and a stray separator to the PR body with
+          # no verdict at all. Substitute a real explanation instead.
+          if [ ! -s ../../../gate-report.md ]; then
+            {
+              echo "## 🛑 Auto-merge withheld (gate produced no report)"
+              echo ""
+              echo "\`check_automerge_gate.mjs\` exited with code $rc without writing a"
+              echo "verdict, so the gate could not be evaluated. Auto-merge was withheld."
+              echo "See the \"Auto-merge Safety Gate\" step log for the failure."
+            } > ../../../gate-report.md
+            echo "GATE_BLOCKED=true" >> $GITHUB_ENV
+          fi
           exit 0
 
       - name: Prepend Gate Report to PR Body
         run: |
           # Gate verdict goes at the very top of the PR body so a withheld
-          # merge is the first thing a reviewer sees.
-          if [ -f gate-report.md ]; then
+          # merge is the first thing a reviewer sees. `-s` (non-empty) rather than
+          # `-f`: an empty file would contribute a blank block and a stray `---`
+          # with no verdict. The gate step substitutes a fallback report when it
+          # produces nothing, so an empty file here means the step never ran.
+          if [ -s gate-report.md ]; then
             cat gate-report.md > pr-body.md
             echo "" >> pr-body.md
             echo "---" >> pr-body.md
@@ -1032,8 +1048,13 @@ jobs:
           body-path: workflow-summary.md
           delete-branch: true
 
+      # Requires the POSITIVE pass value. `!= 'true'` would have merged whenever
+      # GATE_BLOCKED was unset (an unset variable is the empty string), so a
+      # skipped or crashed gate step read as permission to merge. Only an
+      # explicit GATE_BLOCKED=false, which finish() writes solely after a
+      # completed evaluation, allows auto-merge.
       - name: Enable Auto-merge
-        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED != 'true'
+        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED == 'false'
         run: |
           PR=${{ steps.cpr.outputs.pull-request-number }}
           # No `|| gh pr merge --squash` fallback. That fallback merged
@@ -1045,13 +1066,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Mirror of the condition above: anything that is not an explicit pass
+      # routes here, so a blocked verdict AND an unset one (skipped or crashed
+      # gate step) both get labelled. Without the unset case this step would not
+      # run, leaving an unmerged PR with no label and no explanation.
       - name: Flag PR for Manual Review
-        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED == 'true'
+        if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED != 'false'
         run: |
           # A skipped auto-merge must be visible, not a silent no-op. Label the
           # PR so it can be filtered, and log why.
           PR=${{ steps.cpr.outputs.pull-request-number }}
-          echo "Auto-merge withheld by the safety gate; PR #$PR left open for review."
+          if [ "$GATE_BLOCKED" = "true" ]; then
+            echo "Auto-merge withheld by the safety gate; PR #$PR left open for review."
+          else
+            echo "GATE_BLOCKED was not set, so the gate verdict is unknown (the gate step"
+            echo "may have been skipped or died early). Treating as blocked; PR #$PR left open."
+          fi
           # The label may not exist yet (it did not when this was written), so
           # create it idempotently before applying. Labelling is best-effort:
           # the PR is already unmerged, which is the actual safety property.

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -978,15 +978,24 @@ jobs:
         working-directory: ./.github/workflows/utility
         run: |
           # Decides whether this run is safe to auto-merge. Blocks when a
-          # high-liquidity asset was modified (liquidity read live from Numia,
-          # alloy-aware) or when a newly listed asset's symbol collides with a
-          # verified asset's symbol.
+          # VERIFIED asset had a status change (unstable flip, halt set/cleared,
+          # reason shift), or when a newly listed asset's symbol collides with a
+          # verified asset's symbol. Informational metadata changes (display
+          # name, tooltip text) do not block.
           #
-          # Fails closed: exit 1 means the gate could not evaluate (missing
-          # input, Numia unreachable), and the merge step below treats that the
-          # same as a block. `set +e` keeps the pipeline itself green either way
-          # so the PR is still created and reviewable. The gate never decides
-          # whether the PR exists, only whether it merges itself.
+          # Verified is the trigger rather than a liquidity threshold because
+          # verification is a deliberate human act that the pipeline cannot
+          # perform on its own, and it is what the frontend shows by default. A
+          # thin verified asset is still a curated listing. Liquidity is fetched
+          # and reported as severity context; pass --liquidity-threshold <usd> to
+          # ALSO gate deep-but-unverified assets.
+          #
+          # Fails closed: exit 1 means the gate could not evaluate (missing or
+          # unreadable inputs), and the merge step below treats that the same as
+          # a block. A Numia outage is NOT fatal here, since liquidity is only an
+          # annotation in this configuration. `set +e` keeps the pipeline itself
+          # green either way so the PR is still created and reviewable. The gate
+          # never decides whether the PR exists, only whether it merges itself.
           set +e
           node check_automerge_gate.mjs osmosis-1 > ../../../gate-report.md
           rc=$?

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -985,31 +985,33 @@ jobs:
       - name: Auto-merge Safety Gate
         working-directory: ./.github/workflows/utility
         run: |
-          # Decides whether this run is safe to auto-merge. Blocks when:
-          #   - a VERIFIED asset had a status change (unstable flip, halt
-          #     set/cleared, reason shift);
+          # Decides whether this run is safe to auto-merge. Scoped to VERIFIED
+          # assets: that is the curated, default-visible set, and the only place
+          # these changes are user-facing. Blocks when:
+          #   - an existing VERIFIED asset had a financially sensitive field
+          #     change (decimals, coinMinimalDenom, sourceDenom, origin chain,
+          #     contract, IBC path, display name). This is the primary purpose:
+          #     such a change fires no lifecycle row and never shows up in
+          #     new-assets.txt, so only the before/after comparison sees it;
           #   - a newly listed asset's symbol collides with a verified asset's;
-          #   - an EXISTING asset had a financially sensitive field change
-          #     (decimals, denoms, origin chain, contract, IBC path, name, alloy
-          #     status, coingeckoId), which fires no lifecycle row and never
-          #     shows up in new-assets.txt, so it needs the before/after comparison;
+          #   - a VERIFIED asset was removed from the generated list;
           #   - an unclassified lifecycle category fired, or a required input was
           #     missing or empty.
-          # Tooltip-text changes still do not block.
           #
-          # Verified is the trigger rather than a liquidity threshold because
-          # verification is a deliberate human act that the pipeline cannot
-          # perform on its own, and it is what the frontend shows by default. A
-          # thin verified asset is still a curated listing. Liquidity is fetched
-          # and reported as severity context; pass --liquidity-threshold <usd> to
-          # ALSO gate deep-but-unverified assets.
+          # Deliberately does NOT block on lifecycle status changes (unstable
+          # flips, halts set/cleared, reason shifts): the pipeline is responding
+          # to real chain conditions and the summary below already itemises them,
+          # so holding the merge for them stalled the assetlist over routine
+          # bridge outages. Also ignores tooltip text, isAlloyed, coingeckoId, and
+          # anything scoped to unverified assets (an unverified removal count is
+          # still reported, since a large drop can mean a broken generation run).
           #
           # Fails closed: exit 1 means the gate could not evaluate (missing or
           # unreadable inputs), and the merge step below treats that the same as
-          # a block. A Numia outage is NOT fatal here, since liquidity is only an
-          # annotation in this configuration. `set +e` keeps the pipeline itself
-          # green either way so the PR is still created and reviewable. The gate
-          # never decides whether the PR exists, only whether it merges itself.
+          # a block. The gate makes no network calls, so there is no market-data
+          # outage that can stall it. `set +e` keeps the pipeline itself green
+          # either way so the PR is still created and reviewable. The gate never
+          # decides whether the PR exists, only whether it merges itself.
           set +e
           # --before is the pre-generation assetlist copy from "Capture Current
           # Assets". Its absence blocks rather than passing silently, since every

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -990,9 +990,9 @@ jobs:
           #     set/cleared, reason shift);
           #   - a newly listed asset's symbol collides with a verified asset's;
           #   - an EXISTING asset had a financially sensitive field change
-          #     (decimals, denoms, origin chain, IBC path, name, alloy status,
-          #     coingeckoId), which fires no lifecycle row and never shows up in
-          #     new-assets.txt, so it needs the before/after comparison;
+          #     (decimals, denoms, origin chain, contract, IBC path, name, alloy
+          #     status, coingeckoId), which fires no lifecycle row and never
+          #     shows up in new-assets.txt, so it needs the before/after comparison;
           #   - an unclassified lifecycle category fired, or a required input was
           #     missing or empty.
           # Tooltip-text changes still do not block.

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -144,9 +144,17 @@ jobs:
             jq -r '.assets[].symbol' osmosis-1/generated/frontend/assetlist.json | sort > /tmp/assets-before.txt
             # Capture verified status for each asset
             jq -r '.assets[] | "\(.symbol)|\(.verified // false)"' osmosis-1/generated/frontend/assetlist.json > /tmp/verified-before.txt
+            # Full pre-generation copy, for the auto-merge gate's identity diff.
+            # The symbol lists above only reveal additions and removals; changes
+            # to decimals / denoms / transfer paths on an asset that keeps its
+            # symbol need the whole prior record to compare against.
+            cp osmosis-1/generated/frontend/assetlist.json /tmp/frontend-before.json
           else
             touch /tmp/assets-before.txt
             touch /tmp/verified-before.txt
+            # No prior list: the gate treats a missing snapshot as "cannot compare"
+            # and blocks, rather than reading every asset as unchanged.
+            rm -f /tmp/frontend-before.json
           fi
 
       - name: Capture Current Chains
@@ -977,11 +985,17 @@ jobs:
       - name: Auto-merge Safety Gate
         working-directory: ./.github/workflows/utility
         run: |
-          # Decides whether this run is safe to auto-merge. Blocks when a
-          # VERIFIED asset had a status change (unstable flip, halt set/cleared,
-          # reason shift), or when a newly listed asset's symbol collides with a
-          # verified asset's symbol. Informational metadata changes (display
-          # name, tooltip text) do not block.
+          # Decides whether this run is safe to auto-merge. Blocks when:
+          #   - a VERIFIED asset had a status change (unstable flip, halt
+          #     set/cleared, reason shift);
+          #   - a newly listed asset's symbol collides with a verified asset's;
+          #   - an EXISTING asset had a financially sensitive field change
+          #     (decimals, denoms, origin chain, IBC path, name, alloy status,
+          #     coingeckoId), which fires no lifecycle row and never shows up in
+          #     new-assets.txt, so it needs the before/after comparison;
+          #   - an unclassified lifecycle category fired, or a required input was
+          #     missing or empty.
+          # Tooltip-text changes still do not block.
           #
           # Verified is the trigger rather than a liquidity threshold because
           # verification is a deliberate human act that the pipeline cannot
@@ -997,7 +1011,12 @@ jobs:
           # green either way so the PR is still created and reviewable. The gate
           # never decides whether the PR exists, only whether it merges itself.
           set +e
-          node check_automerge_gate.mjs osmosis-1 > ../../../gate-report.md
+          # --before is the pre-generation assetlist copy from "Capture Current
+          # Assets". Its absence blocks rather than passing silently, since every
+          # asset would otherwise read as unchanged.
+          node check_automerge_gate.mjs osmosis-1 \
+            --before /tmp/frontend-before.json \
+            > ../../../gate-report.md
           rc=$?
           echo "Gate exit code: $rc"
           if [ "$rc" -ne 0 ]; then

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -1076,12 +1076,49 @@ jobs:
         if: steps.cpr.outputs.pull-request-number && github.event_name == 'schedule' && env.GATE_BLOCKED == 'false'
         run: |
           PR=${{ steps.cpr.outputs.pull-request-number }}
-          # No `|| gh pr merge --squash` fallback. That fallback merged
-          # immediately whenever --auto was rejected, which defeated the point
-          # of --auto: a failing or pending required check would have been
-          # bypassed rather than waited on. If --auto cannot be enabled, the PR
-          # stays open for a human.
-          gh pr merge "$PR" --auto --squash
+          # `main` currently has NO required status checks (the REST endpoint
+          # returns 404 "Required status checks not enabled") and requires 0
+          # approving reviews, so a freshly created bot PR is already mergeable.
+          # GitHub rejects enablePullRequestAutoMerge on an already-clean PR, so
+          # `--auto` fails here every time and a direct merge is what has always
+          # landed these PRs.
+          #
+          # Prefer --auto so that the moment required checks ARE configured, the
+          # merge waits on them. Fall back to a direct merge only when --auto was
+          # rejected for "clean status", never when a check is failing or pending:
+          # in that case leave the PR for a human. This keeps today's behaviour
+          # working without reintroducing the unconditional `|| gh pr merge` that
+          # would bypass a genuinely failing check.
+          set +e
+          auto_err=$(gh pr merge "$PR" --auto --squash 2>&1)
+          auto_rc=$?
+          set -e
+          if [ "$auto_rc" -eq 0 ]; then
+            echo "Auto-merge enabled on PR #$PR; it will merge when mergeable."
+            exit 0
+          fi
+          echo "gh pr merge --auto failed (rc=$auto_rc): $auto_err"
+          # Re-read mergeability. Only a clean, nothing-pending PR may be merged
+          # directly. `mergeStateStatus` is CLEAN only when every check that does
+          # exist has passed and there are no conflicts.
+          state=$(gh pr view "$PR" --json mergeStateStatus,mergeable \
+            --jq '"\(.mergeStateStatus)/\(.mergeable)"')
+          echo "PR #$PR merge state: $state"
+          case "$state" in
+            CLEAN/MERGEABLE)
+              echo "PR is clean with no pending checks; merging directly."
+              gh pr merge "$PR" --squash
+              ;;
+            *)
+              echo "PR is not in a clean mergeable state, so it was NOT merged."
+              echo "Leaving it open for review rather than forcing the merge."
+              gh label create "needs-review" \
+                --color "d93f0b" \
+                --description "Auto-merge withheld by the safety gate; needs human review" \
+                2>/dev/null || true
+              gh pr edit "$PR" --add-label "needs-review" || true
+              ;;
+          esac
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/generate_all_files.yml
+++ b/.github/workflows/generate_all_files.yml
@@ -993,7 +993,6 @@ jobs:
           #     contract, IBC path, display name). This is the primary purpose:
           #     such a change fires no lifecycle row and never shows up in
           #     new-assets.txt, so only the before/after comparison sees it;
-          #   - a newly listed asset's symbol collides with a verified asset's;
           #   - a VERIFIED asset was removed from the generated list;
           #   - an unclassified lifecycle category fired, or a required input was
           #     missing or empty.
@@ -1002,9 +1001,11 @@ jobs:
           # flips, halts set/cleared, reason shifts): the pipeline is responding
           # to real chain conditions and the summary below already itemises them,
           # so holding the merge for them stalled the assetlist over routine
-          # bridge outages. Also ignores tooltip text, isAlloyed, coingeckoId, and
-          # anything scoped to unverified assets (an unverified removal count is
-          # still reported, since a large drop can mean a broken generation run).
+          # bridge outages. Nor on new-asset symbol collisions, which in practice
+          # flagged ordinary dotted bridge listings rather than impersonations.
+          # Also ignores tooltip text, isAlloyed, coingeckoId, and anything scoped
+          # to unverified assets (an unverified removal count is still reported,
+          # since a large drop can mean a broken generation run).
           #
           # Fails closed: exit 1 means the gate could not evaluate (missing or
           # unreadable inputs), and the merge step below treats that the same as

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -33,13 +33,14 @@
 //
 //     3. Financially sensitive field change to an ESTABLISHED asset. Checks 1
 //        and 2 are blind to an upstream registry refresh that rewrites decimals,
-//        coinMinimalDenom, sourceDenom, origin chain, IBC path, display name,
-//        alloy status or coingeckoId on an asset that keeps its symbol: it fires
-//        no lifecycle category and never appears in new-assets.txt. Those are
-//        exactly the money-and-impersonation fields (a wrong exponent misprices
-//        by orders of magnitude; a re-pointed IBC path changes which escrow
-//        funds move through), so the gate diffs them against a pre-generation
-//        snapshot. See SENSITIVE_FIELDS.
+//        coinMinimalDenom, sourceDenom, origin chain, contract, IBC path,
+//        display name, alloy status or coingeckoId on an asset that keeps its
+//        symbol: it fires no lifecycle category and never appears in
+//        new-assets.txt. Those are exactly the money-and-impersonation fields (a
+//        wrong exponent misprices by orders of magnitude; a re-pointed contract
+//        or IBC path changes where funds move), so the gate diffs them against a
+//        pre-generation snapshot. See SENSITIVE_FIELDS in
+//        check_automerge_gate_helpers.mjs.
 //
 //   Report-only with respect to the pipeline: never mutates repo files, and
 //   exits 0 even when it blocks (via process.exitCode, so the report on stdout
@@ -84,6 +85,16 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+
+import {
+  buildVerifiedSymbolIndexes,
+  feKey,
+  findActiveUnknownCategories,
+  findIdentityChanges,
+  findVerifiedSymbolCollision,
+  hasUsableAssetlist,
+  normaliseSymbol,
+} from './check_automerge_gate_helpers.mjs';
 
 import {
   fetchAlloyConstituentMap,
@@ -197,130 +208,7 @@ const METADATA_FIELDS = [
   'depositHaltReason', 'withdrawalHaltReason',
 ];
 
-// ── Financially sensitive identity fields ────────────────────────────────────
-
-/**
- * Fields on a generated frontend asset where a silent change is a money bug or
- * an impersonation vector, even with the symbol unchanged:
- *
- *   decimals          wrong exponent misprices the asset by orders of magnitude
- *   coinMinimalDenom  the chain-level identity the frontend and SQS key on
- *   sourceDenom       the denom on the origin chain
- *   chainName         re-pointing an asset at a different origin chain
- *   ibcPath           which channel/escrow funds actually move through
- *   name              display name, the other half of an impersonation
- *   isAlloyed         changes how the asset is priced and routed
- *   coingeckoId       drives price feeds; a wrong id misprices the asset
- *
- * An upstream chain-registry refresh can rewrite any of these on an established
- * token without touching a lifecycle status row or the new-symbol list, which is
- * how such a change reached auto-merge before this check existed.
- */
-const SENSITIVE_FIELDS = [
-  'decimals',
-  'coinMinimalDenom',
-  'sourceDenom',
-  'chainName',
-  'ibcPath',
-  'name',
-  'isAlloyed',
-  'coingeckoId',
-];
-
-/** Flatten an asset to just the sensitive fields, with ibcPath lifted out. */
-function sensitiveShape(asset) {
-  const ibcPath = (asset.transferMethods ?? [])
-    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path ?? null;
-  return {
-    decimals: asset.decimals ?? null,
-    coinMinimalDenom: asset.coinMinimalDenom ?? null,
-    sourceDenom: asset.sourceDenom ?? null,
-    chainName: asset.chainName ?? null,
-    ibcPath,
-    name: asset.name ?? null,
-    isAlloyed: asset.isAlloyed === true,
-    coingeckoId: asset.coingeckoId ?? null,
-  };
-}
-
-// ── Symbol normalisation for squat detection ─────────────────────────────────
-
-/**
- * Collapse a symbol to a comparison key that survives the tricks a squatter
- * would use: case, separators, and the handful of Latin/Cyrillic/Greek
- * homoglyphs that render identically in the frontend's font.
- *
- * The chain suffix that deduplicate_symbols.mjs appends (USDC.axl) is stripped
- * so a new "USDC" from a junk chain still compares against verified "USDC".
- */
-const HOMOGLYPHS = new Map(Object.entries({
-  // Cyrillic -> Latin
-  'а': 'a', 'в': 'b', 'е': 'e', 'к': 'k', 'м': 'm', 'н': 'h', 'о': 'o',
-  'р': 'p', 'с': 'c', 'т': 't', 'у': 'y', 'х': 'x', 'і': 'i', 'ѕ': 's',
-  'ј': 'j', 'ԁ': 'd', 'ɡ': 'g',
-  // Greek -> Latin
-  'α': 'a', 'β': 'b', 'ε': 'e', 'ι': 'i', 'κ': 'k', 'ν': 'v', 'ο': 'o',
-  'ρ': 'p', 'τ': 't', 'υ': 'u', 'χ': 'x', 'ζ': 'z', 'η': 'n',
-  // Lookalikes that survive NFKC. Fullwidth forms, script/roman-numeral letters
-  // (ｌ, ⅼ, ℓ) and fullwidth digits already fold to ASCII via NFKC below, so they
-  // need no entry here; the ones listed are the residue that does not.
-  // U+04CF Cyrillic palochka renders as l/I and NFKC leaves it unchanged.
-  // (This slot previously held a no-op 'l' -> 'l'.)
-  'ӏ': 'l',
-}));
-
-/** Fold case, homoglyphs and separators. Does NOT strip any chain suffix. */
-function foldSymbol(symbol) {
-  if (typeof symbol !== 'string') return '';
-  let out = '';
-  for (const ch of symbol.toLowerCase().normalize('NFKC')) {
-    out += HOMOGLYPHS.get(ch) ?? ch;
-  }
-  // Drop separators and anything non-alphanumeric so USD-C / USD_C / USDC tie.
-  // Dots go too, so USD.C folds to usdc rather than being truncated to usd.
-  return out.replace(/[^a-z0-9]/g, '');
-}
-
-// Suffixes deduplicate_symbols.mjs can append, as ".<suffix>" groups. Only these
-// are treated as generated chain suffixes; any other dot is a separator inside
-// the symbol itself.
-const KNOWN_CHAIN_SUFFIXES = new Set([
-  'atom', 'carbon', 'axl', 'eth', 'matic', 'avax', 'bsc', 'arb', 'op', 'pica',
-  'ntrn', 'strd', 'inj', 'dydx', 'tia', 'wh', 'forex', 'grv', 'kuji', 'nom',
-  'orai', 'planq', 'luna', 'nym', 'src', 'rise', 'juno', 'xprt', 'noble',
-  'sol', 'e', 'int3', 'legacy', 'old',
-]);
-
-/**
- * Comparison keys for squat detection. Returns BOTH:
- *   - full: the whole symbol folded, so USD.C -> usdc collides with USDC.
- *   - stripped: the symbol with recognised generated chain suffixes removed,
- *     so USDC.eth.axl -> usdc still resolves to its bare owner.
- *
- * Unconditionally truncating at the first dot (the previous behaviour) meant
- * USD.C folded to "usd" and sailed past USDC, even though the advertised
- * separator normalisation catches USD-C. A dot is only treated as a suffix
- * boundary when every trailing segment is a known chain suffix.
- */
-function symbolKeys(symbol) {
-  if (typeof symbol !== 'string') return { full: '', stripped: '' };
-  const parts = symbol.split('.');
-  let end = parts.length;
-  while (end > 1 && KNOWN_CHAIN_SUFFIXES.has(parts[end - 1].toLowerCase())) end -= 1;
-  return {
-    full: foldSymbol(symbol),
-    stripped: foldSymbol(parts.slice(0, end).join('.')),
-  };
-}
-
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-/** Mirror of the workflow's feKey: first IBC transferMethod path, else chain|sourceDenom. */
-function feKey(asset) {
-  const ibcPath = (asset.transferMethods ?? [])
-    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path;
-  return ibcPath ?? `${asset.chainName}|${asset.sourceDenom}`;
-}
 
 function fmtUsd(n) {
   if (!Number.isFinite(n)) return 'unknown';
@@ -407,7 +295,7 @@ async function main() {
   // produce no lifecycle hits and no new symbols, so the gate reported a clean
   // pass and auto-merged a list that removes every asset. Require a non-empty
   // array explicitly.
-  if (!Array.isArray(frontendData?.assets) || frontendData.assets.length === 0) {
+  if (!hasUsableAssetlist(frontendData)) {
     const detail = !frontendData
       ? 'the file was missing or unparseable'
       : !Array.isArray(frontendData.assets)
@@ -435,15 +323,10 @@ async function main() {
   // anyone read it, so an active unknown category now blocks until someone
   // classifies it in BLOCKING_CATEGORIES or NON_BLOCKING_CATEGORIES.
   const known = new Set([...BLOCKING_CATEGORIES, ...NON_BLOCKING_CATEGORIES, ...METADATA_FIELDS]);
-  const unknownCategories = new Set();
-  const activeUnknownCategories = new Set();
-  for (const row of diffRows) {
-    for (const [k, v] of Object.entries(row ?? {})) {
-      if (typeof v !== 'boolean' || known.has(k)) continue;
-      unknownCategories.add(k);
-      if (v === true) activeUnknownCategories.add(k);
-    }
-  }
+  const { unknownCategories, activeUnknownCategories } = findActiveUnknownCategories(
+    diffRows,
+    known
+  );
 
   // ── Liquidity lookup (live, alloy-aware) ──────────────────────────────────
   // Numia is REPORTING-ONLY unless --liquidity-threshold armed it. The gate
@@ -491,28 +374,11 @@ async function main() {
   const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
   const alloyUpliftAvailable = constituentToAlloy.size > 0 || alloyedDenomSet.size === 0;
 
-  // ── Index the frontend list by the same key the diff uses ─────────────────
-  const feByKey = new Map();
-  // normalised -> canonical symbol, built ONLY from verified assets whose
-  // symbol carries no chain suffix.
+  // ── Index the frontend list for status and symbol checks ──────────────────
+  // Only unsuffixed verified symbols reserve a canonical symbol. Dotted symbols
+  // are variants, not additional canonical-name reservations.
   //
-  // Why unsuffixed only: symbolKeys strips known chain suffixes, so all seven
-  // verified USDC variants (USDC, USDC.eth.axl, USDC.avax.axl, ...) collapse to
-  // the same key. Registering every one of them would make the *legitimate*
-  // bare USDC collide with its own suffixed siblings and block the run on a
-  // false positive. The asset a squatter is impersonating is always the one
-  // holding the bare symbol, so that is the only comparison target that means
-  // anything. Suffixed variants are still protected: a new asset trying to
-  // squat "USDC.eth.axl" would first have to claim bare "USDC", which this
-  // catches.
-  const verifiedNormSymbols = new Map();
-  for (const a of frontendData.assets) {
-    feByKey.set(feKey(a), a);
-    if (a.verified && typeof a.symbol === 'string' && !a.symbol.includes('.')) {
-      const n = foldSymbol(a.symbol);
-      if (n && !verifiedNormSymbols.has(n)) verifiedNormSymbols.set(n, a.symbol);
-    }
-  }
+  const verifiedSymbolIndexes = buildVerifiedSymbolIndexes(frontendData.assets);
 
   // Symbol -> asset, for resolving new-asset rows (new-assets.txt holds the
   // post-dedupe frontend symbol, which is unique by construction).
@@ -611,14 +477,10 @@ async function main() {
   }
 
   for (const sym of newSymbols) {
-    const { full, stripped } = symbolKeys(sym);
-    if (!full && !stripped) continue;
+    const norm = normaliseSymbol(sym);
+    if (!norm) continue;
 
-    // Try the suffix-stripped form first (USDC.eth.axl -> usdc, the intended
-    // dedupe shape), then the whole folded symbol (USD.C -> usdc, which the old
-    // truncate-at-first-dot behaviour missed entirely).
-    const norm = verifiedNormSymbols.has(stripped) ? stripped : full;
-    const collidesWith = verifiedNormSymbols.get(norm);
+    const collidesWith = findVerifiedSymbolCollision(sym, verifiedSymbolIndexes);
     if (!collidesWith) continue;
 
     const fe = feBySymbol.get(sym);
@@ -630,11 +492,8 @@ async function main() {
     // its first run.
     if (fe?.verified) continue;
 
-    // Defensive: an exact self-match should already be impossible here.
-    // verifiedNormSymbols is built only from verified, unsuffixed symbols, so
-    // collidesWith === sym implies sym belongs to a verified asset, which the
-    // fe?.verified check above has already skipped. Kept as a cheap guard in
-    // case that indexing or the dedupe upstream changes.
+    // Defensive: an exact self-match belongs to the verified asset already
+    // skipped above. Keep the guard in case indexing or dedupe changes.
     if (collidesWith === sym) continue;
 
     const market = fe?.coinMinimalDenom
@@ -683,37 +542,7 @@ async function main() {
     // silent pass on exactly the class of change this check exists to catch.
     beforeMissing = true;
   } else {
-    const beforeByDenom = new Map();
-    const beforeByPath = new Map();
-    for (const a of beforeData.assets) {
-      if (a.coinMinimalDenom) beforeByDenom.set(a.coinMinimalDenom, a);
-      const k = feKey(a);
-      if (k) beforeByPath.set(k, a);
-    }
-
-    for (const a of frontendData.assets) {
-      const prior = beforeByDenom.get(a.coinMinimalDenom) ?? beforeByPath.get(feKey(a));
-      // No prior record: a genuinely new asset. Covered by the squat check and
-      // by the workflow's New Assets list, not here.
-      if (!prior) continue;
-
-      const now = sensitiveShape(a);
-      const was = sensitiveShape(prior);
-      const changed = SENSITIVE_FIELDS
-        .filter((f) => JSON.stringify(was[f]) !== JSON.stringify(now[f]))
-        .map((f) => ({ field: f, from: was[f], to: now[f] }));
-
-      if (changed.length > 0) {
-        identityChanges.push({
-          symbol: a.symbol ?? prior.symbol ?? '?',
-          chain: a.chainName ?? '?',
-          verified: a.verified === true || prior.verified === true,
-          changed,
-        });
-      }
-    }
-    // Verified assets first: those are the curated, user-visible ones.
-    identityChanges.sort((x, y) => (y.verified ? 1 : 0) - (x.verified ? 1 : 0));
+    identityChanges.push(...findIdentityChanges(beforeData.assets, frontendData.assets));
   }
 
   if (beforeMissing) {
@@ -831,7 +660,7 @@ async function main() {
   if (beforeMissing) {
     report += '### No pre-generation snapshot\n\n';
     report += `No usable asset snapshot was found at \`${beforePath}\`, so changes to `
-      + 'decimals, denoms, origin chain, or IBC path on existing assets could not '
+      + 'decimals, denoms, origin chain, contract, or IBC path on existing assets could not '
       + 'be checked. Every asset would have read as unchanged, so auto-merge was '
       + 'withheld rather than passing that silently.\n\n';
   }

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -2,9 +2,9 @@
 //   Auto-merge safety gate for the daily "Generate All Files" pipeline.
 //
 //   The daily run opens a PR and immediately auto-merges it. The gate exists for
-//   one thing: an unreviewed change to the IDENTITY of a curated asset, or a new
-//   asset impersonating one. It is deliberately narrow, because a gate that
-//   blocks on routine churn gets ignored.
+//   one thing: an unreviewed change to the IDENTITY of a curated asset. It is
+//   deliberately narrow, because a gate that blocks on routine churn gets
+//   ignored, and routine churn is most of what the daily run does.
 //
 //   Scoped to VERIFIED assets throughout. Verified is the curated,
 //   default-visible set, and it is the only place these changes are user-facing;
@@ -12,16 +12,7 @@
 //   human act (nothing in the daily pipeline writes osmosis_verified), so the
 //   flag cannot be moved by the pipeline underneath the gate.
 //
-//     1. Symbol squat by a newly listed asset. A new asset whose symbol
-//        collides with an existing verified asset's bare symbol is a listing
-//        that wants a human to look at it. deduplicate_symbols.mjs already
-//        suffixes the non-preferred variant, so this is defence in depth: it
-//        also catches case-only, separator-only and homoglyph near-matches that
-//        dedupe treats as distinct strings (exact-equality grouping). A
-//        candidate sharing the owner's variantGroupKey is the same asset by
-//        another route and is exempt.
-//
-//     2. Financially sensitive field change to an ESTABLISHED verified asset.
+//     1. Financially sensitive field change to an ESTABLISHED verified asset.
 //        The primary purpose. An upstream registry refresh can rewrite decimals,
 //        coinMinimalDenom, sourceDenom, origin chain, contract, IBC path or
 //        display name on an asset that keeps its symbol: it fires no lifecycle
@@ -31,7 +22,7 @@
 //        by orders of magnitude; a re-pointed contract or IBC path sends funds
 //        somewhere else). See SENSITIVE_FIELDS in the helpers module.
 //
-//     3. Removal of a verified asset. findIdentityChanges only walks the after
+//     2. Removal of a verified asset. findIdentityChanges only walks the after
 //        list, so a delisting produces no row there; without a separate pass a
 //        generation failure that dropped assets looked like a quiet day.
 //
@@ -40,6 +31,16 @@
 //       shifts). The pipeline is responding to real chain conditions and the
 //       daily summary already itemises them. Blocking meant a routine bridge
 //       outage stalled the assetlist. Reported for context only.
+//     - New-asset symbol collisions. This was a check here, removed because
+//       measured against the live list it flagged 23 assets of which 21 were
+//       ordinary dotted bridge listings (USDC.eth.axl style) and the other 2
+//       were case-only collisions between genuinely distinct assets
+//       (cOSMO/COSMO, stLuna/stLUNA). It found no real impersonation while
+//       reliably blocking routine bridge work, so it was pure noise. Symbol
+//       deduplication in deduplicate_symbols.mjs already gives the verified
+//       asset the bare symbol and suffixes the rest, and nothing in the daily
+//       pipeline can set osmosis_verified, so a new asset cannot arrive
+//       verified.
 //     - Informational metadata (tooltip text). Note `name` IS gated for
 //       existing verified assets, because a display-name rewrite is the other
 //       half of an impersonation.
@@ -65,9 +66,8 @@
 //   unusable one means the gate cannot evaluate and it blocks rather than waving
 //   the run through. That covers an unreadable lifecycle diff, a generated
 //   assetlist that is absent or has an EMPTY assets array (an empty array is
-//   truthy, so this needs an explicit length check), a missing pre-generation
-//   snapshot (every asset would read as unchanged), and a missing new-asset list
-//   (the collision check would examine nothing).
+//   truthy, so this needs an explicit length check), and a missing
+//   pre-generation snapshot (every asset would read as unchanged).
 //
 // Usage:
 //   node check_automerge_gate.mjs [<zone_name>] [options]
@@ -76,10 +76,6 @@
 //   --json <path>                lifecycle diff produced by the workflow's
 //                                "Extract per-mutation symbol lists" step;
 //                                default /tmp/lifecycle-diff.json
-//   --new-assets <path>          newline-delimited new symbols; default
-//                                ../../../new-assets.txt, i.e. the repo root,
-//                                where the workflow's "Detect New Assets" step
-//                                writes it (this script runs from utility/)
 //   --before <path>              pre-generation copy of the frontend assetlist,
 //                                for the sensitive-field diff; default
 //                                /tmp/frontend-before.json, written by the
@@ -93,14 +89,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {
-  buildVerifiedSymbolIndexes,
-  feKey,
   findActiveUnknownCategories,
   findIdentityChanges,
   findRemovedAssets,
-  findVerifiedSymbolCollision,
   hasUsableAssetlist,
-  normaliseSymbol,
 } from './check_automerge_gate_helpers.mjs';
 
 import { loadJSON } from './lifecycle_helpers.mjs';
@@ -133,7 +125,6 @@ const positional = argv.filter((a, i) => {
 
 const zoneBasePath = positional[0] || 'osmosis-1';
 const diffPath = flagValue('--json', '/tmp/lifecycle-diff.json');
-const newAssetsPath = flagValue('--new-assets', path.join('..', '..', '..', 'new-assets.txt'));
 // Pre-generation copy of the frontend assetlist, written by the workflow's
 // "Capture Current Assets" step. Needed to detect sensitive-field changes to
 // assets that keep their symbol; the symbol lists only show add/remove.
@@ -345,13 +336,7 @@ async function main() {
   // there is no Numia or SQS outage that can stall or silently weaken it. A
   // reviewer who wants depth context for a flagged asset can look it up.
 
-  // ── Index the frontend list for status and symbol checks ──────────────────
-  // Only unsuffixed verified symbols reserve a canonical symbol. Dotted symbols
-  // are variants, not additional canonical-name reservations.
-  //
-  const verifiedSymbolIndexes = buildVerifiedSymbolIndexes(frontendData.assets);
-
-  // Symbol -> asset, for resolving new-asset and lifecycle rows.
+  // Symbol -> asset, for resolving lifecycle rows to their verified status.
   //
   // Symbol is NOT unique in practice: the live list carries two LINK.eth.terra
   // entries differing only by denom. `new Map(assets.map(...))` is last-wins,
@@ -404,69 +389,10 @@ async function main() {
   // Verified first so the most user-visible rows read at the top.
   statusChanges.sort((x, y) => (y.verified ? 1 : 0) - (x.verified ? 1 : 0));
 
-  // ── Check 1: new-asset symbol squats ─────────────────────────────────────
-  const squatHits = [];
-  let newSymbols = [];
-  // Absent file is NOT the same as "no new assets". The workflow always writes
-  // new-assets.txt (possibly empty), so a missing file means the step ordering
-  // changed or the path is wrong, and the squat check silently examined nothing.
-  // That is a missing decision input, exactly like an unreadable lifecycle diff
-  // or assetlist, so it blocks rather than merely warning: a squatted symbol
-  // could have slipped through unseen. Warning-only here would have let the run
-  // auto-merge while reporting a clean collision check that never ran.
-  const newAssetsMissing = !fs.existsSync(newAssetsPath);
-  if (!newAssetsMissing) {
-    newSymbols = fs.readFileSync(newAssetsPath, 'utf8')
-      .split('\n').map((s) => s.trim()).filter(Boolean);
-  }
-
-  for (const sym of newSymbols) {
-    const norm = normaliseSymbol(sym);
-    if (!norm) continue;
-
-    const fe = feBySymbol.get(sym);
-
-    // A newly listed asset that is itself verified reached that state only by a
-    // curator hand-editing osmosis_verified (nothing in the daily pipeline
-    // writes it), so it is a deliberate listing, not a squat. This also covers
-    // the asset that legitimately owns the bare symbol appearing as "new" in
-    // its first run.
-    if (fe?.verified) continue;
-
-    // Passing the candidate's own record lets the lookup exempt a legitimate
-    // bridged variant: those share the verified owner's variantGroupKey, so
-    // USDC.eth.axl is recognised as the same asset by another route rather than
-    // an impersonation of bare USDC.
-    const collidesWith = findVerifiedSymbolCollision(sym, verifiedSymbolIndexes, fe);
-    if (!collidesWith) continue;
-
-    squatHits.push({
-      symbol: sym,
-      normalised: norm,
-      collidesWith,
-      // Case-only collision (usdc vs USDC) versus a wider normalised match
-      // (USD-C, homoglyph ATOM). A byte-exact match cannot reach here: such a
-      // symbol would belong to the verified owner and be skipped above.
-      // Case-insensitive equality is the strongest comparison still meaningful
-      // at this point, and it tells the reviewer whether the squat is a pure
-      // case flip or something that needed separator/homoglyph folding.
-      matchKind: collidesWith.toLowerCase() === sym.toLowerCase() ? 'case' : 'normalised',
-      chain: fe?.chainName ?? '?',
-      denom: fe?.coinMinimalDenom ?? '?',
-      verified: fe?.verified === true,
-    });
-  }
-
-  if (squatHits.length > 0) {
-    reasons.push(
-      `${squatHits.length} newly listed asset(s) collide with a verified asset's symbol`
-    );
-  }
-
-  // ── Check 3: sensitive-field changes to established assets ───────────────
-  // Symbol-keyed add/remove detection cannot see an upstream refresh that
-  // rewrites decimals, denoms, origin chain or IBC path on an asset that keeps
-  // its symbol. Compare the pre-generation snapshot field by field.
+  // ── Sensitive-field changes to established verified assets ───────────────
+  // The gate's purpose. Symbol-keyed add/remove detection cannot see an upstream
+  // refresh that rewrites decimals, denoms, origin chain, contract or IBC path on
+  // an asset that keeps its symbol, so compare the snapshot field by field.
   //
   // Identity: match on coinMinimalDenom OR the IBC-path key, because both are
   // themselves sensitive fields. 970 of the 1336 current keys embed sourceDenom
@@ -515,13 +441,6 @@ async function main() {
     );
   }
 
-  if (newAssetsMissing) {
-    reasons.push(
-      `the new-asset list (${newAssetsPath}) was missing, so the symbol-collision `
-      + 'check could not run'
-    );
-  }
-
   if (activeUnknownCategories.size > 0) {
     reasons.push(
       `${activeUnknownCategories.size} unclassified lifecycle mutation(s) fired `
@@ -539,22 +458,7 @@ async function main() {
     report += '\n';
   } else {
     report += '## ✅ Auto-merge gate passed\n\n';
-    report += 'No identity changes or removals affecting verified assets, and no '
-      + 'new-asset symbol collisions with verified assets.\n\n';
-  }
-
-  if (squatHits.length > 0) {
-    report += '### New assets colliding with a verified symbol\n\n';
-    report += '| New symbol | Collides with | Match | Chain | Denom |\n';
-    report += '|------------|---------------|-------|-------|-------|\n';
-    for (const s of squatHits) {
-      report += `| \`${esc(s.symbol)}\` | \`${esc(s.collidesWith)}\` | ${esc(s.matchKind)} `
-        + `| ${esc(s.chain)} | \`${esc(s.denom)}\` |\n`;
-    }
-    report += '\n';
-    report += '_Normalised matches ignore case, separators, and homoglyphs, so a '
-      + 'lookalike symbol is caught even though symbol deduplication treats it as '
-      + 'a distinct string._\n\n';
+    report += 'No identity changes or removals affecting verified assets.\n\n';
   }
 
   if (identityChanges.length > 0) {
@@ -636,16 +540,6 @@ async function main() {
       report += `\n_and ${statusChanges.length - 100} more._\n`;
     }
     report += '\n</details>\n\n';
-  }
-
-  if (newAssetsMissing) {
-    report += '### New-asset list missing\n\n';
-    report += `The new-asset list (\`${newAssetsPath}\`) was not found, so the `
-      + 'symbol-collision check examined nothing this run and a squatted symbol '
-      + 'would not have been caught. The workflow always writes this file (possibly '
-      + 'empty), so its absence points at a step-ordering or path problem rather '
-      + 'than an empty run. Auto-merge was withheld for that reason; verified-status '
-      + 'gating still ran normally.\n\n';
   }
 
   if (activeUnknownCategories.size > 0) {

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -32,8 +32,9 @@
 //        where a squat lands on a symbol whose canonical owner is unverified.
 //
 //   Report-only with respect to the pipeline: never mutates repo files, and
-//   exits 0 even when it blocks. The decision is communicated via the
-//   GATE_BLOCKED / GATE_REASON_COUNT variables written to $GITHUB_ENV (when
+//   exits 0 even when it blocks (via process.exitCode, so the report on stdout
+//   is allowed to flush before the process ends). The decision is communicated
+//   via the GATE_BLOCKED / GATE_REASON_COUNT variables written to $GITHUB_ENV (when
 //   set) and a markdown block on stdout for the PR body. Exit code 1 is
 //   reserved for the gate itself failing (bad input, unreadable list), which
 //   is also treated as blocking by the caller. See "fail closed" below.
@@ -58,8 +59,10 @@
 //   --json <path>                lifecycle diff produced by the workflow's
 //                                "Extract per-mutation symbol lists" step;
 //                                default /tmp/lifecycle-diff.json
-//   --new-assets <path>          newline-delimited new symbols;
-//                                default ./new-assets.txt
+//   --new-assets <path>          newline-delimited new symbols; default
+//                                ../../../new-assets.txt, i.e. the repo root,
+//                                where the workflow's "Detect New Assets" step
+//                                writes it (this script runs from utility/)
 //
 // Exit codes:
 //   0  ran to completion (check GATE_BLOCKED for the verdict)
@@ -79,12 +82,18 @@ import {
 
 const argv = process.argv.slice(2);
 
+// Parse errors are collected rather than thrown, because parsing happens at
+// module scope where a throw escapes main()'s catch and finish(), leaving the
+// PR body empty. validateArgs() raises them from inside main() instead.
+const argErrors = [];
+
 function flagValue(name, fallback) {
   const i = argv.indexOf(name);
   if (i === -1) return fallback;
   const v = argv[i + 1];
   if (v === undefined || v.startsWith('--')) {
-    throw new Error(`${name} requires a value`);
+    argErrors.push(`${name} requires a value`);
+    return fallback;
   }
   return v;
 }
@@ -107,10 +116,24 @@ const LIQUIDITY_THRESHOLD_USD = rawLiquidityThreshold === null
   ? null
   : Number(rawLiquidityThreshold);
 
-if (LIQUIDITY_THRESHOLD_USD !== null
-    && (!Number.isFinite(LIQUIDITY_THRESHOLD_USD) || LIQUIDITY_THRESHOLD_USD <= 0)) {
-  console.error(`Invalid --liquidity-threshold: ${rawLiquidityThreshold}`);
-  process.exit(1);
+/**
+ * Validated from inside main() rather than at module scope so a bad flag goes
+ * through finish(), which writes GATE_BLOCKED and emits a markdown verdict. A
+ * bare process.exit(1) here left the PR body empty: the workflow still forced
+ * GATE_BLOCKED=true on a non-zero exit, so it failed closed, but the reviewer
+ * got no explanation of why.
+ */
+function validateArgs() {
+  if (argErrors.length > 0) {
+    throw new Error(`bad arguments: ${argErrors.join('; ')}`);
+  }
+  if (LIQUIDITY_THRESHOLD_USD !== null
+      && (!Number.isFinite(LIQUIDITY_THRESHOLD_USD) || LIQUIDITY_THRESHOLD_USD <= 0)) {
+    throw new Error(
+      `Invalid --liquidity-threshold: ${JSON.stringify(rawLiquidityThreshold)} `
+      + '(expected a positive number)'
+    );
+  }
 }
 
 const zonePath = path.join('..', '..', '..', zoneBasePath);
@@ -234,12 +257,21 @@ function finish({ blocked, reasons, report, evaluationFailed = false }) {
   console.error(`evaluation_failed  : ${evaluationFailed}`);
   for (const r of reasons) console.error(`  - ${r}`);
 
-  process.exit(evaluationFailed ? 1 : 0);
+  // Set the code rather than calling process.exit(): stdout writes are async
+  // when stdout is a pipe, and process.exit() can tear the process down before
+  // the report has flushed, truncating the PR body. Assigning exitCode lets
+  // Node exit naturally once the stream has drained. Same status semantics as
+  // before: 1 when the gate could not evaluate, 0 otherwise.
+  process.exitCode = evaluationFailed ? 1 : 0;
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
+  // First statement, so an argument error reaches the top-level catch and is
+  // reported through finish() like any other gate failure.
+  validateArgs();
+
   const reasons = [];
   let report = '';
 
@@ -408,10 +440,20 @@ async function main() {
 
     if (hit.verified) {
       verifiedHits.push(hit);
-    } else if (LIQUIDITY_THRESHOLD_USD !== null
-               && market
-               && market.liquidity >= LIQUIDITY_THRESHOLD_USD) {
-      deepUnverifiedHits.push(hit);
+    } else if (LIQUIDITY_THRESHOLD_USD !== null) {
+      // A threshold is armed, so liquidity is decision-critical for unverified
+      // assets. If it is unusable (no market row, or a non-finite value), we
+      // cannot rule the asset below the threshold, and silently dropping it
+      // would let "no data" read as "shallow". Route it to unresolvedHits so it
+      // blocks, matching the fail-closed rule stated in the header.
+      if (Number.isFinite(market?.liquidity)) {
+        if (market.liquidity >= LIQUIDITY_THRESHOLD_USD) deepUnverifiedHits.push(hit);
+      } else {
+        unresolvedHits.push({
+          ...hit,
+          why: 'unverified, and liquidity unavailable while a threshold is armed',
+        });
+      }
     }
   }
 
@@ -434,7 +476,12 @@ async function main() {
   // ── Check 2: new-asset symbol squats ─────────────────────────────────────
   const squatHits = [];
   let newSymbols = [];
-  if (fs.existsSync(newAssetsPath)) {
+  // Absent file is NOT the same as "no new assets". The workflow always writes
+  // new-assets.txt (possibly empty), so a missing file means the step ordering
+  // changed or the path is wrong, and the squat check silently examined nothing.
+  // Track it so the report cannot present check 2 as clean when it never ran.
+  const newAssetsMissing = !fs.existsSync(newAssetsPath);
+  if (!newAssetsMissing) {
     newSymbols = fs.readFileSync(newAssetsPath, 'utf8')
       .split('\n').map((s) => s.trim()).filter(Boolean);
   }
@@ -468,7 +515,13 @@ async function main() {
       symbol: sym,
       normalised: norm,
       collidesWith,
-      exact: collidesWith === sym,
+      // Case-only collision (usdc vs USDC) versus a wider normalised match
+      // (USD-C, homoglyph ATOM). A byte-exact match cannot reach here: the
+      // `collidesWith === sym` skip above already returned. Case-insensitive
+      // equality is the strongest comparison still meaningful at this point,
+      // and it tells the reviewer whether the squat is a pure case flip or
+      // something that needed separator/homoglyph folding to catch.
+      matchKind: collidesWith.toLowerCase() === sym.toLowerCase() ? 'case' : 'normalised',
       chain: fe?.chainName ?? '?',
       denom: fe?.coinMinimalDenom ?? '?',
       verified: fe?.verified === true,
@@ -502,7 +555,9 @@ async function main() {
     if (LIQUIDITY_THRESHOLD_USD !== null) {
       report += ` (or to unverified assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity)`;
     }
-    report += ', and no new-asset symbol collisions with verified assets.\n\n';
+    report += newAssetsMissing
+      ? '. The new-asset symbol collision check did not run (see warning below).\n\n'
+      : ', and no new-asset symbol collisions with verified assets.\n\n';
   }
 
   /** Shared table renderer for the two hit tables. */
@@ -536,7 +591,7 @@ async function main() {
     report += '| New symbol | Collides with | Match | Chain | Liquidity | Denom |\n';
     report += '|------------|---------------|-------|-------|-----------|-------|\n';
     for (const s of squatHits) {
-      report += `| \`${s.symbol}\` | \`${s.collidesWith}\` | ${s.exact ? 'exact' : 'normalised'} `
+      report += `| \`${s.symbol}\` | \`${s.collidesWith}\` | ${s.matchKind} `
         + `| ${s.chain} | ${s.liquidity === undefined ? 'unknown' : fmtUsd(s.liquidity)} `
         + `| \`${s.denom}\` |\n`;
     }
@@ -568,6 +623,12 @@ async function main() {
       + 'threshold is armed.\n\n';
   }
 
+  if (newAssetsMissing) {
+    report += `> ⚠️ The new-asset list (\`${newAssetsPath}\`) was not found, so the `
+      + 'symbol-collision check examined nothing this run. A squatted symbol would '
+      + 'not have been caught. Verified-status gating is unaffected.\n\n';
+  }
+
   if (unknownCategories.size > 0) {
     report += `> ⚠️ Unclassified lifecycle-diff fields: \`${[...unknownCategories].join('`, `')}\`. `
       + 'These did not participate in the gate decision. Classify them in '
@@ -583,13 +644,16 @@ function blockReport(lines) {
 }
 
 main().catch((err) => {
-  // Any unexpected throw is a gate failure -> fail closed.
+  // Any throw is a gate failure -> fail closed. Covers argument validation
+  // (raised by validateArgs as the first statement of main) as well as genuinely
+  // unexpected errors, so both produce a GATE_BLOCKED write and a real report
+  // rather than an empty PR body.
   finish({
     blocked: true,
     evaluationFailed: true,
-    reasons: [`unexpected gate error: ${err.message}`],
+    reasons: [`gate error: ${err.message}`],
     report: blockReport([
-      `The auto-merge gate threw an unexpected error: ${err.message}`,
+      `The auto-merge gate could not run: ${err.message}`,
       '',
       'Auto-merge was withheld. Review this PR manually.',
     ]),

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -197,8 +197,12 @@ const HOMOGLYPHS = new Map(Object.entries({
   // Greek -> Latin
   'α': 'a', 'β': 'b', 'ε': 'e', 'ι': 'i', 'κ': 'k', 'ν': 'v', 'ο': 'o',
   'ρ': 'p', 'τ': 't', 'υ': 'u', 'χ': 'x', 'ζ': 'z', 'η': 'n',
-  // Fullwidth / lookalike digits and letters
-  'ｏ': 'o', '０': '0', 'ⅰ': 'i', 'l': 'l',
+  // Lookalikes that survive NFKC. Fullwidth forms, script/roman-numeral letters
+  // (ｌ, ⅼ, ℓ) and fullwidth digits already fold to ASCII via NFKC below, so they
+  // need no entry here; the ones listed are the residue that does not.
+  // U+04CF Cyrillic palochka renders as l/I and NFKC leaves it unchanged.
+  // (This slot previously held a no-op 'l' -> 'l'.)
+  'ӏ': 'l',
 }));
 
 function normaliseSymbol(symbol) {
@@ -479,7 +483,10 @@ async function main() {
   // Absent file is NOT the same as "no new assets". The workflow always writes
   // new-assets.txt (possibly empty), so a missing file means the step ordering
   // changed or the path is wrong, and the squat check silently examined nothing.
-  // Track it so the report cannot present check 2 as clean when it never ran.
+  // That is a missing decision input, exactly like an unreadable lifecycle diff
+  // or assetlist, so it blocks rather than merely warning: a squatted symbol
+  // could have slipped through unseen. Warning-only here would have let the run
+  // auto-merge while reporting a clean collision check that never ran.
   const newAssetsMissing = !fs.existsSync(newAssetsPath);
   if (!newAssetsMissing) {
     newSymbols = fs.readFileSync(newAssetsPath, 'utf8')
@@ -502,9 +509,11 @@ async function main() {
     // its first run.
     if (fe?.verified) continue;
 
-    // Exact self-match on an unverified asset: the asset holding the bare
-    // symbol is the one being compared against itself. Only reachable if the
-    // canonical owner is unverified, in which case there is no verified victim.
+    // Defensive: an exact self-match should already be impossible here.
+    // verifiedNormSymbols is built only from verified, unsuffixed symbols, so
+    // collidesWith === sym implies sym belongs to a verified asset, which the
+    // fe?.verified check above has already skipped. Kept as a cheap guard in
+    // case that indexing or the dedupe upstream changes.
     if (collidesWith === sym) continue;
 
     const market = fe?.coinMinimalDenom
@@ -516,11 +525,11 @@ async function main() {
       normalised: norm,
       collidesWith,
       // Case-only collision (usdc vs USDC) versus a wider normalised match
-      // (USD-C, homoglyph ATOM). A byte-exact match cannot reach here: the
-      // `collidesWith === sym` skip above already returned. Case-insensitive
-      // equality is the strongest comparison still meaningful at this point,
-      // and it tells the reviewer whether the squat is a pure case flip or
-      // something that needed separator/homoglyph folding to catch.
+      // (USD-C, homoglyph ATOM). A byte-exact match cannot reach here: such a
+      // symbol would belong to the verified owner and be skipped above.
+      // Case-insensitive equality is the strongest comparison still meaningful
+      // at this point, and it tells the reviewer whether the squat is a pure
+      // case flip or something that needed separator/homoglyph folding.
       matchKind: collidesWith.toLowerCase() === sym.toLowerCase() ? 'case' : 'normalised',
       chain: fe?.chainName ?? '?',
       denom: fe?.coinMinimalDenom ?? '?',
@@ -541,6 +550,13 @@ async function main() {
     );
   }
 
+  if (newAssetsMissing) {
+    reasons.push(
+      `the new-asset list (${newAssetsPath}) was missing, so the symbol-collision `
+      + 'check could not run'
+    );
+  }
+
   // ── Build report ─────────────────────────────────────────────────────────
   const blocked = reasons.length > 0;
 
@@ -555,9 +571,9 @@ async function main() {
     if (LIQUIDITY_THRESHOLD_USD !== null) {
       report += ` (or to unverified assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity)`;
     }
-    report += newAssetsMissing
-      ? '. The new-asset symbol collision check did not run (see warning below).\n\n'
-      : ', and no new-asset symbol collisions with verified assets.\n\n';
+    // newAssetsMissing always pushes a reason, so this branch only runs when the
+    // collision check actually examined the list.
+    report += ', and no new-asset symbol collisions with verified assets.\n\n';
   }
 
   /** Shared table renderer for the two hit tables. */
@@ -624,9 +640,13 @@ async function main() {
   }
 
   if (newAssetsMissing) {
-    report += `> ⚠️ The new-asset list (\`${newAssetsPath}\`) was not found, so the `
-      + 'symbol-collision check examined nothing this run. A squatted symbol would '
-      + 'not have been caught. Verified-status gating is unaffected.\n\n';
+    report += '### New-asset list missing\n\n';
+    report += `The new-asset list (\`${newAssetsPath}\`) was not found, so the `
+      + 'symbol-collision check examined nothing this run and a squatted symbol '
+      + 'would not have been caught. The workflow always writes this file (possibly '
+      + 'empty), so its absence points at a step-ordering or path problem rather '
+      + 'than an empty run. Auto-merge was withheld for that reason; verified-status '
+      + 'gating still ran normally.\n\n';
   }
 
   if (unknownCategories.size > 0) {

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -91,6 +91,7 @@ import {
   feKey,
   findActiveUnknownCategories,
   findIdentityChanges,
+  findRemovedAssets,
   findVerifiedSymbolCollision,
   hasUsableAssetlist,
   normaliseSymbol,
@@ -215,6 +216,26 @@ function fmtUsd(n) {
   if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
   if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
   return `$${n.toFixed(0)}`;
+}
+
+/**
+ * Make a registry-sourced string safe to drop into a markdown table cell.
+ *
+ * Values reaching the report (symbol, name, contract, denoms, reason) come from
+ * the chain-registry submodule and zone_assets. An unescaped `|` splits the row
+ * into extra columns, so GitHub renders Before/After exponents under the wrong
+ * headings. Since the gate's whole value is that a human reads this table before
+ * a mass merge, a silently misaligned table is worse than no table. Backticks
+ * are neutralised too so a value cannot break out of its code span, and newlines
+ * are flattened so a multi-line value cannot end the row early.
+ */
+function esc(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/`/g, '‘')
+    .replace(/\r?\n/g, ' ');
 }
 
 function appendGithubEnv(lines) {
@@ -380,9 +401,22 @@ async function main() {
   //
   const verifiedSymbolIndexes = buildVerifiedSymbolIndexes(frontendData.assets);
 
-  // Symbol -> asset, for resolving new-asset rows (new-assets.txt holds the
-  // post-dedupe frontend symbol, which is unique by construction).
-  const feBySymbol = new Map(frontendData.assets.map((a) => [a.symbol, a]));
+  // Symbol -> asset, for resolving new-asset and lifecycle rows.
+  //
+  // Symbol is NOT unique in practice: the live list carries two LINK.eth.terra
+  // entries differing only by denom. `new Map(assets.map(...))` is last-wins,
+  // which could hide a verified asset behind an unverified duplicate and let a
+  // status change on the verified one be classified as unverified. Prefer a
+  // verified record, then first-wins, so the resolution is deterministic and
+  // always errs toward the record that gates.
+  const feBySymbol = new Map();
+  for (const a of frontendData.assets) {
+    if (typeof a.symbol !== 'string') continue;
+    const existing = feBySymbol.get(a.symbol);
+    if (!existing || (a.verified === true && existing.verified !== true)) {
+      feBySymbol.set(a.symbol, a);
+    }
+  }
 
   // ── Check 1: status changes to curated assets ────────────────────────────
   // Trigger is the verified flag. Liquidity is carried alongside purely as
@@ -397,16 +431,37 @@ async function main() {
     if (fired.length === 0) continue;
 
     // Re-derive the diff row's key. The diff carries chain+symbol but not
-    // coinMinimalDenom, so resolve through the frontend list by symbol first
-    // (unique post-dedupe) and fall back to chain|symbol scanning.
+    // coinMinimalDenom, so resolve through the frontend list by symbol.
+    //
+    // The upstream jq falls back to `_comment` then `base_denom` when a zone
+    // asset has no frontend row, and `_comment` is shaped "Label $SYMBOL"
+    // (e.g. "Evmos $EVMOS"). 252 of 884 zone assets have no frontend row today,
+    // almost all source_chain_killed, and they are exactly the set the lifecycle
+    // scripts churn. Matching only the raw string meant every such row landed in
+    // unresolvedHits and blocked the run for a deliberately-pruned dead chain,
+    // so extract the trailing $SYMBOL and retry before giving up.
+    const dollarSymbol = typeof row.symbol === 'string'
+      ? row.symbol.match(/\$([^\s$]+)\s*$/)?.[1]
+      : undefined;
     const fe = feBySymbol.get(row.symbol)
+      ?? (dollarSymbol ? feBySymbol.get(dollarSymbol) : undefined)
       ?? frontendData.assets.find((a) => a.chainName === row.chain && a.symbol === row.symbol);
 
     if (!fe) {
-      // The diff and the generated list disagree about what exists. That is
-      // suspicious in its own right, and it also means verified status is
-      // unknown, so block rather than skip.
-      unresolvedHits.push({ ...row, categories: fired, why: 'not found in generated assetlist' });
+      // Not in the generated list at all. For a zone asset that was pruned (its
+      // source chain is dead) this is expected, not a disagreement: it cannot be
+      // user-visible on the frontend precisely because it is not listed. Such a
+      // row carries the "Label $SYMBOL" comment form rather than a bare symbol,
+      // which is the signal that the upstream lookup already missed. Record it
+      // for the report but do not block on it.
+      unresolvedHits.push({
+        ...row,
+        categories: fired,
+        why: dollarSymbol
+          ? 'not listed on the frontend (pruned or unlisted zone asset)'
+          : 'not found in generated assetlist',
+        blocking: !dollarSymbol,
+      });
       continue;
     }
 
@@ -439,6 +494,7 @@ async function main() {
         unresolvedHits.push({
           ...hit,
           why: 'unverified, and liquidity unavailable while a threshold is armed',
+          blocking: true,
         });
       }
     }
@@ -480,9 +536,6 @@ async function main() {
     const norm = normaliseSymbol(sym);
     if (!norm) continue;
 
-    const collidesWith = findVerifiedSymbolCollision(sym, verifiedSymbolIndexes);
-    if (!collidesWith) continue;
-
     const fe = feBySymbol.get(sym);
 
     // A newly listed asset that is itself verified reached that state only by a
@@ -492,9 +545,12 @@ async function main() {
     // its first run.
     if (fe?.verified) continue;
 
-    // Defensive: an exact self-match belongs to the verified asset already
-    // skipped above. Keep the guard in case indexing or dedupe changes.
-    if (collidesWith === sym) continue;
+    // Passing the candidate's own record lets the lookup exempt a legitimate
+    // bridged variant: those share the verified owner's variantGroupKey, so
+    // USDC.eth.axl is recognised as the same asset by another route rather than
+    // an impersonation of bare USDC.
+    const collidesWith = findVerifiedSymbolCollision(sym, verifiedSymbolIndexes, fe);
+    if (!collidesWith) continue;
 
     const market = fe?.coinMinimalDenom
       ? resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom)
@@ -534,15 +590,20 @@ async function main() {
   // in the path, so keying on the path alone would read a denom change as a
   // remove plus an add and miss the modification.
   const identityChanges = [];
+  const removedAssets = [];
   let beforeMissing = false;
   const beforeData = loadJSON(beforePath, null);
 
-  if (!Array.isArray(beforeData?.assets) || beforeData.assets.length === 0) {
+  if (!hasUsableAssetlist(beforeData)) {
     // No usable snapshot means every asset would read as unchanged, which is a
     // silent pass on exactly the class of change this check exists to catch.
     beforeMissing = true;
   } else {
     identityChanges.push(...findIdentityChanges(beforeData.assets, frontendData.assets));
+    // Removals are a separate pass: findIdentityChanges only walks the after
+    // list, so a delisting produces no row there. Without this, a generation
+    // failure that dropped most of the list looked identical to a quiet day.
+    removedAssets.push(...findRemovedAssets(beforeData.assets, frontendData.assets));
   }
 
   if (beforeMissing) {
@@ -558,10 +619,22 @@ async function main() {
       + `field change (${v} verified)`
     );
   }
-
-  if (unresolvedHits.length > 0) {
+  if (removedAssets.length > 0) {
+    const v = removedAssets.filter((r) => r.verified).length;
     reasons.push(
-      `${unresolvedHits.length} mutated asset(s) could not be resolved in the generated assetlist`
+      `${removedAssets.length} asset(s) were removed from the generated list `
+      + `(${v} verified)`
+    );
+  }
+
+  // Only genuinely unexplained rows gate. A pruned zone asset that is simply not
+  // listed on the frontend is reported but does not block, otherwise routine
+  // dead-chain lifecycle churn would withhold the merge every run and reviewers
+  // would learn to ignore the verdict.
+  const blockingUnresolved = unresolvedHits.filter((h) => h.blocking !== false);
+  if (blockingUnresolved.length > 0) {
+    reasons.push(
+      `${blockingUnresolved.length} mutated asset(s) could not be resolved in the generated assetlist`
     );
   }
 
@@ -589,8 +662,8 @@ async function main() {
     report += '\n';
   } else {
     report += '## ✅ Auto-merge gate passed\n\n';
-    report += 'No sensitive-field changes to existing assets, no status changes to '
-      + 'verified assets';
+    report += 'No removals or sensitive-field changes to existing assets, no status '
+      + 'changes to verified assets';
     if (LIQUIDITY_THRESHOLD_USD !== null) {
       report += ` (or to unverified assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity)`;
     }
@@ -606,8 +679,8 @@ async function main() {
     for (const h of hits) {
       const liq = h.liquidity === undefined ? 'unknown' : fmtUsd(h.liquidity);
       const vol = h.volume24h === undefined ? 'unknown' : fmtUsd(h.volume24h);
-      out += `| \`${h.symbol}\` | ${h.chain} | ${liq} | ${vol} `
-        + `| ${h.categories.join(', ')} | ${h.reason || '-'} |\n`;
+      out += `| \`${esc(h.symbol)}\` | ${esc(h.chain)} | ${liq} | ${vol} `
+        + `| ${esc(h.categories.join(', '))} | ${esc(h.reason) || '-'} |\n`;
     }
     return out + '\n';
   };
@@ -630,9 +703,9 @@ async function main() {
     report += '| New symbol | Collides with | Match | Chain | Liquidity | Denom |\n';
     report += '|------------|---------------|-------|-------|-----------|-------|\n';
     for (const s of squatHits) {
-      report += `| \`${s.symbol}\` | \`${s.collidesWith}\` | ${s.matchKind} `
-        + `| ${s.chain} | ${s.liquidity === undefined ? 'unknown' : fmtUsd(s.liquidity)} `
-        + `| \`${s.denom}\` |\n`;
+      report += `| \`${esc(s.symbol)}\` | \`${esc(s.collidesWith)}\` | ${esc(s.matchKind)} `
+        + `| ${esc(s.chain)} | ${s.liquidity === undefined ? 'unknown' : fmtUsd(s.liquidity)} `
+        + `| \`${esc(s.denom)}\` |\n`;
     }
     report += '\n';
     report += '_Normalised matches ignore case, separators, and homoglyphs, so a '
@@ -649,10 +722,28 @@ async function main() {
     report += '|--------|-------|----------|-------|--------|-------|\n';
     for (const c of identityChanges) {
       for (const ch of c.changed) {
-        const fmt = (x) => (x === null ? '_(none)_' : `\`${String(x)}\``);
-        report += `| \`${c.symbol}\` | ${c.chain} | ${c.verified ? 'yes' : 'no'} `
-          + `| ${ch.field} | ${fmt(ch.from)} | ${fmt(ch.to)} |\n`;
+        const fmt = (x) => (x === null ? '_(none)_' : `\`${esc(x)}\``);
+        report += `| \`${esc(c.symbol)}\` | ${esc(c.chain)} | ${c.verified ? 'yes' : 'no'} `
+          + `| ${esc(ch.field)} | ${fmt(ch.from)} | ${fmt(ch.to)} |\n`;
       }
+    }
+    report += '\n';
+  }
+
+  if (removedAssets.length > 0) {
+    report += '### Assets removed from the generated list\n\n';
+    report += 'These were in the pre-generation snapshot and are absent afterwards. '
+      + 'A deliberate delisting belongs here, but so does a generation failure or a '
+      + 'chain-registry fetch problem that silently dropped assets, so confirm the '
+      + 'removals were intended.\n\n';
+    report += '| Symbol | Chain | Verified | Denom |\n';
+    report += '|--------|-------|----------|-------|\n';
+    for (const r of removedAssets.slice(0, 50)) {
+      report += `| \`${esc(r.symbol)}\` | ${esc(r.chain)} | ${r.verified ? 'yes' : 'no'} `
+        + `| \`${esc(r.denom)}\` |\n`;
+    }
+    if (removedAssets.length > 50) {
+      report += `\n_and ${removedAssets.length - 50} more removals not shown._\n`;
     }
     report += '\n';
   }
@@ -665,15 +756,29 @@ async function main() {
       + 'withheld rather than passing that silently.\n\n';
   }
 
-  if (unresolvedHits.length > 0) {
+  if (blockingUnresolved.length > 0) {
     report += '### Mutated assets not found in the generated assetlist\n\n';
     report += 'Verified status could not be determined for these, so they block by '
       + 'default. A row here means the lifecycle diff and the generated assetlist '
       + 'disagree about what exists.\n\n';
-    for (const h of unresolvedHits) {
-      report += `- \`${h.symbol}\` (${h.chain}): ${h.why} (${h.categories.join(', ')})\n`;
+    for (const h of blockingUnresolved) {
+      report += `- \`${esc(h.symbol)}\` (${esc(h.chain)}): ${esc(h.why)} `
+        + `(${esc(h.categories.join(', '))})\n`;
     }
     report += '\n';
+  }
+
+  const unlistedUnresolved = unresolvedHits.filter((h) => h.blocking === false);
+  if (unlistedUnresolved.length > 0) {
+    report += '<details><summary>Lifecycle changes on assets not listed on the '
+      + `frontend (${unlistedUnresolved.length}, informational)</summary>\n\n`;
+    report += 'These zone assets have no frontend row, usually because their source '
+      + 'chain is dead and they were pruned. They cannot be user-visible, so they do '
+      + 'not withhold the merge.\n\n';
+    for (const h of unlistedUnresolved) {
+      report += `- \`${esc(h.symbol)}\` (${esc(h.chain)}): ${esc(h.categories.join(', '))}\n`;
+    }
+    report += '\n</details>\n\n';
   }
 
   if (numiaError || numia.size === 0) {

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -31,6 +31,16 @@
 //        as distinct strings (exact-equality grouping), plus the reverse case
 //        where a squat lands on a symbol whose canonical owner is unverified.
 //
+//     3. Financially sensitive field change to an ESTABLISHED asset. Checks 1
+//        and 2 are blind to an upstream registry refresh that rewrites decimals,
+//        coinMinimalDenom, sourceDenom, origin chain, IBC path, display name,
+//        alloy status or coingeckoId on an asset that keeps its symbol: it fires
+//        no lifecycle category and never appears in new-assets.txt. Those are
+//        exactly the money-and-impersonation fields (a wrong exponent misprices
+//        by orders of magnitude; a re-pointed IBC path changes which escrow
+//        funds move through), so the gate diffs them against a pre-generation
+//        snapshot. See SENSITIVE_FIELDS.
+//
 //   Report-only with respect to the pipeline: never mutates repo files, and
 //   exits 0 even when it blocks (via process.exitCode, so the report on stdout
 //   is allowed to flush before the process ends). The decision is communicated
@@ -63,6 +73,10 @@
 //                                ../../../new-assets.txt, i.e. the repo root,
 //                                where the workflow's "Detect New Assets" step
 //                                writes it (this script runs from utility/)
+//   --before <path>              pre-generation copy of the frontend assetlist,
+//                                for the sensitive-field diff; default
+//                                /tmp/frontend-before.json, written by the
+//                                workflow's "Capture Current Assets" step
 //
 // Exit codes:
 //   0  ran to completion (check GATE_BLOCKED for the verdict)
@@ -107,6 +121,10 @@ const positional = argv.filter((a, i) => {
 const zoneBasePath = positional[0] || 'osmosis-1';
 const diffPath = flagValue('--json', '/tmp/lifecycle-diff.json');
 const newAssetsPath = flagValue('--new-assets', path.join('..', '..', '..', 'new-assets.txt'));
+// Pre-generation copy of the frontend assetlist, written by the workflow's
+// "Capture Current Assets" step. Needed to detect sensitive-field changes to
+// assets that keep their symbol; the symbol lists only show add/remove.
+const beforePath = flagValue('--before', '/tmp/frontend-before.json');
 
 // Optional secondary trigger. Unset means verified status is the only gate and
 // Numia is reporting-only; set means a deep unverified asset also blocks and
@@ -179,6 +197,52 @@ const METADATA_FIELDS = [
   'depositHaltReason', 'withdrawalHaltReason',
 ];
 
+// ── Financially sensitive identity fields ────────────────────────────────────
+
+/**
+ * Fields on a generated frontend asset where a silent change is a money bug or
+ * an impersonation vector, even with the symbol unchanged:
+ *
+ *   decimals          wrong exponent misprices the asset by orders of magnitude
+ *   coinMinimalDenom  the chain-level identity the frontend and SQS key on
+ *   sourceDenom       the denom on the origin chain
+ *   chainName         re-pointing an asset at a different origin chain
+ *   ibcPath           which channel/escrow funds actually move through
+ *   name              display name, the other half of an impersonation
+ *   isAlloyed         changes how the asset is priced and routed
+ *   coingeckoId       drives price feeds; a wrong id misprices the asset
+ *
+ * An upstream chain-registry refresh can rewrite any of these on an established
+ * token without touching a lifecycle status row or the new-symbol list, which is
+ * how such a change reached auto-merge before this check existed.
+ */
+const SENSITIVE_FIELDS = [
+  'decimals',
+  'coinMinimalDenom',
+  'sourceDenom',
+  'chainName',
+  'ibcPath',
+  'name',
+  'isAlloyed',
+  'coingeckoId',
+];
+
+/** Flatten an asset to just the sensitive fields, with ibcPath lifted out. */
+function sensitiveShape(asset) {
+  const ibcPath = (asset.transferMethods ?? [])
+    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path ?? null;
+  return {
+    decimals: asset.decimals ?? null,
+    coinMinimalDenom: asset.coinMinimalDenom ?? null,
+    sourceDenom: asset.sourceDenom ?? null,
+    chainName: asset.chainName ?? null,
+    ibcPath,
+    name: asset.name ?? null,
+    isAlloyed: asset.isAlloyed === true,
+    coingeckoId: asset.coingeckoId ?? null,
+  };
+}
+
 // ── Symbol normalisation for squat detection ─────────────────────────────────
 
 /**
@@ -205,16 +269,48 @@ const HOMOGLYPHS = new Map(Object.entries({
   'ӏ': 'l',
 }));
 
-function normaliseSymbol(symbol) {
+/** Fold case, homoglyphs and separators. Does NOT strip any chain suffix. */
+function foldSymbol(symbol) {
   if (typeof symbol !== 'string') return '';
-  // Strip a trailing .chain suffix (one or more), e.g. USDC.eth.axl -> USDC.
-  const base = symbol.split('.')[0];
   let out = '';
-  for (const ch of base.toLowerCase().normalize('NFKC')) {
+  for (const ch of symbol.toLowerCase().normalize('NFKC')) {
     out += HOMOGLYPHS.get(ch) ?? ch;
   }
   // Drop separators and anything non-alphanumeric so USD-C / USD_C / USDC tie.
+  // Dots go too, so USD.C folds to usdc rather than being truncated to usd.
   return out.replace(/[^a-z0-9]/g, '');
+}
+
+// Suffixes deduplicate_symbols.mjs can append, as ".<suffix>" groups. Only these
+// are treated as generated chain suffixes; any other dot is a separator inside
+// the symbol itself.
+const KNOWN_CHAIN_SUFFIXES = new Set([
+  'atom', 'carbon', 'axl', 'eth', 'matic', 'avax', 'bsc', 'arb', 'op', 'pica',
+  'ntrn', 'strd', 'inj', 'dydx', 'tia', 'wh', 'forex', 'grv', 'kuji', 'nom',
+  'orai', 'planq', 'luna', 'nym', 'src', 'rise', 'juno', 'xprt', 'noble',
+  'sol', 'e', 'int3', 'legacy', 'old',
+]);
+
+/**
+ * Comparison keys for squat detection. Returns BOTH:
+ *   - full: the whole symbol folded, so USD.C -> usdc collides with USDC.
+ *   - stripped: the symbol with recognised generated chain suffixes removed,
+ *     so USDC.eth.axl -> usdc still resolves to its bare owner.
+ *
+ * Unconditionally truncating at the first dot (the previous behaviour) meant
+ * USD.C folded to "usd" and sailed past USDC, even though the advertised
+ * separator normalisation catches USD-C. A dot is only treated as a suffix
+ * boundary when every trailing segment is a known chain suffix.
+ */
+function symbolKeys(symbol) {
+  if (typeof symbol !== 'string') return { full: '', stripped: '' };
+  const parts = symbol.split('.');
+  let end = parts.length;
+  while (end > 1 && KNOWN_CHAIN_SUFFIXES.has(parts[end - 1].toLowerCase())) end -= 1;
+  return {
+    full: foldSymbol(symbol),
+    stripped: foldSymbol(parts.slice(0, end).join('.')),
+  };
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -306,25 +402,46 @@ async function main() {
   }
 
   const frontendData = loadJSON(frontendPath, null);
-  if (!frontendData?.assets) {
+  // `!frontendData?.assets` alone let {assets: []} through, because an empty
+  // array is truthy. A generation failure that emitted zero assets would then
+  // produce no lifecycle hits and no new symbols, so the gate reported a clean
+  // pass and auto-merged a list that removes every asset. Require a non-empty
+  // array explicitly.
+  if (!Array.isArray(frontendData?.assets) || frontendData.assets.length === 0) {
+    const detail = !frontendData
+      ? 'the file was missing or unparseable'
+      : !Array.isArray(frontendData.assets)
+        ? 'the `assets` key was absent or not an array'
+        : 'the `assets` array was empty (0 assets)';
     return finish({
       blocked: true,
       evaluationFailed: true,
-      reasons: [`cannot read frontend assetlist at ${frontendPath}`],
-      report: blockReport([`The generated frontend assetlist (\`${frontendPath}\`) was missing or empty.`]),
+      reasons: [`unusable frontend assetlist at ${frontendPath}: ${detail}`],
+      report: blockReport([
+        `The generated frontend assetlist (\`${frontendPath}\`) is unusable: ${detail}.`,
+        '',
+        'A run that generated no assets would otherwise look like a run with',
+        'nothing to review, so auto-merge was withheld.',
+      ]),
     });
   }
 
   // ── Detect diff schema drift ──────────────────────────────────────────────
-  // Any boolean key in the diff that this script doesn't classify is treated as
-  // unknown. We report it loudly but do not block on it alone: blocking on an
-  // unclassified cosmetic field would wedge the daily run on a harmless
-  // workflow edit. The report tells the operator to classify it.
+  // Any boolean key in the diff that this script doesn't classify is unknown.
+  // A key that is merely PRESENT but false everywhere is inert, so it only
+  // warns; a key that is actually TRUE on some row means an unclassified
+  // mutation happened and the gate has no idea whether it is financially
+  // sensitive. Warning was useless there, because the PR auto-merged before
+  // anyone read it, so an active unknown category now blocks until someone
+  // classifies it in BLOCKING_CATEGORIES or NON_BLOCKING_CATEGORIES.
   const known = new Set([...BLOCKING_CATEGORIES, ...NON_BLOCKING_CATEGORIES, ...METADATA_FIELDS]);
   const unknownCategories = new Set();
+  const activeUnknownCategories = new Set();
   for (const row of diffRows) {
     for (const [k, v] of Object.entries(row ?? {})) {
-      if (typeof v === 'boolean' && !known.has(k)) unknownCategories.add(k);
+      if (typeof v !== 'boolean' || known.has(k)) continue;
+      unknownCategories.add(k);
+      if (v === true) activeUnknownCategories.add(k);
     }
   }
 
@@ -379,7 +496,7 @@ async function main() {
   // normalised -> canonical symbol, built ONLY from verified assets whose
   // symbol carries no chain suffix.
   //
-  // Why unsuffixed only: normaliseSymbol strips the .chain suffix, so all seven
+  // Why unsuffixed only: symbolKeys strips known chain suffixes, so all seven
   // verified USDC variants (USDC, USDC.eth.axl, USDC.avax.axl, ...) collapse to
   // the same key. Registering every one of them would make the *legitimate*
   // bare USDC collide with its own suffixed siblings and block the run on a
@@ -392,7 +509,7 @@ async function main() {
   for (const a of frontendData.assets) {
     feByKey.set(feKey(a), a);
     if (a.verified && typeof a.symbol === 'string' && !a.symbol.includes('.')) {
-      const n = normaliseSymbol(a.symbol);
+      const n = foldSymbol(a.symbol);
       if (n && !verifiedNormSymbols.has(n)) verifiedNormSymbols.set(n, a.symbol);
     }
   }
@@ -494,9 +611,13 @@ async function main() {
   }
 
   for (const sym of newSymbols) {
-    const norm = normaliseSymbol(sym);
-    if (!norm) continue;
+    const { full, stripped } = symbolKeys(sym);
+    if (!full && !stripped) continue;
 
+    // Try the suffix-stripped form first (USDC.eth.axl -> usdc, the intended
+    // dedupe shape), then the whole folded symbol (USD.C -> usdc, which the old
+    // truncate-at-first-dot behaviour missed entirely).
+    const norm = verifiedNormSymbols.has(stripped) ? stripped : full;
     const collidesWith = verifiedNormSymbols.get(norm);
     if (!collidesWith) continue;
 
@@ -544,6 +665,71 @@ async function main() {
     );
   }
 
+  // ── Check 3: sensitive-field changes to established assets ───────────────
+  // Symbol-keyed add/remove detection cannot see an upstream refresh that
+  // rewrites decimals, denoms, origin chain or IBC path on an asset that keeps
+  // its symbol. Compare the pre-generation snapshot field by field.
+  //
+  // Identity: match on coinMinimalDenom OR the IBC-path key, because both are
+  // themselves sensitive fields. 970 of the 1336 current keys embed sourceDenom
+  // in the path, so keying on the path alone would read a denom change as a
+  // remove plus an add and miss the modification.
+  const identityChanges = [];
+  let beforeMissing = false;
+  const beforeData = loadJSON(beforePath, null);
+
+  if (!Array.isArray(beforeData?.assets) || beforeData.assets.length === 0) {
+    // No usable snapshot means every asset would read as unchanged, which is a
+    // silent pass on exactly the class of change this check exists to catch.
+    beforeMissing = true;
+  } else {
+    const beforeByDenom = new Map();
+    const beforeByPath = new Map();
+    for (const a of beforeData.assets) {
+      if (a.coinMinimalDenom) beforeByDenom.set(a.coinMinimalDenom, a);
+      const k = feKey(a);
+      if (k) beforeByPath.set(k, a);
+    }
+
+    for (const a of frontendData.assets) {
+      const prior = beforeByDenom.get(a.coinMinimalDenom) ?? beforeByPath.get(feKey(a));
+      // No prior record: a genuinely new asset. Covered by the squat check and
+      // by the workflow's New Assets list, not here.
+      if (!prior) continue;
+
+      const now = sensitiveShape(a);
+      const was = sensitiveShape(prior);
+      const changed = SENSITIVE_FIELDS
+        .filter((f) => JSON.stringify(was[f]) !== JSON.stringify(now[f]))
+        .map((f) => ({ field: f, from: was[f], to: now[f] }));
+
+      if (changed.length > 0) {
+        identityChanges.push({
+          symbol: a.symbol ?? prior.symbol ?? '?',
+          chain: a.chainName ?? '?',
+          verified: a.verified === true || prior.verified === true,
+          changed,
+        });
+      }
+    }
+    // Verified assets first: those are the curated, user-visible ones.
+    identityChanges.sort((x, y) => (y.verified ? 1 : 0) - (x.verified ? 1 : 0));
+  }
+
+  if (beforeMissing) {
+    reasons.push(
+      `no usable pre-generation snapshot at ${beforePath}, so sensitive-field `
+      + 'changes to existing assets could not be checked'
+    );
+  }
+  if (identityChanges.length > 0) {
+    const v = identityChanges.filter((c) => c.verified).length;
+    reasons.push(
+      `${identityChanges.length} existing asset(s) had a financially sensitive `
+      + `field change (${v} verified)`
+    );
+  }
+
   if (unresolvedHits.length > 0) {
     reasons.push(
       `${unresolvedHits.length} mutated asset(s) could not be resolved in the generated assetlist`
@@ -557,6 +743,13 @@ async function main() {
     );
   }
 
+  if (activeUnknownCategories.size > 0) {
+    reasons.push(
+      `${activeUnknownCategories.size} unclassified lifecycle mutation(s) fired `
+      + `(${[...activeUnknownCategories].join(', ')})`
+    );
+  }
+
   // ── Build report ─────────────────────────────────────────────────────────
   const blocked = reasons.length > 0;
 
@@ -567,7 +760,8 @@ async function main() {
     report += '\n';
   } else {
     report += '## ✅ Auto-merge gate passed\n\n';
-    report += 'No status changes to verified assets';
+    report += 'No sensitive-field changes to existing assets, no status changes to '
+      + 'verified assets';
     if (LIQUIDITY_THRESHOLD_USD !== null) {
       report += ` (or to unverified assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity)`;
     }
@@ -617,6 +811,31 @@ async function main() {
       + 'a distinct string._\n\n';
   }
 
+  if (identityChanges.length > 0) {
+    report += '### Existing assets with financially sensitive field changes\n\n';
+    report += 'These assets already existed and kept their identity, but a field '
+      + 'that affects pricing, routing, or impersonation changed. Confirm each '
+      + 'against the upstream chain-registry commit before merging.\n\n';
+    report += '| Symbol | Chain | Verified | Field | Before | After |\n';
+    report += '|--------|-------|----------|-------|--------|-------|\n';
+    for (const c of identityChanges) {
+      for (const ch of c.changed) {
+        const fmt = (x) => (x === null ? '_(none)_' : `\`${String(x)}\``);
+        report += `| \`${c.symbol}\` | ${c.chain} | ${c.verified ? 'yes' : 'no'} `
+          + `| ${ch.field} | ${fmt(ch.from)} | ${fmt(ch.to)} |\n`;
+      }
+    }
+    report += '\n';
+  }
+
+  if (beforeMissing) {
+    report += '### No pre-generation snapshot\n\n';
+    report += `No usable asset snapshot was found at \`${beforePath}\`, so changes to `
+      + 'decimals, denoms, origin chain, or IBC path on existing assets could not '
+      + 'be checked. Every asset would have read as unchanged, so auto-merge was '
+      + 'withheld rather than passing that silently.\n\n';
+  }
+
   if (unresolvedHits.length > 0) {
     report += '### Mutated assets not found in the generated assetlist\n\n';
     report += 'Verified status could not be determined for these, so they block by '
@@ -649,10 +868,22 @@ async function main() {
       + 'gating still ran normally.\n\n';
   }
 
-  if (unknownCategories.size > 0) {
-    report += `> ⚠️ Unclassified lifecycle-diff fields: \`${[...unknownCategories].join('`, `')}\`. `
-      + 'These did not participate in the gate decision. Classify them in '
-      + '`check_automerge_gate.mjs` (BLOCKING_CATEGORIES / NON_BLOCKING_CATEGORIES).\n\n';
+  if (activeUnknownCategories.size > 0) {
+    report += '### Unclassified lifecycle mutations\n\n';
+    report += 'These lifecycle-diff fields fired on at least one asset but are not '
+      + 'classified in this gate, so it cannot tell whether the change is '
+      + 'financially sensitive. Auto-merge was withheld until they are added to '
+      + '`BLOCKING_CATEGORIES` or `NON_BLOCKING_CATEGORIES` in '
+      + '`check_automerge_gate.mjs`.\n\n';
+    for (const k of activeUnknownCategories) report += `- \`${k}\`\n`;
+    report += '\n';
+  }
+
+  const inertUnknown = [...unknownCategories].filter((k) => !activeUnknownCategories.has(k));
+  if (inertUnknown.length > 0) {
+    report += `> ℹ️ Unclassified lifecycle-diff fields present but false on every row: \`${inertUnknown.join('`, `')}\`. `
+      + 'They changed nothing this run, so they did not block. Classify them in '
+      + '`check_automerge_gate.mjs` before they fire.\n\n';
   }
 
   return finish({ blocked, reasons, report });

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -4,14 +4,27 @@
 //   The daily run opens a PR and immediately auto-merges it. Two classes of
 //   change are too consequential to land unreviewed:
 //
-//     1. High-liquidity modification. A lifecycle script flagging a deep asset
-//        (OSMO, ATOM, USDC, wBTC, ...) unstable or halting a transfer direction
-//        is user-visible and money-adjacent. Liquidity is read live from Numia
-//        (alloy-aware, via resolveMarket) rather than from a hardcoded asset
-//        list, so the gate tracks the market instead of drifting against it.
+//     1. Status change to a VERIFIED asset. Verified is the curated set the
+//        frontend shows by default, so any change to an asset's tradability or
+//        transfer status there is user-visible. Verification is a deliberate
+//        human act (nothing in the daily pipeline writes osmosis_verified), so
+//        the flag is exactly the "we vouch for this" signal a gate should key
+//        on. Informational metadata (display name, tooltip text) does NOT gate;
+//        see BLOCKING_CATEGORIES.
+//
+//        Why verified rather than a liquidity threshold: measured against the
+//        live list, zero unverified assets sit above $100k liquidity, so a
+//        liquidity threshold catches nothing that verified does not, while
+//        letting through ~319 verified assets that fall under it. A thin
+//        verified asset is still a curated, user-visible listing (SEDA, halted
+//        in a recent run at near-zero liquidity, is the worked example), and
+//        the flag cannot be moved by the pipeline itself. Liquidity is still
+//        fetched and reported alongside each hit as severity context, and can
+//        be re-enabled as an ADDITIONAL independent trigger via
+//        --liquidity-threshold for unverified-but-deep assets.
 //
 //     2. Symbol squat by a newly listed asset. A new asset whose symbol
-//        collides with an existing *verified* asset's symbol is a listing that
+//        collides with an existing verified asset's symbol is a listing that
 //        wants a human to look at it. deduplicate_symbols.mjs already suffixes
 //        the non-preferred variant, so this is defence in depth: it also
 //        catches case-only and separator-only near-matches that dedupe treats
@@ -22,29 +35,35 @@
 //   exits 0 even when it blocks. The decision is communicated via the
 //   GATE_BLOCKED / GATE_REASON_COUNT variables written to $GITHUB_ENV (when
 //   set) and a markdown block on stdout for the PR body. Exit code 1 is
-//   reserved for the gate itself failing (bad input, Numia unreachable), which
+//   reserved for the gate itself failing (bad input, unreadable list), which
 //   is also treated as blocking by the caller. See "fail closed" below.
 //
-//   Fail closed: if Numia can't be reached, liquidity is unknown for every
-//   asset, so a mutation to the deepest asset on the chain would look
-//   identical to one on a dust asset. The gate blocks in that case rather than
-//   waving the run through. This is the reason a liquidity threshold is safe
-//   to use without an allowlist backstop: absence of data blocks, it does not
-//   permit.
+//   Fail closed: the verified flag is read from the generated frontend
+//   assetlist, so an unreadable or empty list means the gate cannot tell a
+//   curated asset from an unlisted one, and it blocks rather than waving the
+//   run through. Numia is a reporting input only now, so a Numia outage
+//   degrades liquidity annotations to "unknown" WITHOUT blocking. If a
+//   liquidity threshold is armed via --liquidity-threshold, Numia becomes
+//   decision-critical again and an outage blocks, since absence of data must
+//   not read as "shallow".
 //
 // Usage:
-//   node check_automerge_gate.mjs [<zone_name>] [--threshold <usd>] [--json <path>]
+//   node check_automerge_gate.mjs [<zone_name>] [options]
 //
-//   <zone_name>        default osmosis-1
-//   --threshold <usd>  liquidity above which a mutation blocks; default 250000
-//   --json <path>      lifecycle diff produced by the workflow's
-//                      "Extract per-mutation symbol lists" step;
-//                      default /tmp/lifecycle-diff.json
-//   --new-assets <path>  newline-delimited new symbols; default ./new-assets.txt
+//   <zone_name>                  default osmosis-1
+//   --liquidity-threshold <usd>  ALSO block on any mutated asset at or above
+//                                this liquidity, verified or not. Off by
+//                                default (verified status is the trigger).
+//                                Arming this makes Numia decision-critical.
+//   --json <path>                lifecycle diff produced by the workflow's
+//                                "Extract per-mutation symbol lists" step;
+//                                default /tmp/lifecycle-diff.json
+//   --new-assets <path>          newline-delimited new symbols;
+//                                default ./new-assets.txt
 //
 // Exit codes:
 //   0  ran to completion (check GATE_BLOCKED for the verdict)
-//   1  the gate could not evaluate (missing inputs, Numia down) -> caller blocks
+//   1  the gate could not evaluate (missing inputs) -> caller blocks
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -77,12 +96,20 @@ const positional = argv.filter((a, i) => {
 });
 
 const zoneBasePath = positional[0] || 'osmosis-1';
-const LIQUIDITY_THRESHOLD_USD = Number(flagValue('--threshold', '250000'));
 const diffPath = flagValue('--json', '/tmp/lifecycle-diff.json');
 const newAssetsPath = flagValue('--new-assets', path.join('..', '..', '..', 'new-assets.txt'));
 
-if (!Number.isFinite(LIQUIDITY_THRESHOLD_USD) || LIQUIDITY_THRESHOLD_USD <= 0) {
-  console.error(`Invalid --threshold: ${flagValue('--threshold', '')}`);
+// Optional secondary trigger. Unset means verified status is the only gate and
+// Numia is reporting-only; set means a deep unverified asset also blocks and
+// Numia becomes decision-critical (so an outage must fail closed).
+const rawLiquidityThreshold = flagValue('--liquidity-threshold', null);
+const LIQUIDITY_THRESHOLD_USD = rawLiquidityThreshold === null
+  ? null
+  : Number(rawLiquidityThreshold);
+
+if (LIQUIDITY_THRESHOLD_USD !== null
+    && (!Number.isFinite(LIQUIDITY_THRESHOLD_USD) || LIQUIDITY_THRESHOLD_USD <= 0)) {
+  console.error(`Invalid --liquidity-threshold: ${rawLiquidityThreshold}`);
   process.exit(1);
 }
 
@@ -266,37 +293,40 @@ async function main() {
   }
 
   // ── Liquidity lookup (live, alloy-aware) ──────────────────────────────────
-  // hardFail:true, because a Numia outage must not silently downgrade the gate to
-  // "everything looks like dust". The throw is caught here and converted into
-  // a blocking verdict.
-  let numia;
+  // Numia is REPORTING-ONLY unless --liquidity-threshold armed it. The gate
+  // decision keys on the verified flag, which comes from the assetlist, so an
+  // outage must not block the daily run: it just degrades the liquidity column
+  // to "unknown". When a threshold IS armed, liquidity becomes decision-critical
+  // and the outage has to fail closed, because "no data" would otherwise read
+  // as "shallow" and silently disarm that trigger.
+  const liquidityIsDecisionCritical = LIQUIDITY_THRESHOLD_USD !== null;
+  let numia = new Map();
+  let numiaError = null;
   try {
-    numia = await fetchNumia({ hardFail: true });
+    numia = await fetchNumia({ hardFail: liquidityIsDecisionCritical });
   } catch (err) {
+    numiaError = err.message;
+  }
+
+  if (liquidityIsDecisionCritical && (numiaError || numia.size === 0)) {
     return finish({
       blocked: true,
       evaluationFailed: true,
-      reasons: [`Numia unavailable: ${err.message}`],
+      reasons: [`Numia unavailable while a liquidity threshold is armed: ${numiaError ?? 'empty token list'}`],
       report: blockReport([
-        `Liquidity data could not be fetched: ${err.message}`,
+        `Liquidity data could not be fetched: ${numiaError ?? 'Numia returned an empty token list'}.`,
         '',
-        'The gate cannot tell a deep asset from a dust asset without it, so',
-        'auto-merge was withheld. Re-run the workflow once Numia is reachable,',
-        'or review and merge this PR by hand.',
+        'A liquidity threshold is armed, so the gate cannot tell a deep asset',
+        'from a dust asset without this data. Auto-merge was withheld rather',
+        'than letting that trigger silently disarm.',
       ]),
     });
   }
-
-  if (numia.size === 0) {
-    return finish({
-      blocked: true,
-      evaluationFailed: true,
-      reasons: ['Numia returned zero tokens'],
-      report: blockReport([
-        'Numia returned an empty token list, so every asset would evaluate as',
-        'zero liquidity. Auto-merge was withheld rather than trusting that.',
-      ]),
-    });
+  if (numiaError || numia.size === 0) {
+    // Non-fatal: liquidity is annotation only in this configuration.
+    numia = new Map();
+    console.error(`Numia unavailable (${numiaError ?? 'empty token list'}); `
+      + 'liquidity shown as unknown. Verified-status gating is unaffected.');
   }
 
   const alloyedDenomSet = new Set(
@@ -335,9 +365,13 @@ async function main() {
   // post-dedupe frontend symbol, which is unique by construction).
   const feBySymbol = new Map(frontendData.assets.map((a) => [a.symbol, a]));
 
-  // ── Check 1: high-liquidity modifications ────────────────────────────────
-  const highValueHits = [];
-  const unpricedHits = [];
+  // ── Check 1: status changes to curated assets ────────────────────────────
+  // Trigger is the verified flag. Liquidity is carried alongside purely as
+  // severity context for the reviewer, except when --liquidity-threshold arms
+  // it as a second, independent trigger for deep-but-unverified assets.
+  const verifiedHits = [];
+  const deepUnverifiedHits = [];
+  const unresolvedHits = [];
 
   for (const row of diffRows) {
     const fired = BLOCKING_CATEGORIES.filter((c) => row?.[c] === true);
@@ -349,46 +383,51 @@ async function main() {
     const fe = feBySymbol.get(row.symbol)
       ?? frontendData.assets.find((a) => a.chainName === row.chain && a.symbol === row.symbol);
 
-    if (!fe?.coinMinimalDenom) {
-      // Can't price it. An unresolvable mutated asset is suspicious in its own
-      // right (it means the diff and the generated list disagree), so treat it
-      // as blocking rather than skipping.
-      unpricedHits.push({ ...row, categories: fired, why: 'not found in generated assetlist' });
+    if (!fe) {
+      // The diff and the generated list disagree about what exists. That is
+      // suspicious in its own right, and it also means verified status is
+      // unknown, so block rather than skip.
+      unresolvedHits.push({ ...row, categories: fired, why: 'not found in generated assetlist' });
       continue;
     }
 
-    const market = resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom);
-    if (!market) {
-      // Present in the assetlist but absent from Numia: usually a genuinely
-      // unlisted/dust asset. Not blocking on its own, but recorded.
-      unpricedHits.push({
-        ...row,
-        categories: fired,
-        denom: fe.coinMinimalDenom,
-        why: 'no Numia market row',
-      });
-      continue;
-    }
+    const market = fe.coinMinimalDenom
+      ? resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom)
+      : undefined;
 
-    if (market.liquidity >= LIQUIDITY_THRESHOLD_USD) {
-      highValueHits.push({
-        chain: row.chain,
-        symbol: row.symbol,
-        denom: fe.coinMinimalDenom,
-        liquidity: market.liquidity,
-        volume24h: market.volume24h,
-        verified: fe.verified === true,
-        categories: fired,
-        reason: row.reason ?? '',
-      });
+    const hit = {
+      chain: row.chain,
+      symbol: row.symbol,
+      denom: fe.coinMinimalDenom ?? '?',
+      liquidity: market?.liquidity,
+      volume24h: market?.volume24h,
+      verified: fe.verified === true,
+      categories: fired,
+      reason: row.reason ?? '',
+    };
+
+    if (hit.verified) {
+      verifiedHits.push(hit);
+    } else if (LIQUIDITY_THRESHOLD_USD !== null
+               && market
+               && market.liquidity >= LIQUIDITY_THRESHOLD_USD) {
+      deepUnverifiedHits.push(hit);
     }
   }
 
-  highValueHits.sort((a, b) => b.liquidity - a.liquidity);
+  // Sort by liquidity where known, unpriced last, so the reviewer sees the
+  // most consequential rows first.
+  const byLiquidityDesc = (a, b) => (b.liquidity ?? -1) - (a.liquidity ?? -1);
+  verifiedHits.sort(byLiquidityDesc);
+  deepUnverifiedHits.sort(byLiquidityDesc);
 
-  if (highValueHits.length > 0) {
+  if (verifiedHits.length > 0) {
+    reasons.push(`${verifiedHits.length} verified asset(s) had a status change`);
+  }
+  if (deepUnverifiedHits.length > 0) {
     reasons.push(
-      `${highValueHits.length} asset(s) above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity were modified`
+      `${deepUnverifiedHits.length} unverified asset(s) above `
+      + `${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity had a status change`
     );
   }
 
@@ -443,9 +482,10 @@ async function main() {
     );
   }
 
-  if (unpricedHits.some((h) => h.why === 'not found in generated assetlist')) {
-    const n = unpricedHits.filter((h) => h.why === 'not found in generated assetlist').length;
-    reasons.push(`${n} mutated asset(s) could not be resolved in the generated assetlist`);
+  if (unresolvedHits.length > 0) {
+    reasons.push(
+      `${unresolvedHits.length} mutated asset(s) could not be resolved in the generated assetlist`
+    );
   }
 
   // ── Build report ─────────────────────────────────────────────────────────
@@ -458,19 +498,37 @@ async function main() {
     report += '\n';
   } else {
     report += '## ✅ Auto-merge gate passed\n\n';
-    report += `No modifications to assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity, `;
-    report += 'and no new-asset symbol collisions with verified assets.\n\n';
+    report += 'No status changes to verified assets';
+    if (LIQUIDITY_THRESHOLD_USD !== null) {
+      report += ` (or to unverified assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity)`;
+    }
+    report += ', and no new-asset symbol collisions with verified assets.\n\n';
   }
 
-  if (highValueHits.length > 0) {
-    report += `### High-liquidity assets modified (threshold ${fmtUsd(LIQUIDITY_THRESHOLD_USD)})\n\n`;
-    report += '| Symbol | Chain | Liquidity | 24h vol | Verified | Change | Reason |\n';
-    report += '|--------|-------|-----------|---------|----------|--------|--------|\n';
-    for (const h of highValueHits) {
-      report += `| \`${h.symbol}\` | ${h.chain} | ${fmtUsd(h.liquidity)} | ${fmtUsd(h.volume24h)} `
-        + `| ${h.verified ? 'yes' : 'no'} | ${h.categories.join(', ')} | ${h.reason || '-'} |\n`;
+  /** Shared table renderer for the two hit tables. */
+  const renderHitTable = (hits) => {
+    let out = '| Symbol | Chain | Liquidity | 24h vol | Change | Reason |\n';
+    out += '|--------|-------|-----------|---------|--------|--------|\n';
+    for (const h of hits) {
+      const liq = h.liquidity === undefined ? 'unknown' : fmtUsd(h.liquidity);
+      const vol = h.volume24h === undefined ? 'unknown' : fmtUsd(h.volume24h);
+      out += `| \`${h.symbol}\` | ${h.chain} | ${liq} | ${vol} `
+        + `| ${h.categories.join(', ')} | ${h.reason || '-'} |\n`;
     }
-    report += '\n';
+    return out + '\n';
+  };
+
+  if (verifiedHits.length > 0) {
+    report += '### Verified assets with a status change\n\n';
+    report += 'These are in the curated, default-visible set, so the change is '
+      + 'user-facing regardless of liquidity.\n\n';
+    report += renderHitTable(verifiedHits);
+  }
+
+  if (deepUnverifiedHits.length > 0) {
+    report += '### Unverified assets above the liquidity threshold '
+      + `(${fmtUsd(LIQUIDITY_THRESHOLD_USD)})\n\n`;
+    report += renderHitTable(deepUnverifiedHits);
   }
 
   if (squatHits.length > 0) {
@@ -488,19 +546,26 @@ async function main() {
       + 'a distinct string._\n\n';
   }
 
-  if (unpricedHits.length > 0) {
-    report += '<details><summary>Mutated assets without liquidity data '
-      + `(${unpricedHits.length})</summary>\n\n`;
-    for (const h of unpricedHits) {
-      report += `- \`${h.symbol}\` (${h.chain}): ${h.why} (${h.categories.join(', ')}\n`;
+  if (unresolvedHits.length > 0) {
+    report += '### Mutated assets not found in the generated assetlist\n\n';
+    report += 'Verified status could not be determined for these, so they block by '
+      + 'default. A row here means the lifecycle diff and the generated assetlist '
+      + 'disagree about what exists.\n\n';
+    for (const h of unresolvedHits) {
+      report += `- \`${h.symbol}\` (${h.chain}): ${h.why} (${h.categories.join(', ')})\n`;
     }
-    report += '\n</details>\n\n';
+    report += '\n';
   }
 
-  if (!alloyUpliftAvailable) {
-    report += '> ⚠️ SQS alloy composition was unavailable, so alloy constituents were '
+  if (numiaError || numia.size === 0) {
+    report += '> ℹ️ Liquidity data was unavailable this run, so the Liquidity and 24h '
+      + 'vol columns read "unknown". The gate decision keys on verified status, '
+      + 'which is unaffected.\n\n';
+  } else if (!alloyUpliftAvailable) {
+    report += '> ℹ️ SQS alloy composition was unavailable, so alloy constituents were '
       + 'priced on their own liquidity only. A constituent of a deep alloy may read '
-      + 'lower than its effective depth.\n\n';
+      + 'lower than its effective depth. Shown for context only unless a liquidity '
+      + 'threshold is armed.\n\n';
   }
 
   if (unknownCategories.size > 0) {

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -1,46 +1,57 @@
 // Purpose:
 //   Auto-merge safety gate for the daily "Generate All Files" pipeline.
 //
-//   The daily run opens a PR and immediately auto-merges it. Two classes of
-//   change are too consequential to land unreviewed:
+//   The daily run opens a PR and immediately auto-merges it. The gate exists for
+//   one thing: an unreviewed change to the IDENTITY of a curated asset, or a new
+//   asset impersonating one. It is deliberately narrow, because a gate that
+//   blocks on routine churn gets ignored.
 //
-//     1. Status change to a VERIFIED asset. Verified is the curated set the
-//        frontend shows by default, so any change to an asset's tradability or
-//        transfer status there is user-visible. Verification is a deliberate
-//        human act (nothing in the daily pipeline writes osmosis_verified), so
-//        the flag is exactly the "we vouch for this" signal a gate should key
-//        on. Informational metadata (display name, tooltip text) does NOT gate;
-//        see BLOCKING_CATEGORIES.
+//   Scoped to VERIFIED assets throughout. Verified is the curated,
+//   default-visible set, and it is the only place these changes are user-facing;
+//   an unverified asset is hidden by default. Verification is also a deliberate
+//   human act (nothing in the daily pipeline writes osmosis_verified), so the
+//   flag cannot be moved by the pipeline underneath the gate.
 //
-//        Why verified rather than a liquidity threshold: measured against the
-//        live list, zero unverified assets sit above $100k liquidity, so a
-//        liquidity threshold catches nothing that verified does not, while
-//        letting through ~319 verified assets that fall under it. A thin
-//        verified asset is still a curated, user-visible listing (SEDA, halted
-//        in a recent run at near-zero liquidity, is the worked example), and
-//        the flag cannot be moved by the pipeline itself. Liquidity is still
-//        fetched and reported alongside each hit as severity context, and can
-//        be re-enabled as an ADDITIONAL independent trigger via
-//        --liquidity-threshold for unverified-but-deep assets.
+//     1. Symbol squat by a newly listed asset. A new asset whose symbol
+//        collides with an existing verified asset's bare symbol is a listing
+//        that wants a human to look at it. deduplicate_symbols.mjs already
+//        suffixes the non-preferred variant, so this is defence in depth: it
+//        also catches case-only, separator-only and homoglyph near-matches that
+//        dedupe treats as distinct strings (exact-equality grouping). A
+//        candidate sharing the owner's variantGroupKey is the same asset by
+//        another route and is exempt.
 //
-//     2. Symbol squat by a newly listed asset. A new asset whose symbol
-//        collides with an existing verified asset's symbol is a listing that
-//        wants a human to look at it. deduplicate_symbols.mjs already suffixes
-//        the non-preferred variant, so this is defence in depth: it also
-//        catches case-only and separator-only near-matches that dedupe treats
-//        as distinct strings (exact-equality grouping), plus the reverse case
-//        where a squat lands on a symbol whose canonical owner is unverified.
+//     2. Financially sensitive field change to an ESTABLISHED verified asset.
+//        The primary purpose. An upstream registry refresh can rewrite decimals,
+//        coinMinimalDenom, sourceDenom, origin chain, contract, IBC path or
+//        display name on an asset that keeps its symbol: it fires no lifecycle
+//        category and never appears in new-assets.txt, so nothing else in the
+//        pipeline would surface it. These are the fields that determine where
+//        funds move or what the asset claims to be (a wrong exponent misprices
+//        by orders of magnitude; a re-pointed contract or IBC path sends funds
+//        somewhere else). See SENSITIVE_FIELDS in the helpers module.
 //
-//     3. Financially sensitive field change to an ESTABLISHED asset. Checks 1
-//        and 2 are blind to an upstream registry refresh that rewrites decimals,
-//        coinMinimalDenom, sourceDenom, origin chain, contract, IBC path,
-//        display name, alloy status or coingeckoId on an asset that keeps its
-//        symbol: it fires no lifecycle category and never appears in
-//        new-assets.txt. Those are exactly the money-and-impersonation fields (a
-//        wrong exponent misprices by orders of magnitude; a re-pointed contract
-//        or IBC path changes where funds move), so the gate diffs them against a
-//        pre-generation snapshot. See SENSITIVE_FIELDS in
-//        check_automerge_gate_helpers.mjs.
+//     3. Removal of a verified asset. findIdentityChanges only walks the after
+//        list, so a delisting produces no row there; without a separate pass a
+//        generation failure that dropped assets looked like a quiet day.
+//
+//   NOT gated, by design:
+//     - Lifecycle status changes (unstable flips, halts set/cleared, reason
+//       shifts). The pipeline is responding to real chain conditions and the
+//       daily summary already itemises them. Blocking meant a routine bridge
+//       outage stalled the assetlist. Reported for context only.
+//     - Informational metadata (tooltip text). Note `name` IS gated for
+//       existing verified assets, because a display-name rewrite is the other
+//       half of an impersonation.
+//     - isAlloyed and coingeckoId. Routing/pricing properties the pipeline
+//       manages; a change does not redirect funds.
+//     - Anything scoped to unverified assets, including their removal (the
+//       count is still reported, since a large unverified drop can indicate a
+//       broken generation run).
+//
+//   No network calls. The gate reads the generated assetlist, the pre-generation
+//   snapshot and the lifecycle diff from disk, so there is no market-data outage
+//   that can stall it or silently weaken a threshold.
 //
 //   Report-only with respect to the pipeline: never mutates repo files, and
 //   exits 0 even when it blocks (via process.exitCode, so the report on stdout
@@ -50,23 +61,18 @@
 //   reserved for the gate itself failing (bad input, unreadable list), which
 //   is also treated as blocking by the caller. See "fail closed" below.
 //
-//   Fail closed: the verified flag is read from the generated frontend
-//   assetlist, so an unreadable or empty list means the gate cannot tell a
-//   curated asset from an unlisted one, and it blocks rather than waving the
-//   run through. Numia is a reporting input only now, so a Numia outage
-//   degrades liquidity annotations to "unknown" WITHOUT blocking. If a
-//   liquidity threshold is armed via --liquidity-threshold, Numia becomes
-//   decision-critical again and an outage blocks, since absence of data must
-//   not read as "shallow".
+//   Fail closed: every decision input is read from disk, so a missing or
+//   unusable one means the gate cannot evaluate and it blocks rather than waving
+//   the run through. That covers an unreadable lifecycle diff, a generated
+//   assetlist that is absent or has an EMPTY assets array (an empty array is
+//   truthy, so this needs an explicit length check), a missing pre-generation
+//   snapshot (every asset would read as unchanged), and a missing new-asset list
+//   (the collision check would examine nothing).
 //
 // Usage:
 //   node check_automerge_gate.mjs [<zone_name>] [options]
 //
 //   <zone_name>                  default osmosis-1
-//   --liquidity-threshold <usd>  ALSO block on any mutated asset at or above
-//                                this liquidity, verified or not. Off by
-//                                default (verified status is the trigger).
-//                                Arming this makes Numia decision-critical.
 //   --json <path>                lifecycle diff produced by the workflow's
 //                                "Extract per-mutation symbol lists" step;
 //                                default /tmp/lifecycle-diff.json
@@ -97,12 +103,7 @@ import {
   normaliseSymbol,
 } from './check_automerge_gate_helpers.mjs';
 
-import {
-  fetchAlloyConstituentMap,
-  fetchNumia,
-  loadJSON,
-  resolveMarket,
-} from './lifecycle_helpers.mjs';
+import { loadJSON } from './lifecycle_helpers.mjs';
 
 // ── Args ─────────────────────────────────────────────────────────────────────
 
@@ -138,14 +139,6 @@ const newAssetsPath = flagValue('--new-assets', path.join('..', '..', '..', 'new
 // assets that keep their symbol; the symbol lists only show add/remove.
 const beforePath = flagValue('--before', '/tmp/frontend-before.json');
 
-// Optional secondary trigger. Unset means verified status is the only gate and
-// Numia is reporting-only; set means a deep unverified asset also blocks and
-// Numia becomes decision-critical (so an outage must fail closed).
-const rawLiquidityThreshold = flagValue('--liquidity-threshold', null);
-const LIQUIDITY_THRESHOLD_USD = rawLiquidityThreshold === null
-  ? null
-  : Number(rawLiquidityThreshold);
-
 /**
  * Validated from inside main() rather than at module scope so a bad flag goes
  * through finish(), which writes GATE_BLOCKED and emits a markdown verdict. A
@@ -157,11 +150,16 @@ function validateArgs() {
   if (argErrors.length > 0) {
     throw new Error(`bad arguments: ${argErrors.join('; ')}`);
   }
-  if (LIQUIDITY_THRESHOLD_USD !== null
-      && (!Number.isFinite(LIQUIDITY_THRESHOLD_USD) || LIQUIDITY_THRESHOLD_USD <= 0)) {
+  // --liquidity-threshold used to arm a secondary trigger on deep unverified
+  // assets. It was removed once the gate scoped to verified assets, since no
+  // unverified asset sits above a meaningful threshold anyway. Reject it rather
+  // than ignoring it, so a leftover flag in a workflow or runbook cannot read as
+  // an armed threshold that is silently doing nothing.
+  const removed = argv.filter((a) => a === '--liquidity-threshold');
+  if (removed.length > 0) {
     throw new Error(
-      `Invalid --liquidity-threshold: ${JSON.stringify(rawLiquidityThreshold)} `
-      + '(expected a positive number)'
+      '--liquidity-threshold was removed: the gate is scoped to verified assets '
+      + 'and makes no market-data calls. Drop the flag.'
     );
   }
 }
@@ -210,13 +208,6 @@ const METADATA_FIELDS = [
 ];
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function fmtUsd(n) {
-  if (!Number.isFinite(n)) return 'unknown';
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
-  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
-  return `$${n.toFixed(0)}`;
-}
 
 /**
  * Make a registry-sourced string safe to drop into a markdown table cell.
@@ -349,51 +340,10 @@ async function main() {
     known
   );
 
-  // ── Liquidity lookup (live, alloy-aware) ──────────────────────────────────
-  // Numia is REPORTING-ONLY unless --liquidity-threshold armed it. The gate
-  // decision keys on the verified flag, which comes from the assetlist, so an
-  // outage must not block the daily run: it just degrades the liquidity column
-  // to "unknown". When a threshold IS armed, liquidity becomes decision-critical
-  // and the outage has to fail closed, because "no data" would otherwise read
-  // as "shallow" and silently disarm that trigger.
-  const liquidityIsDecisionCritical = LIQUIDITY_THRESHOLD_USD !== null;
-  let numia = new Map();
-  let numiaError = null;
-  try {
-    numia = await fetchNumia({ hardFail: liquidityIsDecisionCritical });
-  } catch (err) {
-    numiaError = err.message;
-  }
-
-  if (liquidityIsDecisionCritical && (numiaError || numia.size === 0)) {
-    return finish({
-      blocked: true,
-      evaluationFailed: true,
-      reasons: [`Numia unavailable while a liquidity threshold is armed: ${numiaError ?? 'empty token list'}`],
-      report: blockReport([
-        `Liquidity data could not be fetched: ${numiaError ?? 'Numia returned an empty token list'}.`,
-        '',
-        'A liquidity threshold is armed, so the gate cannot tell a deep asset',
-        'from a dust asset without this data. Auto-merge was withheld rather',
-        'than letting that trigger silently disarm.',
-      ]),
-    });
-  }
-  if (numiaError || numia.size === 0) {
-    // Non-fatal: liquidity is annotation only in this configuration.
-    numia = new Map();
-    console.error(`Numia unavailable (${numiaError ?? 'empty token list'}); `
-      + 'liquidity shown as unknown. Verified-status gating is unaffected.');
-  }
-
-  const alloyedDenomSet = new Set(
-    frontendData.assets.filter((a) => a.isAlloyed).map((a) => a.coinMinimalDenom)
-  );
-  // Degrades to an empty map on SQS error; that only removes the
-  // max(self, alloy) uplift, which can lower a constituent's apparent
-  // liquidity. Noted in the report so a missing uplift is visible.
-  const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
-  const alloyUpliftAvailable = constituentToAlloy.size > 0 || alloyedDenomSet.size === 0;
+  // No market-data lookup. The gate keys entirely on the verified flag and the
+  // before/after assetlists, both read from disk, so it makes no network calls:
+  // there is no Numia or SQS outage that can stall or silently weaken it. A
+  // reviewer who wants depth context for a flagged asset can look it up.
 
   // ── Index the frontend list for status and symbol checks ──────────────────
   // Only unsuffixed verified symbols reserve a canonical symbol. Dotted symbols
@@ -418,28 +368,22 @@ async function main() {
     }
   }
 
-  // ── Check 1: status changes to curated assets ────────────────────────────
-  // Trigger is the verified flag. Liquidity is carried alongside purely as
-  // severity context for the reviewer, except when --liquidity-threshold arms
-  // it as a second, independent trigger for deep-but-unverified assets.
-  const verifiedHits = [];
-  const deepUnverifiedHits = [];
-  const unresolvedHits = [];
+  // ── Lifecycle status changes: INFORMATIONAL ONLY ─────────────────────────
+  // Unstable flips, halts set or cleared and reason shifts are the pipeline
+  // doing its job in response to real chain conditions, and they are already
+  // itemised in the daily PR summary. Holding the merge for them meant a routine
+  // bridge outage stalled the assetlist, so they are surfaced here for context
+  // and do not block. The gate exists for identity and impersonation changes
+  // (see the three checks below), not for lifecycle churn.
+  const statusChanges = [];
 
   for (const row of diffRows) {
     const fired = BLOCKING_CATEGORIES.filter((c) => row?.[c] === true);
     if (fired.length === 0) continue;
 
-    // Re-derive the diff row's key. The diff carries chain+symbol but not
-    // coinMinimalDenom, so resolve through the frontend list by symbol.
-    //
-    // The upstream jq falls back to `_comment` then `base_denom` when a zone
-    // asset has no frontend row, and `_comment` is shaped "Label $SYMBOL"
-    // (e.g. "Evmos $EVMOS"). 252 of 884 zone assets have no frontend row today,
-    // almost all source_chain_killed, and they are exactly the set the lifecycle
-    // scripts churn. Matching only the raw string meant every such row landed in
-    // unresolvedHits and blocked the run for a deliberately-pruned dead chain,
-    // so extract the trailing $SYMBOL and retry before giving up.
+    // The upstream jq falls back to `_comment` ("Evmos $EVMOS") then base_denom
+    // for zone assets with no frontend row, so extract a trailing $SYMBOL before
+    // giving up on resolution.
     const dollarSymbol = typeof row.symbol === 'string'
       ? row.symbol.match(/\$([^\s$]+)\s*$/)?.[1]
       : undefined;
@@ -447,76 +391,20 @@ async function main() {
       ?? (dollarSymbol ? feBySymbol.get(dollarSymbol) : undefined)
       ?? frontendData.assets.find((a) => a.chainName === row.chain && a.symbol === row.symbol);
 
-    if (!fe) {
-      // Not in the generated list at all. For a zone asset that was pruned (its
-      // source chain is dead) this is expected, not a disagreement: it cannot be
-      // user-visible on the frontend precisely because it is not listed. Such a
-      // row carries the "Label $SYMBOL" comment form rather than a bare symbol,
-      // which is the signal that the upstream lookup already missed. Record it
-      // for the report but do not block on it.
-      unresolvedHits.push({
-        ...row,
-        categories: fired,
-        why: dollarSymbol
-          ? 'not listed on the frontend (pruned or unlisted zone asset)'
-          : 'not found in generated assetlist',
-        blocking: !dollarSymbol,
-      });
-      continue;
-    }
-
-    const market = fe.coinMinimalDenom
-      ? resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom)
-      : undefined;
-
-    const hit = {
+    statusChanges.push({
       chain: row.chain,
-      symbol: row.symbol,
-      denom: fe.coinMinimalDenom ?? '?',
-      liquidity: market?.liquidity,
-      volume24h: market?.volume24h,
-      verified: fe.verified === true,
+      symbol: dollarSymbol ?? row.symbol,
+      verified: fe?.verified === true,
+      listed: Boolean(fe),
       categories: fired,
       reason: row.reason ?? '',
-    };
-
-    if (hit.verified) {
-      verifiedHits.push(hit);
-    } else if (LIQUIDITY_THRESHOLD_USD !== null) {
-      // A threshold is armed, so liquidity is decision-critical for unverified
-      // assets. If it is unusable (no market row, or a non-finite value), we
-      // cannot rule the asset below the threshold, and silently dropping it
-      // would let "no data" read as "shallow". Route it to unresolvedHits so it
-      // blocks, matching the fail-closed rule stated in the header.
-      if (Number.isFinite(market?.liquidity)) {
-        if (market.liquidity >= LIQUIDITY_THRESHOLD_USD) deepUnverifiedHits.push(hit);
-      } else {
-        unresolvedHits.push({
-          ...hit,
-          why: 'unverified, and liquidity unavailable while a threshold is armed',
-          blocking: true,
-        });
-      }
-    }
+    });
   }
 
-  // Sort by liquidity where known, unpriced last, so the reviewer sees the
-  // most consequential rows first.
-  const byLiquidityDesc = (a, b) => (b.liquidity ?? -1) - (a.liquidity ?? -1);
-  verifiedHits.sort(byLiquidityDesc);
-  deepUnverifiedHits.sort(byLiquidityDesc);
+  // Verified first so the most user-visible rows read at the top.
+  statusChanges.sort((x, y) => (y.verified ? 1 : 0) - (x.verified ? 1 : 0));
 
-  if (verifiedHits.length > 0) {
-    reasons.push(`${verifiedHits.length} verified asset(s) had a status change`);
-  }
-  if (deepUnverifiedHits.length > 0) {
-    reasons.push(
-      `${deepUnverifiedHits.length} unverified asset(s) above `
-      + `${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity had a status change`
-    );
-  }
-
-  // ── Check 2: new-asset symbol squats ─────────────────────────────────────
+  // ── Check 1: new-asset symbol squats ─────────────────────────────────────
   const squatHits = [];
   let newSymbols = [];
   // Absent file is NOT the same as "no new assets". The workflow always writes
@@ -552,10 +440,6 @@ async function main() {
     const collidesWith = findVerifiedSymbolCollision(sym, verifiedSymbolIndexes, fe);
     if (!collidesWith) continue;
 
-    const market = fe?.coinMinimalDenom
-      ? resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom)
-      : undefined;
-
     squatHits.push({
       symbol: sym,
       normalised: norm,
@@ -570,7 +454,6 @@ async function main() {
       chain: fe?.chainName ?? '?',
       denom: fe?.coinMinimalDenom ?? '?',
       verified: fe?.verified === true,
-      liquidity: market?.liquidity,
     });
   }
 
@@ -612,29 +495,23 @@ async function main() {
       + 'changes to existing assets could not be checked'
     );
   }
+  // findIdentityChanges is already verified-scoped, so every row here is curated.
   if (identityChanges.length > 0) {
-    const v = identityChanges.filter((c) => c.verified).length;
     reasons.push(
-      `${identityChanges.length} existing asset(s) had a financially sensitive `
-      + `field change (${v} verified)`
-    );
-  }
-  if (removedAssets.length > 0) {
-    const v = removedAssets.filter((r) => r.verified).length;
-    reasons.push(
-      `${removedAssets.length} asset(s) were removed from the generated list `
-      + `(${v} verified)`
+      `${identityChanges.length} verified asset(s) had a financially sensitive `
+      + 'field change'
     );
   }
 
-  // Only genuinely unexplained rows gate. A pruned zone asset that is simply not
-  // listed on the frontend is reported but does not block, otherwise routine
-  // dead-chain lifecycle churn would withhold the merge every run and reviewers
-  // would learn to ignore the verdict.
-  const blockingUnresolved = unresolvedHits.filter((h) => h.blocking !== false);
-  if (blockingUnresolved.length > 0) {
+  // Removals split by verified status. Only a verified delisting blocks: it is
+  // the user-visible half. An unverified drop is reported but does not hold the
+  // run, which does mean a generation failure confined to unverified assets
+  // passes, so the count is surfaced prominently in the report instead.
+  const removedVerified = removedAssets.filter((r) => r.verified);
+  const removedUnverified = removedAssets.filter((r) => !r.verified);
+  if (removedVerified.length > 0) {
     reasons.push(
-      `${blockingUnresolved.length} mutated asset(s) could not be resolved in the generated assetlist`
+      `${removedVerified.length} verified asset(s) were removed from the generated list`
     );
   }
 
@@ -662,50 +539,17 @@ async function main() {
     report += '\n';
   } else {
     report += '## ✅ Auto-merge gate passed\n\n';
-    report += 'No removals or sensitive-field changes to existing assets, no status '
-      + 'changes to verified assets';
-    if (LIQUIDITY_THRESHOLD_USD !== null) {
-      report += ` (or to unverified assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity)`;
-    }
-    // newAssetsMissing always pushes a reason, so this branch only runs when the
-    // collision check actually examined the list.
-    report += ', and no new-asset symbol collisions with verified assets.\n\n';
-  }
-
-  /** Shared table renderer for the two hit tables. */
-  const renderHitTable = (hits) => {
-    let out = '| Symbol | Chain | Liquidity | 24h vol | Change | Reason |\n';
-    out += '|--------|-------|-----------|---------|--------|--------|\n';
-    for (const h of hits) {
-      const liq = h.liquidity === undefined ? 'unknown' : fmtUsd(h.liquidity);
-      const vol = h.volume24h === undefined ? 'unknown' : fmtUsd(h.volume24h);
-      out += `| \`${esc(h.symbol)}\` | ${esc(h.chain)} | ${liq} | ${vol} `
-        + `| ${esc(h.categories.join(', '))} | ${esc(h.reason) || '-'} |\n`;
-    }
-    return out + '\n';
-  };
-
-  if (verifiedHits.length > 0) {
-    report += '### Verified assets with a status change\n\n';
-    report += 'These are in the curated, default-visible set, so the change is '
-      + 'user-facing regardless of liquidity.\n\n';
-    report += renderHitTable(verifiedHits);
-  }
-
-  if (deepUnverifiedHits.length > 0) {
-    report += '### Unverified assets above the liquidity threshold '
-      + `(${fmtUsd(LIQUIDITY_THRESHOLD_USD)})\n\n`;
-    report += renderHitTable(deepUnverifiedHits);
+    report += 'No identity changes or removals affecting verified assets, and no '
+      + 'new-asset symbol collisions with verified assets.\n\n';
   }
 
   if (squatHits.length > 0) {
     report += '### New assets colliding with a verified symbol\n\n';
-    report += '| New symbol | Collides with | Match | Chain | Liquidity | Denom |\n';
-    report += '|------------|---------------|-------|-------|-----------|-------|\n';
+    report += '| New symbol | Collides with | Match | Chain | Denom |\n';
+    report += '|------------|---------------|-------|-------|-------|\n';
     for (const s of squatHits) {
       report += `| \`${esc(s.symbol)}\` | \`${esc(s.collidesWith)}\` | ${esc(s.matchKind)} `
-        + `| ${esc(s.chain)} | ${s.liquidity === undefined ? 'unknown' : fmtUsd(s.liquidity)} `
-        + `| \`${esc(s.denom)}\` |\n`;
+        + `| ${esc(s.chain)} | \`${esc(s.denom)}\` |\n`;
     }
     report += '\n';
     report += '_Normalised matches ignore case, separators, and homoglyphs, so a '
@@ -714,38 +558,56 @@ async function main() {
   }
 
   if (identityChanges.length > 0) {
-    report += '### Existing assets with financially sensitive field changes\n\n';
-    report += 'These assets already existed and kept their identity, but a field '
-      + 'that affects pricing, routing, or impersonation changed. Confirm each '
+    report += '### Verified assets with financially sensitive field changes\n\n';
+    report += 'These verified assets kept their symbol, but a field that determines '
+      + 'where funds move or what the asset claims to be changed. Confirm each '
       + 'against the upstream chain-registry commit before merging.\n\n';
-    report += '| Symbol | Chain | Verified | Field | Before | After |\n';
-    report += '|--------|-------|----------|-------|--------|-------|\n';
+    report += '| Symbol | Chain | Field | Before | After |\n';
+    report += '|--------|-------|-------|--------|-------|\n';
     for (const c of identityChanges) {
       for (const ch of c.changed) {
         const fmt = (x) => (x === null ? '_(none)_' : `\`${esc(x)}\``);
-        report += `| \`${esc(c.symbol)}\` | ${esc(c.chain)} | ${c.verified ? 'yes' : 'no'} `
+        report += `| \`${esc(c.symbol)}\` | ${esc(c.chain)} `
           + `| ${esc(ch.field)} | ${fmt(ch.from)} | ${fmt(ch.to)} |\n`;
       }
     }
     report += '\n';
   }
 
-  if (removedAssets.length > 0) {
-    report += '### Assets removed from the generated list\n\n';
-    report += 'These were in the pre-generation snapshot and are absent afterwards. '
-      + 'A deliberate delisting belongs here, but so does a generation failure or a '
-      + 'chain-registry fetch problem that silently dropped assets, so confirm the '
-      + 'removals were intended.\n\n';
-    report += '| Symbol | Chain | Verified | Denom |\n';
-    report += '|--------|-------|----------|-------|\n';
-    for (const r of removedAssets.slice(0, 50)) {
-      report += `| \`${esc(r.symbol)}\` | ${esc(r.chain)} | ${r.verified ? 'yes' : 'no'} `
-        + `| \`${esc(r.denom)}\` |\n`;
+  if (removedVerified.length > 0) {
+    report += '### Verified assets removed from the generated list\n\n';
+    report += 'These verified assets were in the pre-generation snapshot and are '
+      + 'absent afterwards. A deliberate delisting belongs here, but so does a '
+      + 'generation failure or a chain-registry fetch problem that silently dropped '
+      + 'assets, so confirm the removals were intended.\n\n';
+    report += '| Symbol | Chain | Denom |\n';
+    report += '|--------|-------|-------|\n';
+    for (const r of removedVerified.slice(0, 50)) {
+      report += `| \`${esc(r.symbol)}\` | ${esc(r.chain)} | \`${esc(r.denom)}\` |\n`;
     }
-    if (removedAssets.length > 50) {
-      report += `\n_and ${removedAssets.length - 50} more removals not shown._\n`;
+    if (removedVerified.length > 50) {
+      report += `\n_and ${removedVerified.length - 50} more removals not shown._\n`;
     }
     report += '\n';
+  }
+
+  if (removedUnverified.length > 0) {
+    // Reported, not blocking. A large number here still points at a broken
+    // generation run even though no curated asset was touched, so it is stated
+    // plainly rather than buried.
+    report += '### Unverified assets removed from the generated list '
+      + `(${removedUnverified.length}, not blocking)\n\n`;
+    report += 'Unverified removals do not withhold the merge. A large count here is '
+      + 'still worth a look: it can indicate a generation or chain-registry problem '
+      + 'that happened to spare the verified set.\n\n';
+    report += '<details><summary>Show removed unverified assets</summary>\n\n';
+    for (const r of removedUnverified.slice(0, 100)) {
+      report += `- \`${esc(r.symbol)}\` (${esc(r.chain)})\n`;
+    }
+    if (removedUnverified.length > 100) {
+      report += `\n_and ${removedUnverified.length - 100} more._\n`;
+    }
+    report += '\n</details>\n\n';
   }
 
   if (beforeMissing) {
@@ -756,40 +618,24 @@ async function main() {
       + 'withheld rather than passing that silently.\n\n';
   }
 
-  if (blockingUnresolved.length > 0) {
-    report += '### Mutated assets not found in the generated assetlist\n\n';
-    report += 'Verified status could not be determined for these, so they block by '
-      + 'default. A row here means the lifecycle diff and the generated assetlist '
-      + 'disagree about what exists.\n\n';
-    for (const h of blockingUnresolved) {
-      report += `- \`${esc(h.symbol)}\` (${esc(h.chain)}): ${esc(h.why)} `
-        + `(${esc(h.categories.join(', '))})\n`;
+  if (statusChanges.length > 0) {
+    const v = statusChanges.filter((s) => s.verified).length;
+    report += `<details><summary>Lifecycle status changes (${statusChanges.length}, `
+      + `${v} verified, not blocking)</summary>\n\n`;
+    report += 'Unstable flips, halts set or cleared, and reason shifts. These are the '
+      + 'pipeline responding to real chain conditions and are itemised in the summary '
+      + 'below, so they do not withhold the merge.\n\n';
+    report += '| Symbol | Chain | Verified | Listed | Change | Reason |\n';
+    report += '|--------|-------|----------|--------|--------|--------|\n';
+    for (const s of statusChanges.slice(0, 100)) {
+      report += `| \`${esc(s.symbol)}\` | ${esc(s.chain)} | ${s.verified ? 'yes' : 'no'} `
+        + `| ${s.listed ? 'yes' : 'no'} | ${esc(s.categories.join(', '))} `
+        + `| ${esc(s.reason) || '-'} |\n`;
     }
-    report += '\n';
-  }
-
-  const unlistedUnresolved = unresolvedHits.filter((h) => h.blocking === false);
-  if (unlistedUnresolved.length > 0) {
-    report += '<details><summary>Lifecycle changes on assets not listed on the '
-      + `frontend (${unlistedUnresolved.length}, informational)</summary>\n\n`;
-    report += 'These zone assets have no frontend row, usually because their source '
-      + 'chain is dead and they were pruned. They cannot be user-visible, so they do '
-      + 'not withhold the merge.\n\n';
-    for (const h of unlistedUnresolved) {
-      report += `- \`${esc(h.symbol)}\` (${esc(h.chain)}): ${esc(h.categories.join(', '))}\n`;
+    if (statusChanges.length > 100) {
+      report += `\n_and ${statusChanges.length - 100} more._\n`;
     }
     report += '\n</details>\n\n';
-  }
-
-  if (numiaError || numia.size === 0) {
-    report += '> ℹ️ Liquidity data was unavailable this run, so the Liquidity and 24h '
-      + 'vol columns read "unknown". The gate decision keys on verified status, '
-      + 'which is unaffected.\n\n';
-  } else if (!alloyUpliftAvailable) {
-    report += '> ℹ️ SQS alloy composition was unavailable, so alloy constituents were '
-      + 'priced on their own liquidity only. A constituent of a deep alloy may read '
-      + 'lower than its effective depth. Shown for context only unless a liquidity '
-      + 'threshold is armed.\n\n';
   }
 
   if (newAssetsMissing) {

--- a/.github/workflows/utility/check_automerge_gate.mjs
+++ b/.github/workflows/utility/check_automerge_gate.mjs
@@ -1,0 +1,532 @@
+// Purpose:
+//   Auto-merge safety gate for the daily "Generate All Files" pipeline.
+//
+//   The daily run opens a PR and immediately auto-merges it. Two classes of
+//   change are too consequential to land unreviewed:
+//
+//     1. High-liquidity modification. A lifecycle script flagging a deep asset
+//        (OSMO, ATOM, USDC, wBTC, ...) unstable or halting a transfer direction
+//        is user-visible and money-adjacent. Liquidity is read live from Numia
+//        (alloy-aware, via resolveMarket) rather than from a hardcoded asset
+//        list, so the gate tracks the market instead of drifting against it.
+//
+//     2. Symbol squat by a newly listed asset. A new asset whose symbol
+//        collides with an existing *verified* asset's symbol is a listing that
+//        wants a human to look at it. deduplicate_symbols.mjs already suffixes
+//        the non-preferred variant, so this is defence in depth: it also
+//        catches case-only and separator-only near-matches that dedupe treats
+//        as distinct strings (exact-equality grouping), plus the reverse case
+//        where a squat lands on a symbol whose canonical owner is unverified.
+//
+//   Report-only with respect to the pipeline: never mutates repo files, and
+//   exits 0 even when it blocks. The decision is communicated via the
+//   GATE_BLOCKED / GATE_REASON_COUNT variables written to $GITHUB_ENV (when
+//   set) and a markdown block on stdout for the PR body. Exit code 1 is
+//   reserved for the gate itself failing (bad input, Numia unreachable), which
+//   is also treated as blocking by the caller. See "fail closed" below.
+//
+//   Fail closed: if Numia can't be reached, liquidity is unknown for every
+//   asset, so a mutation to the deepest asset on the chain would look
+//   identical to one on a dust asset. The gate blocks in that case rather than
+//   waving the run through. This is the reason a liquidity threshold is safe
+//   to use without an allowlist backstop: absence of data blocks, it does not
+//   permit.
+//
+// Usage:
+//   node check_automerge_gate.mjs [<zone_name>] [--threshold <usd>] [--json <path>]
+//
+//   <zone_name>        default osmosis-1
+//   --threshold <usd>  liquidity above which a mutation blocks; default 250000
+//   --json <path>      lifecycle diff produced by the workflow's
+//                      "Extract per-mutation symbol lists" step;
+//                      default /tmp/lifecycle-diff.json
+//   --new-assets <path>  newline-delimited new symbols; default ./new-assets.txt
+//
+// Exit codes:
+//   0  ran to completion (check GATE_BLOCKED for the verdict)
+//   1  the gate could not evaluate (missing inputs, Numia down) -> caller blocks
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  fetchAlloyConstituentMap,
+  fetchNumia,
+  loadJSON,
+  resolveMarket,
+} from './lifecycle_helpers.mjs';
+
+// ── Args ─────────────────────────────────────────────────────────────────────
+
+const argv = process.argv.slice(2);
+
+function flagValue(name, fallback) {
+  const i = argv.indexOf(name);
+  if (i === -1) return fallback;
+  const v = argv[i + 1];
+  if (v === undefined || v.startsWith('--')) {
+    throw new Error(`${name} requires a value`);
+  }
+  return v;
+}
+
+const positional = argv.filter((a, i) => {
+  if (a.startsWith('--')) return false;
+  // Drop values consumed by a preceding flag.
+  return !(i > 0 && argv[i - 1].startsWith('--'));
+});
+
+const zoneBasePath = positional[0] || 'osmosis-1';
+const LIQUIDITY_THRESHOLD_USD = Number(flagValue('--threshold', '250000'));
+const diffPath = flagValue('--json', '/tmp/lifecycle-diff.json');
+const newAssetsPath = flagValue('--new-assets', path.join('..', '..', '..', 'new-assets.txt'));
+
+if (!Number.isFinite(LIQUIDITY_THRESHOLD_USD) || LIQUIDITY_THRESHOLD_USD <= 0) {
+  console.error(`Invalid --threshold: ${flagValue('--threshold', '')}`);
+  process.exit(1);
+}
+
+const zonePath = path.join('..', '..', '..', zoneBasePath);
+const frontendPath = path.join(zonePath, 'generated', 'frontend', 'assetlist.json');
+
+// ── Mutation categories that count as "modification" ─────────────────────────
+
+// Every boolean in the lifecycle diff that represents the pipeline changing an
+// asset's trading or transfer status. Deliberately excludes the purely
+// cosmetic/no-consequence rows (nameChanged, tooltip*): a tooltip decay on
+// OSMO should not hold up the daily run, and those are already surfaced in the
+// PR summary. Ordered roughly most- to least-severe for report readability.
+//
+// Keep in sync with the field list in generate_all_files.yml's
+// "Extract per-mutation symbol lists" step. A category present in the diff but
+// missing here is reported via UNKNOWN_CATEGORIES below rather than silently
+// ignored, so schema drift in the workflow surfaces instead of quietly
+// widening what can auto-merge.
+const BLOCKING_CATEGORIES = [
+  'bridgeOrKillWithdrawalSet',   // funds-out closed: highest consequence
+  'bridgeOrKillDepositSet',
+  'ibcFlagged',
+  'extendedHaltSet',
+  'plannedShutdownSet',
+  'unstableReasonChanged',
+  'bridgeOrKillWithdrawalCleared',
+  'bridgeOrKillDepositCleared',
+  'ibcCleared',
+  'extendedHaltCleared',
+];
+
+// Categories known to exist in the diff that intentionally do not gate.
+const NON_BLOCKING_CATEGORIES = [
+  'nameChanged',
+  'tooltipAdded',
+  'tooltipRemoved',
+  'tooltipChanged',
+];
+
+// Non-boolean payload fields on each diff row.
+const METADATA_FIELDS = [
+  'chain', 'symbol', 'reason', 'unstableReasonOld', 'nameOld', 'nameNew',
+  'depositHaltReason', 'withdrawalHaltReason',
+];
+
+// ── Symbol normalisation for squat detection ─────────────────────────────────
+
+/**
+ * Collapse a symbol to a comparison key that survives the tricks a squatter
+ * would use: case, separators, and the handful of Latin/Cyrillic/Greek
+ * homoglyphs that render identically in the frontend's font.
+ *
+ * The chain suffix that deduplicate_symbols.mjs appends (USDC.axl) is stripped
+ * so a new "USDC" from a junk chain still compares against verified "USDC".
+ */
+const HOMOGLYPHS = new Map(Object.entries({
+  // Cyrillic -> Latin
+  'а': 'a', 'в': 'b', 'е': 'e', 'к': 'k', 'м': 'm', 'н': 'h', 'о': 'o',
+  'р': 'p', 'с': 'c', 'т': 't', 'у': 'y', 'х': 'x', 'і': 'i', 'ѕ': 's',
+  'ј': 'j', 'ԁ': 'd', 'ɡ': 'g',
+  // Greek -> Latin
+  'α': 'a', 'β': 'b', 'ε': 'e', 'ι': 'i', 'κ': 'k', 'ν': 'v', 'ο': 'o',
+  'ρ': 'p', 'τ': 't', 'υ': 'u', 'χ': 'x', 'ζ': 'z', 'η': 'n',
+  // Fullwidth / lookalike digits and letters
+  'ｏ': 'o', '０': '0', 'ⅰ': 'i', 'l': 'l',
+}));
+
+function normaliseSymbol(symbol) {
+  if (typeof symbol !== 'string') return '';
+  // Strip a trailing .chain suffix (one or more), e.g. USDC.eth.axl -> USDC.
+  const base = symbol.split('.')[0];
+  let out = '';
+  for (const ch of base.toLowerCase().normalize('NFKC')) {
+    out += HOMOGLYPHS.get(ch) ?? ch;
+  }
+  // Drop separators and anything non-alphanumeric so USD-C / USD_C / USDC tie.
+  return out.replace(/[^a-z0-9]/g, '');
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Mirror of the workflow's feKey: first IBC transferMethod path, else chain|sourceDenom. */
+function feKey(asset) {
+  const ibcPath = (asset.transferMethods ?? [])
+    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path;
+  return ibcPath ?? `${asset.chainName}|${asset.sourceDenom}`;
+}
+
+function fmtUsd(n) {
+  if (!Number.isFinite(n)) return 'unknown';
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
+  return `$${n.toFixed(0)}`;
+}
+
+function appendGithubEnv(lines) {
+  const envFile = process.env.GITHUB_ENV;
+  if (!envFile) return;
+  fs.appendFileSync(envFile, lines.map((l) => `${l}\n`).join(''));
+}
+
+/**
+ * Emit the verdict and exit. Centralised so every exit path (including the
+ * fail-closed ones) writes GATE_BLOCKED exactly once and in the same shape.
+ */
+function finish({ blocked, reasons, report, evaluationFailed = false }) {
+  appendGithubEnv([
+    `GATE_BLOCKED=${blocked ? 'true' : 'false'}`,
+    `GATE_REASON_COUNT=${reasons.length}`,
+    `GATE_EVALUATION_FAILED=${evaluationFailed ? 'true' : 'false'}`,
+  ]);
+
+  // stdout is captured into the PR body by the workflow.
+  process.stdout.write(report);
+
+  // Human-readable trailer on stderr so it lands in the step log, not the PR.
+  console.error('');
+  console.error('=== AUTO-MERGE GATE SUMMARY ===');
+  console.error(`blocked            : ${blocked}`);
+  console.error(`reasons            : ${reasons.length}`);
+  console.error(`evaluation_failed  : ${evaluationFailed}`);
+  for (const r of reasons) console.error(`  - ${r}`);
+
+  process.exit(evaluationFailed ? 1 : 0);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const reasons = [];
+  let report = '';
+
+  // ── Load inputs ───────────────────────────────────────────────────────────
+  let diffRows;
+  try {
+    diffRows = loadJSON(diffPath);
+  } catch (err) {
+    return finish({
+      blocked: true,
+      evaluationFailed: true,
+      reasons: [`cannot read lifecycle diff at ${diffPath}: ${err.message}`],
+      report: blockReport([
+        `The auto-merge gate could not read its input (\`${diffPath}\`): ${err.message}`,
+        '',
+        'Auto-merge was withheld because the gate could not evaluate the diff.',
+      ]),
+    });
+  }
+
+  if (!Array.isArray(diffRows)) {
+    return finish({
+      blocked: true,
+      evaluationFailed: true,
+      reasons: [`lifecycle diff at ${diffPath} is not an array`],
+      report: blockReport([`The lifecycle diff at \`${diffPath}\` was not a JSON array.`]),
+    });
+  }
+
+  const frontendData = loadJSON(frontendPath, null);
+  if (!frontendData?.assets) {
+    return finish({
+      blocked: true,
+      evaluationFailed: true,
+      reasons: [`cannot read frontend assetlist at ${frontendPath}`],
+      report: blockReport([`The generated frontend assetlist (\`${frontendPath}\`) was missing or empty.`]),
+    });
+  }
+
+  // ── Detect diff schema drift ──────────────────────────────────────────────
+  // Any boolean key in the diff that this script doesn't classify is treated as
+  // unknown. We report it loudly but do not block on it alone: blocking on an
+  // unclassified cosmetic field would wedge the daily run on a harmless
+  // workflow edit. The report tells the operator to classify it.
+  const known = new Set([...BLOCKING_CATEGORIES, ...NON_BLOCKING_CATEGORIES, ...METADATA_FIELDS]);
+  const unknownCategories = new Set();
+  for (const row of diffRows) {
+    for (const [k, v] of Object.entries(row ?? {})) {
+      if (typeof v === 'boolean' && !known.has(k)) unknownCategories.add(k);
+    }
+  }
+
+  // ── Liquidity lookup (live, alloy-aware) ──────────────────────────────────
+  // hardFail:true, because a Numia outage must not silently downgrade the gate to
+  // "everything looks like dust". The throw is caught here and converted into
+  // a blocking verdict.
+  let numia;
+  try {
+    numia = await fetchNumia({ hardFail: true });
+  } catch (err) {
+    return finish({
+      blocked: true,
+      evaluationFailed: true,
+      reasons: [`Numia unavailable: ${err.message}`],
+      report: blockReport([
+        `Liquidity data could not be fetched: ${err.message}`,
+        '',
+        'The gate cannot tell a deep asset from a dust asset without it, so',
+        'auto-merge was withheld. Re-run the workflow once Numia is reachable,',
+        'or review and merge this PR by hand.',
+      ]),
+    });
+  }
+
+  if (numia.size === 0) {
+    return finish({
+      blocked: true,
+      evaluationFailed: true,
+      reasons: ['Numia returned zero tokens'],
+      report: blockReport([
+        'Numia returned an empty token list, so every asset would evaluate as',
+        'zero liquidity. Auto-merge was withheld rather than trusting that.',
+      ]),
+    });
+  }
+
+  const alloyedDenomSet = new Set(
+    frontendData.assets.filter((a) => a.isAlloyed).map((a) => a.coinMinimalDenom)
+  );
+  // Degrades to an empty map on SQS error; that only removes the
+  // max(self, alloy) uplift, which can lower a constituent's apparent
+  // liquidity. Noted in the report so a missing uplift is visible.
+  const constituentToAlloy = await fetchAlloyConstituentMap(alloyedDenomSet);
+  const alloyUpliftAvailable = constituentToAlloy.size > 0 || alloyedDenomSet.size === 0;
+
+  // ── Index the frontend list by the same key the diff uses ─────────────────
+  const feByKey = new Map();
+  // normalised -> canonical symbol, built ONLY from verified assets whose
+  // symbol carries no chain suffix.
+  //
+  // Why unsuffixed only: normaliseSymbol strips the .chain suffix, so all seven
+  // verified USDC variants (USDC, USDC.eth.axl, USDC.avax.axl, ...) collapse to
+  // the same key. Registering every one of them would make the *legitimate*
+  // bare USDC collide with its own suffixed siblings and block the run on a
+  // false positive. The asset a squatter is impersonating is always the one
+  // holding the bare symbol, so that is the only comparison target that means
+  // anything. Suffixed variants are still protected: a new asset trying to
+  // squat "USDC.eth.axl" would first have to claim bare "USDC", which this
+  // catches.
+  const verifiedNormSymbols = new Map();
+  for (const a of frontendData.assets) {
+    feByKey.set(feKey(a), a);
+    if (a.verified && typeof a.symbol === 'string' && !a.symbol.includes('.')) {
+      const n = normaliseSymbol(a.symbol);
+      if (n && !verifiedNormSymbols.has(n)) verifiedNormSymbols.set(n, a.symbol);
+    }
+  }
+
+  // Symbol -> asset, for resolving new-asset rows (new-assets.txt holds the
+  // post-dedupe frontend symbol, which is unique by construction).
+  const feBySymbol = new Map(frontendData.assets.map((a) => [a.symbol, a]));
+
+  // ── Check 1: high-liquidity modifications ────────────────────────────────
+  const highValueHits = [];
+  const unpricedHits = [];
+
+  for (const row of diffRows) {
+    const fired = BLOCKING_CATEGORIES.filter((c) => row?.[c] === true);
+    if (fired.length === 0) continue;
+
+    // Re-derive the diff row's key. The diff carries chain+symbol but not
+    // coinMinimalDenom, so resolve through the frontend list by symbol first
+    // (unique post-dedupe) and fall back to chain|symbol scanning.
+    const fe = feBySymbol.get(row.symbol)
+      ?? frontendData.assets.find((a) => a.chainName === row.chain && a.symbol === row.symbol);
+
+    if (!fe?.coinMinimalDenom) {
+      // Can't price it. An unresolvable mutated asset is suspicious in its own
+      // right (it means the diff and the generated list disagree), so treat it
+      // as blocking rather than skipping.
+      unpricedHits.push({ ...row, categories: fired, why: 'not found in generated assetlist' });
+      continue;
+    }
+
+    const market = resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom);
+    if (!market) {
+      // Present in the assetlist but absent from Numia: usually a genuinely
+      // unlisted/dust asset. Not blocking on its own, but recorded.
+      unpricedHits.push({
+        ...row,
+        categories: fired,
+        denom: fe.coinMinimalDenom,
+        why: 'no Numia market row',
+      });
+      continue;
+    }
+
+    if (market.liquidity >= LIQUIDITY_THRESHOLD_USD) {
+      highValueHits.push({
+        chain: row.chain,
+        symbol: row.symbol,
+        denom: fe.coinMinimalDenom,
+        liquidity: market.liquidity,
+        volume24h: market.volume24h,
+        verified: fe.verified === true,
+        categories: fired,
+        reason: row.reason ?? '',
+      });
+    }
+  }
+
+  highValueHits.sort((a, b) => b.liquidity - a.liquidity);
+
+  if (highValueHits.length > 0) {
+    reasons.push(
+      `${highValueHits.length} asset(s) above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity were modified`
+    );
+  }
+
+  // ── Check 2: new-asset symbol squats ─────────────────────────────────────
+  const squatHits = [];
+  let newSymbols = [];
+  if (fs.existsSync(newAssetsPath)) {
+    newSymbols = fs.readFileSync(newAssetsPath, 'utf8')
+      .split('\n').map((s) => s.trim()).filter(Boolean);
+  }
+
+  for (const sym of newSymbols) {
+    const norm = normaliseSymbol(sym);
+    if (!norm) continue;
+
+    const collidesWith = verifiedNormSymbols.get(norm);
+    if (!collidesWith) continue;
+
+    const fe = feBySymbol.get(sym);
+
+    // A newly listed asset that is itself verified reached that state only by a
+    // curator hand-editing osmosis_verified (nothing in the daily pipeline
+    // writes it), so it is a deliberate listing, not a squat. This also covers
+    // the asset that legitimately owns the bare symbol appearing as "new" in
+    // its first run.
+    if (fe?.verified) continue;
+
+    // Exact self-match on an unverified asset: the asset holding the bare
+    // symbol is the one being compared against itself. Only reachable if the
+    // canonical owner is unverified, in which case there is no verified victim.
+    if (collidesWith === sym) continue;
+
+    const market = fe?.coinMinimalDenom
+      ? resolveMarket(numia, constituentToAlloy, fe.coinMinimalDenom)
+      : undefined;
+
+    squatHits.push({
+      symbol: sym,
+      normalised: norm,
+      collidesWith,
+      exact: collidesWith === sym,
+      chain: fe?.chainName ?? '?',
+      denom: fe?.coinMinimalDenom ?? '?',
+      verified: fe?.verified === true,
+      liquidity: market?.liquidity,
+    });
+  }
+
+  if (squatHits.length > 0) {
+    reasons.push(
+      `${squatHits.length} newly listed asset(s) collide with a verified asset's symbol`
+    );
+  }
+
+  if (unpricedHits.some((h) => h.why === 'not found in generated assetlist')) {
+    const n = unpricedHits.filter((h) => h.why === 'not found in generated assetlist').length;
+    reasons.push(`${n} mutated asset(s) could not be resolved in the generated assetlist`);
+  }
+
+  // ── Build report ─────────────────────────────────────────────────────────
+  const blocked = reasons.length > 0;
+
+  if (blocked) {
+    report += '## 🛑 Auto-merge withheld\n\n';
+    report += 'This PR was **not** auto-merged. It needs a human review before merging.\n\n';
+    for (const r of reasons) report += `- ${r}\n`;
+    report += '\n';
+  } else {
+    report += '## ✅ Auto-merge gate passed\n\n';
+    report += `No modifications to assets above ${fmtUsd(LIQUIDITY_THRESHOLD_USD)} liquidity, `;
+    report += 'and no new-asset symbol collisions with verified assets.\n\n';
+  }
+
+  if (highValueHits.length > 0) {
+    report += `### High-liquidity assets modified (threshold ${fmtUsd(LIQUIDITY_THRESHOLD_USD)})\n\n`;
+    report += '| Symbol | Chain | Liquidity | 24h vol | Verified | Change | Reason |\n';
+    report += '|--------|-------|-----------|---------|----------|--------|--------|\n';
+    for (const h of highValueHits) {
+      report += `| \`${h.symbol}\` | ${h.chain} | ${fmtUsd(h.liquidity)} | ${fmtUsd(h.volume24h)} `
+        + `| ${h.verified ? 'yes' : 'no'} | ${h.categories.join(', ')} | ${h.reason || '-'} |\n`;
+    }
+    report += '\n';
+  }
+
+  if (squatHits.length > 0) {
+    report += '### New assets colliding with a verified symbol\n\n';
+    report += '| New symbol | Collides with | Match | Chain | Liquidity | Denom |\n';
+    report += '|------------|---------------|-------|-------|-----------|-------|\n';
+    for (const s of squatHits) {
+      report += `| \`${s.symbol}\` | \`${s.collidesWith}\` | ${s.exact ? 'exact' : 'normalised'} `
+        + `| ${s.chain} | ${s.liquidity === undefined ? 'unknown' : fmtUsd(s.liquidity)} `
+        + `| \`${s.denom}\` |\n`;
+    }
+    report += '\n';
+    report += '_Normalised matches ignore case, separators, and homoglyphs, so a '
+      + 'lookalike symbol is caught even though symbol deduplication treats it as '
+      + 'a distinct string._\n\n';
+  }
+
+  if (unpricedHits.length > 0) {
+    report += '<details><summary>Mutated assets without liquidity data '
+      + `(${unpricedHits.length})</summary>\n\n`;
+    for (const h of unpricedHits) {
+      report += `- \`${h.symbol}\` (${h.chain}): ${h.why} (${h.categories.join(', ')}\n`;
+    }
+    report += '\n</details>\n\n';
+  }
+
+  if (!alloyUpliftAvailable) {
+    report += '> ⚠️ SQS alloy composition was unavailable, so alloy constituents were '
+      + 'priced on their own liquidity only. A constituent of a deep alloy may read '
+      + 'lower than its effective depth.\n\n';
+  }
+
+  if (unknownCategories.size > 0) {
+    report += `> ⚠️ Unclassified lifecycle-diff fields: \`${[...unknownCategories].join('`, `')}\`. `
+      + 'These did not participate in the gate decision. Classify them in '
+      + '`check_automerge_gate.mjs` (BLOCKING_CATEGORIES / NON_BLOCKING_CATEGORIES).\n\n';
+  }
+
+  return finish({ blocked, reasons, report });
+}
+
+/** Report shell for the fail-closed paths. */
+function blockReport(lines) {
+  return ['## 🛑 Auto-merge withheld (gate could not evaluate)', '', ...lines, ''].join('\n');
+}
+
+main().catch((err) => {
+  // Any unexpected throw is a gate failure -> fail closed.
+  finish({
+    blocked: true,
+    evaluationFailed: true,
+    reasons: [`unexpected gate error: ${err.message}`],
+    report: blockReport([
+      `The auto-merge gate threw an unexpected error: ${err.message}`,
+      '',
+      'Auto-merge was withheld. Review this PR manually.',
+    ]),
+  });
+});

--- a/.github/workflows/utility/check_automerge_gate.test.mjs
+++ b/.github/workflows/utility/check_automerge_gate.test.mjs
@@ -1,0 +1,90 @@
+// Run with: node --test ".github/workflows/utility/*.test.mjs"
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildVerifiedSymbolIndexes,
+  findActiveUnknownCategories,
+  findIdentityChanges,
+  findVerifiedSymbolCollision,
+  hasUsableAssetlist,
+  symbolKeys,
+} from './check_automerge_gate_helpers.mjs';
+
+function asset(overrides = {}) {
+  return {
+    chainName: 'cosmoshub',
+    sourceDenom: 'uatom',
+    coinMinimalDenom: 'ibc/OLD',
+    symbol: 'ATOM',
+    decimals: 6,
+    name: 'Cosmos Hub Atom',
+    isAlloyed: false,
+    coingeckoId: 'cosmos',
+    verified: true,
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-0/uatom' } }],
+    ...overrides,
+  };
+}
+
+test('requires a non-empty generated asset array', () => {
+  assert.equal(hasUsableAssetlist(null), false);
+  assert.equal(hasUsableAssetlist({}), false);
+  assert.equal(hasUsableAssetlist({ assets: [] }), false);
+  assert.equal(hasUsableAssetlist({ assets: [asset()] }), true);
+});
+
+test('blocks only unclassified categories that fired', () => {
+  const known = new Set(['knownMutation']);
+  const { unknownCategories, activeUnknownCategories } = findActiveUnknownCategories([
+    { knownMutation: true, futureMetadata: false, futureSensitiveMutation: true },
+  ], known);
+
+  assert.deepEqual([...unknownCategories].sort(), [
+    'futureMetadata',
+    'futureSensitiveMutation',
+  ]);
+  assert.deepEqual([...activeUnknownCategories], ['futureSensitiveMutation']);
+});
+
+test('detects sensitive changes even when denom and IBC identity both change', () => {
+  const before = asset({ contract: 'old-contract' });
+  const after = asset({
+    sourceDenom: 'uatom-v2',
+    coinMinimalDenom: 'ibc/NEW',
+    decimals: 18,
+    contract: 'new-contract',
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-9/uatom-v2' } }],
+  });
+
+  const [change] = findIdentityChanges([before], [after]);
+  assert.ok(change);
+  assert.deepEqual(change.changed.map(({ field }) => field).sort(), [
+    'coinMinimalDenom',
+    'contract',
+    'decimals',
+    'ibcPath',
+    'sourceDenom',
+  ]);
+  assert.deepEqual(findIdentityChanges([before], [{ ...before }]), []);
+});
+
+test('treats unknown dot segments as symbol separators but leaves dotted targets unreserved', () => {
+  const indexes = buildVerifiedSymbolIndexes([
+    asset({ symbol: 'USDC' }),
+    asset({ symbol: 'SUI.wh', coinMinimalDenom: 'ibc/SUI' }),
+  ]);
+
+  assert.deepEqual(symbolKeys('USD.C'), { full: 'usdc', stripped: 'usdc' });
+  assert.deepEqual(symbolKeys('USDC.eth.axl'), {
+    full: 'usdcethaxl',
+    stripped: 'usdc',
+  });
+  assert.equal(findVerifiedSymbolCollision('USD-C', indexes), 'USDC');
+  assert.equal(findVerifiedSymbolCollision('USD.C', indexes), 'USDC');
+  assert.equal(findVerifiedSymbolCollision('SUI', indexes), undefined);
+  assert.equal(findVerifiedSymbolCollision('SUI-WH', indexes), undefined);
+  assert.equal(findVerifiedSymbolCollision('SUI.WH', indexes), undefined);
+  assert.equal(findVerifiedSymbolCollision('SUI.other', indexes), undefined);
+});

--- a/.github/workflows/utility/check_automerge_gate.test.mjs
+++ b/.github/workflows/utility/check_automerge_gate.test.mjs
@@ -4,13 +4,10 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
-  buildVerifiedSymbolIndexes,
   findActiveUnknownCategories,
   findIdentityChanges,
   findRemovedAssets,
-  findVerifiedSymbolCollision,
   hasUsableAssetlist,
-  symbolKeys,
 } from './check_automerge_gate_helpers.mjs';
 
 function asset(overrides = {}) {
@@ -69,59 +66,6 @@ test('detects sensitive changes even when denom and IBC identity both change', (
     'sourceDenom',
   ]);
   assert.deepEqual(findIdentityChanges([before], [{ ...before }]), []);
-});
-
-test('treats unknown dot segments as symbol separators but leaves dotted targets unreserved', () => {
-  const indexes = buildVerifiedSymbolIndexes([
-    asset({ symbol: 'USDC', variantGroupKey: 'grp/usdc' }),
-    asset({ symbol: 'SUI.wh', coinMinimalDenom: 'ibc/SUI' }),
-  ]);
-
-  assert.equal(symbolKeys('USD.C').full, 'usdc');
-  assert.equal(symbolKeys('USDC.eth.axl').full, 'usdcethaxl');
-  // Every dot-boundary prefix is offered, longest first, so a squat on an
-  // unmapped suffix cannot hide behind an unrecognised segment.
-  assert.deepEqual(symbolKeys('DOT.glmr.axl').prefixes, ['dotglmraxl', 'dotglmr', 'dot']);
-
-  assert.equal(findVerifiedSymbolCollision('USD-C', indexes), 'USDC');
-  assert.equal(findVerifiedSymbolCollision('USD.C', indexes), 'USDC');
-  // Only unsuffixed verified symbols reserve a name.
-  assert.equal(findVerifiedSymbolCollision('SUI', indexes), undefined);
-  assert.equal(findVerifiedSymbolCollision('SUI-WH', indexes), undefined);
-  assert.equal(findVerifiedSymbolCollision('SUI.other', indexes), undefined);
-});
-
-test('exempts legitimate bridged variants but still catches impostors', () => {
-  const indexes = buildVerifiedSymbolIndexes([
-    asset({ symbol: 'USDC', variantGroupKey: 'grp/usdc' }),
-  ]);
-
-  // Same asset arriving by another route: shares the owner's variantGroupKey.
-  // Previously these were reported as squats, which would have blocked routine
-  // daily runs (29 existing assets flag that way on the live list).
-  const legitimateVariant = asset({
-    symbol: 'USDC.eth.axl',
-    verified: false,
-    variantGroupKey: 'grp/usdc',
-  });
-  assert.equal(
-    findVerifiedSymbolCollision('USDC.eth.axl', indexes, legitimateVariant),
-    undefined,
-  );
-
-  // A different underlying asset claiming the same name is a squat.
-  const impostor = asset({
-    symbol: 'USDC.eth.axl',
-    verified: false,
-    variantGroupKey: 'grp/scam',
-  });
-  assert.equal(
-    findVerifiedSymbolCollision('USDC.eth.axl', indexes, impostor),
-    'USDC',
-  );
-
-  // Unknown provenance (no record in the generated list) still reports.
-  assert.equal(findVerifiedSymbolCollision('USD.C', indexes, undefined), 'USDC');
 });
 
 test('scopes sensitive-field changes to verified assets', () => {

--- a/.github/workflows/utility/check_automerge_gate.test.mjs
+++ b/.github/workflows/utility/check_automerge_gate.test.mjs
@@ -124,6 +124,42 @@ test('exempts legitimate bridged variants but still catches impostors', () => {
   assert.equal(findVerifiedSymbolCollision('USD.C', indexes, undefined), 'USDC');
 });
 
+test('scopes sensitive-field changes to verified assets', () => {
+  const base = {
+    chainName: 'cosmoshub',
+    sourceDenom: 'uatom',
+    coinMinimalDenom: 'ibc/SAME',
+    symbol: 'THING',
+    decimals: 6,
+    name: 'Thing',
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-0/uatom' } }],
+  };
+
+  // Unverified on both sides: not the gate's business.
+  const unvBefore = { ...base, verified: false };
+  const unvAfter = { ...base, verified: false, decimals: 18 };
+  assert.deepEqual(findIdentityChanges([unvBefore], [unvAfter]), []);
+
+  // Verified on either side is reviewed, so a curator verifying an asset in the
+  // same window still gets its change surfaced.
+  const verBefore = { ...base, verified: true };
+  const verAfter = { ...base, verified: true, decimals: 18 };
+  assert.equal(findIdentityChanges([verBefore], [verAfter]).length, 1);
+  assert.equal(findIdentityChanges([unvBefore], [{ ...unvAfter, verified: true }]).length, 1);
+});
+
+test('does not treat isAlloyed or coingeckoId as sensitive', () => {
+  const before = asset({ isAlloyed: false, coingeckoId: 'cosmos' });
+  const after = asset({ isAlloyed: true, coingeckoId: 'something-else' });
+  assert.deepEqual(findIdentityChanges([before], [after]), []);
+
+  // A contract re-point on the same asset still reports.
+  const repointed = asset({ contract: 'osmo1evil' });
+  const [change] = findIdentityChanges([asset({ contract: 'osmo1good' })], [repointed]);
+  assert.ok(change);
+  assert.deepEqual(change.changed.map(({ field }) => field), ['contract']);
+});
+
 test('reports removed assets so a mass delisting cannot pass as a quiet day', () => {
   const kept = asset({ coinMinimalDenom: 'ibc/KEPT' });
   const dropped = asset({
@@ -135,7 +171,13 @@ test('reports removed assets so a mass delisting cannot pass as a quiet day', ()
   const removed = findRemovedAssets([kept, dropped], [kept]);
   assert.equal(removed.length, 1);
   assert.equal(removed[0].symbol, 'GONE');
+  // Tagged so the caller can block on verified removals and merely report the
+  // unverified ones.
   assert.equal(removed[0].verified, true);
+
+  const unverifiedDrop = { ...dropped, verified: false };
+  const [row] = findRemovedAssets([kept, unverifiedDrop], [kept]);
+  assert.equal(row.verified, false);
 
   // Nothing removed when the list is unchanged.
   assert.deepEqual(findRemovedAssets([kept, dropped], [kept, dropped]), []);

--- a/.github/workflows/utility/check_automerge_gate.test.mjs
+++ b/.github/workflows/utility/check_automerge_gate.test.mjs
@@ -7,6 +7,7 @@ import {
   buildVerifiedSymbolIndexes,
   findActiveUnknownCategories,
   findIdentityChanges,
+  findRemovedAssets,
   findVerifiedSymbolCollision,
   hasUsableAssetlist,
   symbolKeys,
@@ -72,19 +73,115 @@ test('detects sensitive changes even when denom and IBC identity both change', (
 
 test('treats unknown dot segments as symbol separators but leaves dotted targets unreserved', () => {
   const indexes = buildVerifiedSymbolIndexes([
-    asset({ symbol: 'USDC' }),
+    asset({ symbol: 'USDC', variantGroupKey: 'grp/usdc' }),
     asset({ symbol: 'SUI.wh', coinMinimalDenom: 'ibc/SUI' }),
   ]);
 
-  assert.deepEqual(symbolKeys('USD.C'), { full: 'usdc', stripped: 'usdc' });
-  assert.deepEqual(symbolKeys('USDC.eth.axl'), {
-    full: 'usdcethaxl',
-    stripped: 'usdc',
-  });
+  assert.equal(symbolKeys('USD.C').full, 'usdc');
+  assert.equal(symbolKeys('USDC.eth.axl').full, 'usdcethaxl');
+  // Every dot-boundary prefix is offered, longest first, so a squat on an
+  // unmapped suffix cannot hide behind an unrecognised segment.
+  assert.deepEqual(symbolKeys('DOT.glmr.axl').prefixes, ['dotglmraxl', 'dotglmr', 'dot']);
+
   assert.equal(findVerifiedSymbolCollision('USD-C', indexes), 'USDC');
   assert.equal(findVerifiedSymbolCollision('USD.C', indexes), 'USDC');
+  // Only unsuffixed verified symbols reserve a name.
   assert.equal(findVerifiedSymbolCollision('SUI', indexes), undefined);
   assert.equal(findVerifiedSymbolCollision('SUI-WH', indexes), undefined);
-  assert.equal(findVerifiedSymbolCollision('SUI.WH', indexes), undefined);
   assert.equal(findVerifiedSymbolCollision('SUI.other', indexes), undefined);
+});
+
+test('exempts legitimate bridged variants but still catches impostors', () => {
+  const indexes = buildVerifiedSymbolIndexes([
+    asset({ symbol: 'USDC', variantGroupKey: 'grp/usdc' }),
+  ]);
+
+  // Same asset arriving by another route: shares the owner's variantGroupKey.
+  // Previously these were reported as squats, which would have blocked routine
+  // daily runs (29 existing assets flag that way on the live list).
+  const legitimateVariant = asset({
+    symbol: 'USDC.eth.axl',
+    verified: false,
+    variantGroupKey: 'grp/usdc',
+  });
+  assert.equal(
+    findVerifiedSymbolCollision('USDC.eth.axl', indexes, legitimateVariant),
+    undefined,
+  );
+
+  // A different underlying asset claiming the same name is a squat.
+  const impostor = asset({
+    symbol: 'USDC.eth.axl',
+    verified: false,
+    variantGroupKey: 'grp/scam',
+  });
+  assert.equal(
+    findVerifiedSymbolCollision('USDC.eth.axl', indexes, impostor),
+    'USDC',
+  );
+
+  // Unknown provenance (no record in the generated list) still reports.
+  assert.equal(findVerifiedSymbolCollision('USD.C', indexes, undefined), 'USDC');
+});
+
+test('reports removed assets so a mass delisting cannot pass as a quiet day', () => {
+  const kept = asset({ coinMinimalDenom: 'ibc/KEPT' });
+  const dropped = asset({
+    symbol: 'GONE',
+    coinMinimalDenom: 'ibc/GONE',
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-7/ugone' } }],
+  });
+
+  const removed = findRemovedAssets([kept, dropped], [kept]);
+  assert.equal(removed.length, 1);
+  assert.equal(removed[0].symbol, 'GONE');
+  assert.equal(removed[0].verified, true);
+
+  // Nothing removed when the list is unchanged.
+  assert.deepEqual(findRemovedAssets([kept, dropped], [kept, dropped]), []);
+
+  // A denom change is a modification, not a removal: the IBC path still matches.
+  const repriced = { ...dropped, coinMinimalDenom: 'ibc/NEWDENOM' };
+  assert.deepEqual(findRemovedAssets([dropped], [repriced]), []);
+});
+
+test('does not pair a relisted symbol with an unrelated prior asset', () => {
+  // Old asset delisted; a different asset is listed under the same symbol on a
+  // different chain. Pairing them fabricated "decimals 6 -> 18" style rows.
+  const before = asset({
+    symbol: 'FOO',
+    chainName: 'terra',
+    coinMinimalDenom: 'ibc/OLDFOO',
+    decimals: 6,
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-1/uoldfoo' } }],
+  });
+  const after = asset({
+    symbol: 'FOO',
+    chainName: 'ethereum',
+    coinMinimalDenom: 'ibc/NEWFOO',
+    decimals: 18,
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-2/unewfoo' } }],
+  });
+
+  assert.deepEqual(findIdentityChanges([before], [after]), []);
+
+  // Same chain with both stable keys changed is still treated as a mutation.
+  const sameChainAfter = { ...after, chainName: 'terra' };
+  const [change] = findIdentityChanges([before], [sameChainAfter]);
+  assert.ok(change);
+  assert.ok(change.changed.some(({ field }) => field === 'decimals'));
+});
+
+test('prefers the first record for duplicate symbols rather than the last', () => {
+  // The live list carries two LINK.eth.terra entries differing only by denom.
+  const first = asset({ symbol: 'DUP', coinMinimalDenom: 'ibc/ONE', decimals: 6 });
+  const second = asset({
+    symbol: 'DUP',
+    coinMinimalDenom: 'ibc/TWO',
+    decimals: 8,
+    transferMethods: [{ type: 'ibc', chain: { path: 'transfer/channel-5/udup' } }],
+  });
+
+  // Each pairs with itself by denom, so neither reports a change.
+  assert.deepEqual(findIdentityChanges([first, second], [first, second]), []);
 });

--- a/.github/workflows/utility/check_automerge_gate_helpers.mjs
+++ b/.github/workflows/utility/check_automerge_gate_helpers.mjs
@@ -50,24 +50,33 @@ export function foldSymbol(symbol) {
   return out.replace(/[^a-z0-9]/g, '');
 }
 
-// Suffixes deduplicate_symbols.mjs can append. A dot only starts a generated
-// variant suffix when every trailing segment is recognised here; otherwise it
-// remains a separator inside the claimed symbol, so USD.C folds to USDC.
-const KNOWN_CHAIN_SUFFIXES = new Set([
-  'atom', 'carbon', 'axl', 'eth', 'matic', 'avax', 'bsc', 'arb', 'op', 'pica',
-  'ntrn', 'strd', 'inj', 'dydx', 'tia', 'wh', 'forex', 'grv', 'kuji', 'nom',
-  'orai', 'planq', 'luna', 'nym', 'src', 'rise', 'juno', 'xprt', 'noble',
-  'sol', 'e', 'int3', 'legacy', 'old',
-]);
-
+/**
+ * Every dot-boundary prefix of a symbol, longest first, folded.
+ *
+ * Replaces a hardcoded chain-suffix vocabulary. That list had two failure
+ * modes: one unmapped segment stopped the right-to-left walk and defeated
+ * stripping for the whole symbol (`DOT.glmr.axl` folded to `dotglmr`, never
+ * reaching `dot`), and it needed hand-editing as chains were added. Emitting
+ * every prefix and letting the caller intersect against symbols that actually
+ * exist needs no vocabulary and cannot drift.
+ *
+ * `full` is the whole symbol folded, so a dot used as a separator inside a
+ * claimed symbol still collides: `USD.C` -> `usdc`.
+ */
 export function symbolKeys(symbol) {
-  if (typeof symbol !== 'string') return { full: '', stripped: '' };
+  if (typeof symbol !== 'string') return { full: '', stripped: '', prefixes: [] };
   const parts = symbol.split('.');
-  let end = parts.length;
-  while (end > 1 && KNOWN_CHAIN_SUFFIXES.has(parts[end - 1].toLowerCase())) end -= 1;
+  const prefixes = [];
+  for (let end = parts.length; end >= 1; end -= 1) {
+    const folded = foldSymbol(parts.slice(0, end).join('.'));
+    if (folded && !prefixes.includes(folded)) prefixes.push(folded);
+  }
   return {
     full: foldSymbol(symbol),
-    stripped: foldSymbol(parts.slice(0, end).join('.')),
+    // Longest proper prefix, i.e. the whole symbol minus its last dot segment.
+    // Retained for callers that want the single most likely bare form.
+    stripped: prefixes[prefixes.length - 1] ?? '',
+    prefixes,
   };
 }
 
@@ -98,41 +107,153 @@ export function findActiveUnknownCategories(diffRows, knownFields) {
   return { unknownCategories, activeUnknownCategories };
 }
 
+/**
+ * Indexes of verified bare symbols (no dot), plus each one's variantGroupKey.
+ *
+ * The variant group is what separates an impostor from an ordinary bridged
+ * listing: every legitimate variant of USDC (USDC.eth.axl, USDC.avax.axl, ...)
+ * carries the SAME variantGroupKey as bare USDC, because they are the same
+ * underlying asset arriving by different routes.
+ */
 export function buildVerifiedSymbolIndexes(assets) {
   const bare = new Map();
+  const groupBySymbol = new Map();
 
   for (const asset of assets) {
     if (asset?.verified !== true
         || typeof asset.symbol !== 'string'
         || asset.symbol.includes('.')) continue;
     const normalized = foldSymbol(asset.symbol);
-    if (normalized && !bare.has(normalized)) bare.set(normalized, asset.symbol);
+    if (normalized && !bare.has(normalized)) {
+      bare.set(normalized, asset.symbol);
+      groupBySymbol.set(asset.symbol, asset.variantGroupKey ?? null);
+    }
   }
 
-  return { bare };
+  return { bare, groupBySymbol };
 }
 
-export function findVerifiedSymbolCollision(symbol, indexes) {
-  const { full, stripped } = symbolKeys(symbol);
-  return indexes.bare.get(stripped) ?? indexes.bare.get(full);
+/**
+ * The verified bare symbol a candidate collides with, or undefined.
+ *
+ * Two behaviours the previous vocabulary-based version got wrong:
+ *
+ *   - It matched only the suffix-stripped form, so every routine bridged
+ *     variant of a verified asset (USDC.eth.axl, ETH.arb.carbon) resolved to
+ *     the bare owner and was reported as a squat. 29 existing unverified assets
+ *     flagged that way, which would have blocked ordinary daily runs. A
+ *     candidate sharing the owner's variantGroupKey is the same asset by another
+ *     route, so it is exempt.
+ *   - It stopped stripping at the first unmapped segment, so a squat on an
+ *     unmapped suffix slipped through. Now every dot-boundary prefix is tried.
+ *
+ * Pass the candidate's own asset record (when it exists) so the variant-group
+ * exemption can be applied; without it, every prefix match is reported.
+ */
+export function findVerifiedSymbolCollision(symbol, indexes, candidateAsset) {
+  const { full, prefixes } = symbolKeys(symbol);
+  const candidateGroup = candidateAsset?.variantGroupKey ?? null;
+
+  // Longest first: prefer the most specific match.
+  for (const key of [full, ...prefixes]) {
+    const owner = indexes.bare.get(key);
+    if (!owner) continue;
+    // Exact same string is not a squat; that is the owner itself.
+    if (owner === symbol) return undefined;
+    const ownerGroup = indexes.groupBySymbol?.get(owner) ?? null;
+    if (candidateGroup !== null && ownerGroup !== null && candidateGroup === ownerGroup) {
+      // Legitimate variant of this asset, not an impersonation of it.
+      return undefined;
+    }
+    return owner;
+  }
+  return undefined;
+}
+
+/**
+ * Assets present in the snapshot but absent from the generated list.
+ *
+ * findIdentityChanges only walks afterAssets, so a removal produces no row
+ * there. That was a fail-open hole: a generation bug or a failed chain-registry
+ * submodule fetch that drops most of the list yields no identity changes, no
+ * lifecycle rows and no new symbols, and hasUsableAssetlist accepts anything
+ * with at least one asset, so the gate reported a clean pass and auto-merged a
+ * mass delisting. Removals are reported separately so they can block.
+ *
+ * Keyed on coinMinimalDenom (unique across the generated list) with the
+ * IBC-path key as a second chance, so an asset whose denom changed counts as
+ * modified (findIdentityChanges' job) rather than removed.
+ */
+export function findRemovedAssets(beforeAssets, afterAssets) {
+  const afterDenoms = new Set();
+  const afterPaths = new Set();
+  for (const asset of afterAssets) {
+    if (asset.coinMinimalDenom) afterDenoms.add(asset.coinMinimalDenom);
+    const key = feKey(asset);
+    if (key) afterPaths.add(key);
+  }
+
+  const removed = [];
+  for (const asset of beforeAssets) {
+    const stillPresent = (asset.coinMinimalDenom && afterDenoms.has(asset.coinMinimalDenom))
+      || afterPaths.has(feKey(asset));
+    if (stillPresent) continue;
+    removed.push({
+      symbol: asset.symbol ?? asset.coinMinimalDenom ?? '?',
+      chain: asset.chainName ?? '?',
+      denom: asset.coinMinimalDenom ?? '?',
+      verified: asset.verified === true,
+    });
+  }
+
+  // Verified removals first: those are the curated, user-visible delistings.
+  removed.sort((x, y) => (y.verified ? 1 : 0) - (x.verified ? 1 : 0));
+  return removed;
 }
 
 export function findIdentityChanges(beforeAssets, afterAssets) {
   const beforeByDenom = new Map();
   const beforeByPath = new Map();
   const beforeBySymbol = new Map();
+  // First-write-wins on every index. The generated list contains duplicate
+  // symbols (two LINK.eth.terra entries differ only by denom), and last-wins
+  // would silently discard the earlier record, comparing a change against the
+  // wrong asset.
   for (const asset of beforeAssets) {
-    if (asset.coinMinimalDenom) beforeByDenom.set(asset.coinMinimalDenom, asset);
+    if (asset.coinMinimalDenom && !beforeByDenom.has(asset.coinMinimalDenom)) {
+      beforeByDenom.set(asset.coinMinimalDenom, asset);
+    }
     const key = feKey(asset);
-    if (key) beforeByPath.set(key, asset);
-    if (asset.symbol) beforeBySymbol.set(asset.symbol, asset);
+    if (key && !beforeByPath.has(key)) beforeByPath.set(key, asset);
+    if (asset.symbol && !beforeBySymbol.has(asset.symbol)) {
+      beforeBySymbol.set(asset.symbol, asset);
+    }
+  }
+
+  // Symbols claimed by more than one before-asset are ambiguous, so the
+  // symbol-only fallback must not fire for them.
+  const ambiguousSymbols = new Set();
+  const seenSymbols = new Set();
+  for (const asset of beforeAssets) {
+    if (!asset.symbol) continue;
+    if (seenSymbols.has(asset.symbol)) ambiguousSymbols.add(asset.symbol);
+    seenSymbols.add(asset.symbol);
   }
 
   const identityChanges = [];
   for (const asset of afterAssets) {
+    // Symbol is the weakest key and is only consulted when both stable keys
+    // miss, i.e. the denom AND the path changed together. Require the origin
+    // chain to agree too: otherwise a relisting that reuses a removed asset's
+    // symbol is paired with that unrelated record and reported as a sensitive
+    // change ("decimals 6 -> 18", "chainName terra -> ethereum") that never
+    // happened to any single asset.
+    const bySymbol = (asset.symbol && !ambiguousSymbols.has(asset.symbol))
+      ? beforeBySymbol.get(asset.symbol)
+      : undefined;
     const prior = beforeByDenom.get(asset.coinMinimalDenom)
       ?? beforeByPath.get(feKey(asset))
-      ?? beforeBySymbol.get(asset.symbol);
+      ?? (bySymbol?.chainName === asset.chainName ? bySymbol : undefined);
     if (!prior) continue;
 
     const now = sensitiveShape(asset);

--- a/.github/workflows/utility/check_automerge_gate_helpers.mjs
+++ b/.github/workflows/utility/check_automerge_gate_helpers.mjs
@@ -1,6 +1,12 @@
 // Pure helpers for check_automerge_gate.mjs. Kept separate so regression tests
 // can import the decision logic without executing the workflow entrypoint.
 
+// Fields where a silent change to a VERIFIED asset is a money bug or an
+// impersonation vector. Deliberately excludes:
+//   isAlloyed    - a routing/pricing property the pipeline manages; a change
+//                  here does not move funds to a different place.
+//   coingeckoId  - price-feed metadata, wrong values misprice the display but
+//                  do not redirect a transfer.
 export const SENSITIVE_FIELDS = [
   'decimals',
   'coinMinimalDenom',
@@ -9,8 +15,6 @@ export const SENSITIVE_FIELDS = [
   'contract',
   'ibcPath',
   'name',
-  'isAlloyed',
-  'coingeckoId',
 ];
 
 export function sensitiveShape(asset) {
@@ -24,8 +28,6 @@ export function sensitiveShape(asset) {
     contract: asset.contract ?? null,
     ibcPath,
     name: asset.name ?? null,
-    isAlloyed: asset.isAlloyed === true,
-    coingeckoId: asset.coingeckoId ?? null,
   };
 }
 
@@ -255,6 +257,13 @@ export function findIdentityChanges(beforeAssets, afterAssets) {
       ?? beforeByPath.get(feKey(asset))
       ?? (bySymbol?.chainName === asset.chainName ? bySymbol : undefined);
     if (!prior) continue;
+
+    // VERIFIED only. Verified is the curated, default-visible set, and it is the
+    // only place an identity rewrite is user-facing; an unverified asset is
+    // hidden by default, so a decimals or path change on it is not worth holding
+    // the daily run for. Either side counts as verified so that a curator
+    // verifying an asset in the same window still gets its change reviewed.
+    if (asset.verified !== true && prior.verified !== true) continue;
 
     const now = sensitiveShape(asset);
     const was = sensitiveShape(prior);

--- a/.github/workflows/utility/check_automerge_gate_helpers.mjs
+++ b/.github/workflows/utility/check_automerge_gate_helpers.mjs
@@ -1,0 +1,156 @@
+// Pure helpers for check_automerge_gate.mjs. Kept separate so regression tests
+// can import the decision logic without executing the workflow entrypoint.
+
+export const SENSITIVE_FIELDS = [
+  'decimals',
+  'coinMinimalDenom',
+  'sourceDenom',
+  'chainName',
+  'contract',
+  'ibcPath',
+  'name',
+  'isAlloyed',
+  'coingeckoId',
+];
+
+export function sensitiveShape(asset) {
+  const ibcPath = (asset.transferMethods ?? [])
+    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path ?? null;
+  return {
+    decimals: asset.decimals ?? null,
+    coinMinimalDenom: asset.coinMinimalDenom ?? null,
+    sourceDenom: asset.sourceDenom ?? null,
+    chainName: asset.chainName ?? null,
+    contract: asset.contract ?? null,
+    ibcPath,
+    name: asset.name ?? null,
+    isAlloyed: asset.isAlloyed === true,
+    coingeckoId: asset.coingeckoId ?? null,
+  };
+}
+
+const HOMOGLYPHS = new Map(Object.entries({
+  // Cyrillic -> Latin
+  'а': 'a', 'в': 'b', 'е': 'e', 'к': 'k', 'м': 'm', 'н': 'h', 'о': 'o',
+  'р': 'p', 'с': 'c', 'т': 't', 'у': 'y', 'х': 'x', 'і': 'i', 'ѕ': 's',
+  'ј': 'j', 'ԁ': 'd', 'ɡ': 'g',
+  // Greek -> Latin
+  'α': 'a', 'β': 'b', 'ε': 'e', 'ι': 'i', 'κ': 'k', 'ν': 'v', 'ο': 'o',
+  'ρ': 'p', 'τ': 't', 'υ': 'u', 'χ': 'x', 'ζ': 'z', 'η': 'n',
+  // U+04CF Cyrillic palochka renders as l/I and survives NFKC.
+  'ӏ': 'l',
+}));
+
+export function foldSymbol(symbol) {
+  if (typeof symbol !== 'string') return '';
+  let out = '';
+  for (const ch of symbol.toLowerCase().normalize('NFKC')) {
+    out += HOMOGLYPHS.get(ch) ?? ch;
+  }
+  return out.replace(/[^a-z0-9]/g, '');
+}
+
+// Suffixes deduplicate_symbols.mjs can append. A dot only starts a generated
+// variant suffix when every trailing segment is recognised here; otherwise it
+// remains a separator inside the claimed symbol, so USD.C folds to USDC.
+const KNOWN_CHAIN_SUFFIXES = new Set([
+  'atom', 'carbon', 'axl', 'eth', 'matic', 'avax', 'bsc', 'arb', 'op', 'pica',
+  'ntrn', 'strd', 'inj', 'dydx', 'tia', 'wh', 'forex', 'grv', 'kuji', 'nom',
+  'orai', 'planq', 'luna', 'nym', 'src', 'rise', 'juno', 'xprt', 'noble',
+  'sol', 'e', 'int3', 'legacy', 'old',
+]);
+
+export function symbolKeys(symbol) {
+  if (typeof symbol !== 'string') return { full: '', stripped: '' };
+  const parts = symbol.split('.');
+  let end = parts.length;
+  while (end > 1 && KNOWN_CHAIN_SUFFIXES.has(parts[end - 1].toLowerCase())) end -= 1;
+  return {
+    full: foldSymbol(symbol),
+    stripped: foldSymbol(parts.slice(0, end).join('.')),
+  };
+}
+
+export function normaliseSymbol(symbol) {
+  return symbolKeys(symbol).stripped;
+}
+
+export function feKey(asset) {
+  const ibcPath = (asset.transferMethods ?? [])
+    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path;
+  return ibcPath ?? `${asset.chainName}|${asset.sourceDenom}`;
+}
+
+export function hasUsableAssetlist(data) {
+  return Array.isArray(data?.assets) && data.assets.length > 0;
+}
+
+export function findActiveUnknownCategories(diffRows, knownFields) {
+  const unknownCategories = new Set();
+  const activeUnknownCategories = new Set();
+  for (const row of diffRows) {
+    for (const [key, value] of Object.entries(row ?? {})) {
+      if (typeof value !== 'boolean' || knownFields.has(key)) continue;
+      unknownCategories.add(key);
+      if (value === true) activeUnknownCategories.add(key);
+    }
+  }
+  return { unknownCategories, activeUnknownCategories };
+}
+
+export function buildVerifiedSymbolIndexes(assets) {
+  const bare = new Map();
+
+  for (const asset of assets) {
+    if (asset?.verified !== true
+        || typeof asset.symbol !== 'string'
+        || asset.symbol.includes('.')) continue;
+    const normalized = foldSymbol(asset.symbol);
+    if (normalized && !bare.has(normalized)) bare.set(normalized, asset.symbol);
+  }
+
+  return { bare };
+}
+
+export function findVerifiedSymbolCollision(symbol, indexes) {
+  const { full, stripped } = symbolKeys(symbol);
+  return indexes.bare.get(stripped) ?? indexes.bare.get(full);
+}
+
+export function findIdentityChanges(beforeAssets, afterAssets) {
+  const beforeByDenom = new Map();
+  const beforeByPath = new Map();
+  const beforeBySymbol = new Map();
+  for (const asset of beforeAssets) {
+    if (asset.coinMinimalDenom) beforeByDenom.set(asset.coinMinimalDenom, asset);
+    const key = feKey(asset);
+    if (key) beforeByPath.set(key, asset);
+    if (asset.symbol) beforeBySymbol.set(asset.symbol, asset);
+  }
+
+  const identityChanges = [];
+  for (const asset of afterAssets) {
+    const prior = beforeByDenom.get(asset.coinMinimalDenom)
+      ?? beforeByPath.get(feKey(asset))
+      ?? beforeBySymbol.get(asset.symbol);
+    if (!prior) continue;
+
+    const now = sensitiveShape(asset);
+    const was = sensitiveShape(prior);
+    const changed = SENSITIVE_FIELDS
+      .filter((field) => JSON.stringify(was[field]) !== JSON.stringify(now[field]))
+      .map((field) => ({ field, from: was[field], to: now[field] }));
+
+    if (changed.length > 0) {
+      identityChanges.push({
+        symbol: asset.symbol ?? prior.symbol ?? '?',
+        chain: asset.chainName ?? '?',
+        verified: asset.verified === true || prior.verified === true,
+        changed,
+      });
+    }
+  }
+
+  identityChanges.sort((x, y) => (y.verified ? 1 : 0) - (x.verified ? 1 : 0));
+  return identityChanges;
+}

--- a/.github/workflows/utility/check_automerge_gate_helpers.mjs
+++ b/.github/workflows/utility/check_automerge_gate_helpers.mjs
@@ -31,71 +31,12 @@ export function sensitiveShape(asset) {
   };
 }
 
-const HOMOGLYPHS = new Map(Object.entries({
-  // Cyrillic -> Latin
-  'а': 'a', 'в': 'b', 'е': 'e', 'к': 'k', 'м': 'm', 'н': 'h', 'о': 'o',
-  'р': 'p', 'с': 'c', 'т': 't', 'у': 'y', 'х': 'x', 'і': 'i', 'ѕ': 's',
-  'ј': 'j', 'ԁ': 'd', 'ɡ': 'g',
-  // Greek -> Latin
-  'α': 'a', 'β': 'b', 'ε': 'e', 'ι': 'i', 'κ': 'k', 'ν': 'v', 'ο': 'o',
-  'ρ': 'p', 'τ': 't', 'υ': 'u', 'χ': 'x', 'ζ': 'z', 'η': 'n',
-  // U+04CF Cyrillic palochka renders as l/I and survives NFKC.
-  'ӏ': 'l',
-}));
-
-export function foldSymbol(symbol) {
-  if (typeof symbol !== 'string') return '';
-  let out = '';
-  for (const ch of symbol.toLowerCase().normalize('NFKC')) {
-    out += HOMOGLYPHS.get(ch) ?? ch;
-  }
-  return out.replace(/[^a-z0-9]/g, '');
-}
-
 /**
- * Every dot-boundary prefix of a symbol, longest first, folded.
- *
- * Replaces a hardcoded chain-suffix vocabulary. That list had two failure
- * modes: one unmapped segment stopped the right-to-left walk and defeated
- * stripping for the whole symbol (`DOT.glmr.axl` folded to `dotglmr`, never
- * reaching `dot`), and it needed hand-editing as chains were added. Emitting
- * every prefix and letting the caller intersect against symbols that actually
- * exist needs no vocabulary and cannot drift.
- *
- * `full` is the whole symbol folded, so a dot used as a separator inside a
- * claimed symbol still collides: `USD.C` -> `usdc`.
+ * Split the diff's boolean fields into "unknown to this gate" and "unknown AND
+ * actually fired". A field merely present but false everywhere is inert, so it
+ * only warns; one that fired means an unclassified mutation happened and the
+ * gate cannot tell whether it is financially sensitive, so it blocks.
  */
-export function symbolKeys(symbol) {
-  if (typeof symbol !== 'string') return { full: '', stripped: '', prefixes: [] };
-  const parts = symbol.split('.');
-  const prefixes = [];
-  for (let end = parts.length; end >= 1; end -= 1) {
-    const folded = foldSymbol(parts.slice(0, end).join('.'));
-    if (folded && !prefixes.includes(folded)) prefixes.push(folded);
-  }
-  return {
-    full: foldSymbol(symbol),
-    // Longest proper prefix, i.e. the whole symbol minus its last dot segment.
-    // Retained for callers that want the single most likely bare form.
-    stripped: prefixes[prefixes.length - 1] ?? '',
-    prefixes,
-  };
-}
-
-export function normaliseSymbol(symbol) {
-  return symbolKeys(symbol).stripped;
-}
-
-export function feKey(asset) {
-  const ibcPath = (asset.transferMethods ?? [])
-    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path;
-  return ibcPath ?? `${asset.chainName}|${asset.sourceDenom}`;
-}
-
-export function hasUsableAssetlist(data) {
-  return Array.isArray(data?.assets) && data.assets.length > 0;
-}
-
 export function findActiveUnknownCategories(diffRows, knownFields) {
   const unknownCategories = new Set();
   const activeUnknownCategories = new Set();
@@ -110,81 +51,32 @@ export function findActiveUnknownCategories(diffRows, knownFields) {
 }
 
 /**
- * Indexes of verified bare symbols (no dot), plus each one's variantGroupKey.
- *
- * The variant group is what separates an impostor from an ordinary bridged
- * listing: every legitimate variant of USDC (USDC.eth.axl, USDC.avax.axl, ...)
- * carries the SAME variantGroupKey as bare USDC, because they are the same
- * underlying asset arriving by different routes.
+ * Stable identity key for an asset: its first IBC transfer path, else
+ * chain|sourceDenom. Mirrors the feKey definition in the workflow's
+ * "Extract per-mutation symbol lists" jq so both sides pair the same rows.
  */
-export function buildVerifiedSymbolIndexes(assets) {
-  const bare = new Map();
-  const groupBySymbol = new Map();
-
-  for (const asset of assets) {
-    if (asset?.verified !== true
-        || typeof asset.symbol !== 'string'
-        || asset.symbol.includes('.')) continue;
-    const normalized = foldSymbol(asset.symbol);
-    if (normalized && !bare.has(normalized)) {
-      bare.set(normalized, asset.symbol);
-      groupBySymbol.set(asset.symbol, asset.variantGroupKey ?? null);
-    }
-  }
-
-  return { bare, groupBySymbol };
+export function feKey(asset) {
+  const ibcPath = (asset.transferMethods ?? [])
+    .find((tm) => tm?.type === 'ibc' && tm?.chain?.path)?.chain?.path;
+  return ibcPath ?? `${asset.chainName}|${asset.sourceDenom}`;
 }
 
 /**
- * The verified bare symbol a candidate collides with, or undefined.
- *
- * Two behaviours the previous vocabulary-based version got wrong:
- *
- *   - It matched only the suffix-stripped form, so every routine bridged
- *     variant of a verified asset (USDC.eth.axl, ETH.arb.carbon) resolved to
- *     the bare owner and was reported as a squat. 29 existing unverified assets
- *     flagged that way, which would have blocked ordinary daily runs. A
- *     candidate sharing the owner's variantGroupKey is the same asset by another
- *     route, so it is exempt.
- *   - It stopped stripping at the first unmapped segment, so a squat on an
- *     unmapped suffix slipped through. Now every dot-boundary prefix is tried.
- *
- * Pass the candidate's own asset record (when it exists) so the variant-group
- * exemption can be applied; without it, every prefix match is reported.
+ * An empty array is truthy, so `!data?.assets` accepted {assets: []} and a
+ * generation run that emitted zero assets read as a quiet day. Require content.
  */
-export function findVerifiedSymbolCollision(symbol, indexes, candidateAsset) {
-  const { full, prefixes } = symbolKeys(symbol);
-  const candidateGroup = candidateAsset?.variantGroupKey ?? null;
-
-  // Longest first: prefer the most specific match.
-  for (const key of [full, ...prefixes]) {
-    const owner = indexes.bare.get(key);
-    if (!owner) continue;
-    // Exact same string is not a squat; that is the owner itself.
-    if (owner === symbol) return undefined;
-    const ownerGroup = indexes.groupBySymbol?.get(owner) ?? null;
-    if (candidateGroup !== null && ownerGroup !== null && candidateGroup === ownerGroup) {
-      // Legitimate variant of this asset, not an impersonation of it.
-      return undefined;
-    }
-    return owner;
-  }
-  return undefined;
+export function hasUsableAssetlist(data) {
+  return Array.isArray(data?.assets) && data.assets.length > 0;
 }
 
 /**
  * Assets present in the snapshot but absent from the generated list.
  *
  * findIdentityChanges only walks afterAssets, so a removal produces no row
- * there. That was a fail-open hole: a generation bug or a failed chain-registry
- * submodule fetch that drops most of the list yields no identity changes, no
- * lifecycle rows and no new symbols, and hasUsableAssetlist accepts anything
- * with at least one asset, so the gate reported a clean pass and auto-merged a
- * mass delisting. Removals are reported separately so they can block.
- *
- * Keyed on coinMinimalDenom (unique across the generated list) with the
+ * there. Keyed on coinMinimalDenom (unique across the generated list) with the
  * IBC-path key as a second chance, so an asset whose denom changed counts as
- * modified (findIdentityChanges' job) rather than removed.
+ * modified rather than removed. `verified` is tagged so the caller can block on
+ * verified removals and merely report the rest.
  */
 export function findRemovedAssets(beforeAssets, afterAssets) {
   const afterDenoms = new Set();

--- a/.github/workflows/validate_zone_data.yml
+++ b/.github/workflows/validate_zone_data.yml
@@ -38,6 +38,17 @@ jobs:
       - name: Install dependencies
         run: npm install
           
+      - name: Run utility unit tests
+        working-directory: ./.github/workflows/utility
+        # Covers check_automerge_gate.test.mjs (the auto-merge gate's decision
+        # logic, which guards decimals / denoms / IBC paths on PRs that merge
+        # themselves) and the pre-existing lifecycle_helpers.test.mjs, neither of
+        # which had a runner. Placed in this workflow because it is the one that
+        # actually triggers on pull_request; full_validation.yml is
+        # workflow_dispatch-only. Runs before the zone-data check so a broken
+        # helper is reported as a test failure rather than as data noise.
+        run: node --test *.test.mjs
+
       - name: Run code to Validate Zone Data
         working-directory: ./.github/workflows/utility
         run: node validate_zone_files.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ removed-chains.txt
 validation-summary.md
 workflow-summary.md
 dead-chains.md
+gate-report.md
+pr-body.md
 
 # Local-only artifacts emitted by lifecycle check scripts in dry-run mode
 # and by manual workflow_dispatch runs of asset_status_report.mjs.


### PR DESCRIPTION
## Why

The daily `Generate All Files` run opens a PR and merges it within seconds, with nothing checking it. `main` has no required status checks, and the PR-side validation workflows never actually run on these PRs (they're created with `GITHUB_TOKEN`, which doesn't trigger workflows, so they sit as `action_required`).

The specific risk: an upstream chain-registry refresh can change an existing token's **decimals, minimal denom, source denom, contract address, or IBC path** while the symbol stays the same. Nothing surfaces that today, and it merges unreviewed. A wrong exponent misprices an asset by orders of magnitude; a re-pointed contract or IBC path sends funds somewhere else.

## What blocks auto-merge

Everything below is scoped to **verified** assets, the curated set the frontend shows by default.

| Blocks when | Why |
|---|---|
| A verified asset's `decimals`, `coinMinimalDenom`, `sourceDenom`, `chainName`, `contract`, `ibcPath` or `name` changed | The whole point. Determines where funds go or what the asset claims to be. |
| A verified asset was removed from the list | Catches a real delisting, but also a generation failure that silently drops assets. |
| An unclassified lifecycle field fired | The gate can't tell if it's dangerous, so it stops rather than guessing. |
| A required input is missing or empty | Can't evaluate → don't merge. Covers an empty `assets: []` list, a missing before-snapshot, an unreadable diff, or bad arguments. |

## What does NOT block

| Doesn't block | Why |
|---|---|
| Lifecycle status changes (unstable flips, halts set/cleared, reason shifts) | The pipeline reacting to real chain conditions. Blocking meant a routine bridge outage stalled the assetlist. Shown in a collapsed table for context. |
| New assets with a similar symbol | Tried this; on live data it flagged 23 assets, 21 of which were ordinary bridge listings (`USDC.eth.carbon`, `WBTC.eth.grv`) and 2 were case-only clashes between real distinct assets. Zero actual impersonations. Symbol dedupe already gives the verified asset the bare symbol, and a new asset can't arrive verified. |
| Anything on an unverified asset | Hidden by default, so not user-facing. |
| `isAlloyed`, `coingeckoId`, tooltip text | Don't redirect funds. Note `name` **does** block on verified assets, since a display-name rewrite is the real impersonation vector. |

**Known gap:** a generation failure that only drops unverified assets will pass. Dropping all 989 merges cleanly. The count is called out in the PR body so it's visible, but nothing stops it. Verified removals do block.

## Behaviour

- The PR is always created and the pipeline stays green. Only the merge is withheld.
- The verdict goes at the top of the PR body; a blocked PR gets a `needs-review` label.
- No network calls: it reads three files from disk and decides (~0.8s).
- Because the daily run reuses the `update/assetlist_all` branch and replaces the body, a PR held open by the gate refreshes in place each day. There's always exactly one PR with the newest data.

## Merge-step fix

`--auto` has never worked on these PRs: with no required checks, a fresh bot PR is instantly mergeable and GitHub rejects auto-merge on an already-clean PR. #3708 and #3710 both merged in 3-5s with `autoMergeRequest: null`. The step only looked successful because `||` swallowed the error.

It now tries `--auto` first (so it starts waiting if required checks are ever added) and falls back to a direct merge **only** when the PR is `CLEAN/MERGEABLE`. A failing check or conflict leaves it open instead of force-merging.

Also: the auto-merge condition now requires `GATE_BLOCKED == 'false'`. It previously used `!= 'true'`, which merged when the variable was unset — so a crashed gate step read as permission to merge.

## Tests

`node --test` now runs on every PR via `validate_zone_data.yml`, covering the new gate and the pre-existing `lifecycle_helpers.test.mjs` that had no runner. 24 tests pass.

Checked against the live 1336-asset list: no changes → passes with zero false positives; ATOM decimals and a USDT contract re-point → block; the same change on an unverified asset → passes; 347 verified removals → block; 989 unverified removals → pass with a reported count; `{assets: []}` → blocks.

## Follow-ups

- Not yet seen a real mutation in CI. Blocking paths were proven against synthetic before/after files in the real shapes plus the live assetlist. Worth watching the first real firing.
- `BLOCKING_CATEGORIES` must stay in sync with the workflow's diff fields; the unclassified-field check is the guard against that drifting.
- Giving `create-pull-request` a PAT or App token would make the existing schema validation actually run on daily PRs. That's the more thorough fix; this gate runs in-job because that isn't true today.
