### PR TITLE
chore(osmosis): drop stale Int3face transfer method from allDOGE

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -27282,15 +27282,7 @@
       "categories": [
         "meme"
       ],
-      "transferMethods": [
-        {
-          "name": "Int3face Bridge",
-          "type": "external_interface",
-          "depositUrl": "https://app.int3face.zone/bridge",
-          "withdrawUrl": "https://app.int3face.zone/bridge",
-          "logoUri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/int3.png"
-        }
-      ],
+      "transferMethods": [],
       "counterparty": [
         {
           "chainName": "dogecoin",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6949,15 +6949,6 @@
       "categories": [
         "meme"
       ],
-      "transfer_methods": [
-        {
-          "name": "Int3face Bridge",
-          "type": "external_interface",
-          "deposit_url": "https://app.int3face.zone/bridge",
-          "withdraw_url": "https://app.int3face.zone/bridge",
-          "logo_uri": "https://raw.githubusercontent.com/cosmos/chain-registry/master/int3face/images/int3.png"
-        }
-      ],
       "_comment": "Dogecoin $DOGE"
     },
     {


### PR DESCRIPTION
## Description

The `allDOGE` alloy is now backed solely by **cbDOGE.axl** (`ibc/D6ED8CCF01DE2F86D0D8A9605A8535A66C930697E986616227506EBDE8B8AC91` = `transfer/channel-208/cbdoge-satoshi`), confirmed onchain via `list_asset_configs` on the transmuter contract. Int3face and Omnity are no longer alloy constituents.

The assetlist had not caught up: `allDOGE` still advertised **Int3face as its only transfer method**, which pinned the frontend deposit/withdraw flow to that route.

This removes the stale `transfer_methods` block from the `allDOGE` entry, and includes the regenerated `osmosis-1/generated/frontend/assetlist.json` (`transferMethods: []`).

### Why remove rather than substitute a Squid URL

- Most alloys (`allBTC`, `allETH`, `allUSDT`, `allSHIB`) carry no `transfer_methods` at all and let the frontend derive routes from constituents. Skip unions the variant family's counterparties for in-app quotes, and the external-URL fallback aggregates constituents' `external_interface` links.
- `cbDOGE.axl` already carries both a Squid `external_interface` and an IBC method, and its `variantGroupKey` is `allDOGE`.
- An alloy-level copy of a provider name wins the dedup against the constituent-derived entry while carrying no halt flags, so hardcoding Squid at the alloy level would shadow the halt-aware path.

`DOGE.int3` and `ckDOGE` entries are unchanged; both still hold supply (~1,240 and ~3,647 DOGE respectively).

### Verification

- `node validate_zone_files.mjs` passes (requires an up-to-date `chain-registry` submodule; the submodule pointer is intentionally not bumped in this PR).
- `node generate_assetlist.mjs` completes; only the mainnet frontend assetlist changed in content.

## Checklist

Not adding an asset or chain, and not upgrading verification status, so the template's sections do not apply.
