### PR TITLE
docs: document Keplr wallet registration as a separate, manual requirement

### DIFF
--- a/LISTING.md
+++ b/LISTING.md
@@ -95,6 +95,9 @@ Integrations with Key Apps:
  - Recognition by key Block Explorers:
    - Mintscan (Assets are added at [Cosmostation's Chainlist](https://github.com/cosmostation/chainlist/blob/main/chain/osmosis/assets_2.json))
    - Celatone (Assets are added at [Celatone's Data Repository](https://github.com/alleslabs/aldus/blob/main/data/assets.json))
+ - Recognition by Keplr Wallet:
+   - Keplr does not read this repository or the Cosmos Chain Registry directly for its asset display list. It maintains its own separate registry at [chainapsis/keplr-chain-registry](https://github.com/chainapsis/keplr-chain-registry), and an asset only gets a name, logo, and CoinGecko ID in Keplr's Osmosis view once someone submits a PR adding it to `cosmos/osmosis.json` there. There is no automated sync from this repo into Keplr's registry; it's a manual, per-asset PR process.
+   - For assets bridged via IBC, visibility also depends on the *origin chain* having its own file in `keplr-chain-registry` (e.g. `cosmos/<chain>.json`). If the origin chain isn't registered with Keplr, the IBC asset can display as an unnamed denom hash on Osmosis even though it is fully registered in the Cosmos Chain Registry and on this repo's own assetlist. Registering the origin chain with Keplr is the correct fix in that case, not hardcoding the asset into `cosmos/osmosis.json` alone.
  - Recognition by key Data Aggregators:
    - CoinGecko (See: [How to list new Cryptocurrencies on CoinGecko](https://support.coingecko.com/hc/en-us/articles/7291312302617-How-to-list-new-cryptocurrencies-on-CoinGecko))
      - Has Price, Supply, and Market Capitalization Data


### PR DESCRIPTION
## Summary
- Keplr wallet does not read this repository or the Cosmos Chain Registry directly for its asset display list. It maintains its own separate registry at chainapsis/keplr-chain-registry, updated only via manual, per-asset PRs.
- For IBC assets, visibility in Keplr also depends on the origin chain having its own file in that registry, not just the asset denom. Otherwise the asset can render as an unnamed denom hash in Keplr on Osmosis, even though it's fully registered here and in the Cosmos Chain Registry.
- This came up investigating why nBTC (Nomic Bitcoin) only recently appeared in Keplr on Osmosis, despite being registered in the Chain Registry since 2023. The asset itself was fine; Nomic was never registered with Keplr, so a community PR patched nBTC directly into Keplr's `cosmos/osmosis.json` as a stopgap (a separate PR to register Nomic properly is still open upstream).

## Test plan
- [x] Docs-only change, no generation/build impact
- [x] Reviewed rendered LISTING.md section for formatting