### PR TITLE
chore(osmosis): halt allDOGE withdrawals as interim cover

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -27303,7 +27303,10 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "manual",
       "preview": false,
+      "tooltipMessage": "DOGE withdrawals are temporarily paused while bridge routing is updated. Trading and existing balances are unaffected. Please check back shortly.",
       "listingDate": "2024-11-19T20:00:00.000Z"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6949,7 +6949,10 @@
       "categories": [
         "meme"
       ],
-      "_comment": "Dogecoin $DOGE"
+      "_comment": "Dogecoin $DOGE",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "DOGE withdrawals are temporarily paused while bridge routing is updated. Trading and existing balances are unaffected. Please check back shortly."
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## Description

Temporary pause on **DOGE withdrawals** while the hardcoded Int3face routing is removed from the frontend. Follows #3705, which dropped the stale Int3face `transfer_methods` entry from the `allDOGE` alloy.

Sets on the `allDOGE` entry:

```json
"osmosis_halt_withdrawals": true,
"osmosis_withdrawal_halt_reason": "manual",
"tooltip_message": "DOGE withdrawals are temporarily paused while bridge routing is updated. Trading and existing balances are unaffected. Please check back shortly."
```

Includes the regenerated `osmosis-1/generated/frontend/assetlist.json`.

### Why the alloy and not a constituent

`haltState` in `amount-screen.tsx:754-789` resolves the halt flag from `selectedDenom`, the denom the user **holds**, not the selected destination variant. A flag on `DOGE.int3` would not fire for a user withdrawing `allDOGE`, which is exactly the case that needs covering. On the alloy, the flag gates the amount screen before the quote UI and also suppresses the external-provider fallback.

### Why `manual`

The withdrawal reason enum is `bridge_down | source_chain_killed | manual`. The first two would misrepresent a routing fix as an outage or a dead chain. `manual` renders as "Withdrawals halted, exercise caution."; the `tooltip_message` overrides that with the generic pause text on the buttons.

### Scope

- **Deposits are left open.** They already avoid Int3face via the deposit-side provider filter in `use-bridges-supported-assets.ts`, so there is nothing to block.
- `DOGE.int3` and `ckDOGE` entries are untouched.

### Caveat: this is cover, not a fix

This gates the UI; it does not tear down routes. Halt flags are not read anywhere in `packages/bridge`, and the hardcoded `chainType === "doge"` sort at `use-bridges-supported-assets.ts:369` is halt-blind, so the dogecoin chain still appears and is still hoisted. The real fix is the pending frontend change. **Revert this once that lands.**

### Verification

- `node validate_zone_files.mjs` passes (needs an up-to-date `chain-registry` submodule; the pointer is intentionally not bumped here).
- `node generate_assetlist.mjs` completes; only the mainnet frontend assetlist changed in content (`haltWithdrawals`, `withdrawalHaltReason`, `tooltipMessage`).

## Checklist

Not adding an asset or chain, and not upgrading verification status, so the template's sections do not apply.
