### PR TITLE
chore(osmosis): mark Nibiru unstable for Osmosis-to-Nibiru IBC timeouts

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4366,7 +4366,10 @@
       "categories": [
         "defi"
       ],
-      "_comment": "Nibiru $NIBI"
+      "_comment": "Nibiru $NIBI",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "tooltip_message": "Transfers from Osmosis to Nibiru are frequently timing out. A timed-out transfer is not refunded automatically and needs manual relayer action to return the funds, which can take days. Deposits from Nibiru to Osmosis are unaffected."
     },
     {
       "chain_name": "injective",


### PR DESCRIPTION
## Summary
- Mark NIBI as manually unstable due to frequent Osmosis-to-Nibiru IBC transfer timeouts
- Add a tooltip explaining timed-out transfers are not auto-refunded and may need manual relayer recovery over several days
- Deposits from Nibiru to Osmosis remain unaffected

## Test plan
- [ ] Verify NIBI shows unstable state in generated assetlist after CI runs
- [ ] Confirm tooltip renders correctly in the frontend
- [ ] Confirm Nibiru-to-Osmosis deposits are not halted