### PR TITLE
fix(osmosis-1): halt XRP.coreum and flag XRP alloy after bridge exploit

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -17709,9 +17709,15 @@
       "name": "Ripple",
       "isAlloyed": false,
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "manual",
       "preview": false,
+      "tooltipMessage": "The XRPL to Coreum bridge was exploited on 9 August 2026 and is halted. XRP.coreum may not be fully backed. Deposits and withdrawals are disabled while the situation is assessed.",
       "listingDate": "2024-03-21T20:09:00.000Z"
     },
     {
@@ -28016,9 +28022,11 @@
       "isAlloyed": true,
       "contract": "osmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0",
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
       "preview": false,
+      "tooltipMessage": "XRP on Osmosis is backed in majority by XRP.coreum, whose bridge was exploited on 9 August 2026 and is halted. Minting and redeeming against the underlying assets is paused, and XRP.coreum cannot be deposited or withdrawn, so XRP may not be fully backed. Take care when trading.",
       "listingDate": "2024-12-05T17:03:58.027Z"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -4338,7 +4338,14 @@
           "logo_uri": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/connectors/images/sologenic.svg"
         }
       ],
-      "_comment": "Ripple $XRP.coreum"
+      "_comment": "Ripple $XRP.coreum",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The XRPL to Coreum bridge was exploited on 9 August 2026 and is halted. XRP.coreum may not be fully backed. Deposits and withdrawals are disabled while the situation is assessed."
     },
     {
       "chain_name": "sei",
@@ -7189,7 +7196,10 @@
           "logo_uri": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/connectors/images/sologenic.svg"
         }
       ],
-      "_comment": "Ripple $XRP"
+      "_comment": "Ripple $XRP",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "tooltip_message": "XRP on Osmosis is backed in majority by XRP.coreum, whose bridge was exploited on 9 August 2026 and is halted. Minting and redeeming against the underlying assets is paused, and XRP.coreum cannot be deposited or withdrawn, so XRP may not be fully backed. Take care when trading."
     },
     {
       "chain_name": "xion",


### PR DESCRIPTION
## What

Marks **XRP.coreum** unstable with deposits and withdrawals halted, and flags the **allXRP alloy** as unstable. Both get a `tooltip_message` explaining the situation to users. All reasons use `manual`.

## Why

The XRPL to Coreum bridge was exploited on **9 August 2026**:

- ~**199,916.3 XRP** drained from the XRPL-side bridge account in 94 signed payments over 97 minutes (19:16 to 20:53 UTC). Bridge balance went from ~200,410 XRP to **493.5 XRP**.
- **Root cause:** relayer logic. The relayer checked that a payment succeeded and parsed the recipient from its memo, but never compared the payment's destination against the bridge address. Attacker-controlled wallet-to-wallet transfers carrying a well-formed bridge memo were therefore credited as real deposits.
- The bridge is halted. Coreum had not published an official incident report as of 11 August.

This is a bridge relayer failure, not a compromise of the Coreum chain or the XRP Ledger. XRP.coreum's problem is **backing**, not chain integrity.

## Why the alloy is flagged too

The allXRP transmuter is not meaningfully diversified away from the exploited leg. Live contract state:

| Denom | In alloy | Share |
| --- | ---: | ---: |
| XRP.coreum `ibc/63A7CA…39F3` | 102,964.45 XRP | **98.15%** |
| XRP.xrplevm `ibc/46EB46…1609` | 1,938.65 XRP | 1.85% |
| **allXRP supply** | **104,903.09** | |

The remaining 1.85% is XRP.xrplevm, which is itself already halted in both directions pending the XRPL EVM mainnet upgrade. There is no healthy leg for holders to exit into, so the alloy is flagged rather than presented as unaffected.

Separately, total XRP.coreum supply on Osmosis is **111,051.06 XRP**, so **8,086.61 XRP.coreum (7.28%) is held outside the alloy**. Those holders carry the same backing risk and are covered by the same halt flags.

## What the onchain pause does and does not do

The transmuter has been **paused onchain** (`is_active: false`). No denoms are marked corrupted (`corrupted_denoms: []`).

Important: the pause stops **minting and redeeming** allXRP against its underlying legs. It does **not** stop allXRP trading. Verified with live SQS quotes: 100 allXRP to OSMO fills via pools 2970/1464 and 3308, and OSMO to allXRP fills via pool 3308. The tooltip is worded accordingly, warning on backing rather than claiming transfers are blocked.

## Automation interaction

Reasons are set to `manual`, which is outside `OWNED_HALT_REASONS` and `OWNED_UNSTABLE_REASONS` in `check_ibc_clients.mjs`, so `canModifyHalt()` and `canModifyUnstable()` return `false`. The `tooltip_message` locks the entries independently. Either alone is sufficient; together they ensure these flags will not be auto-cleared if the IBC client reports Active again. Clearing requires a human.

## Changes

- `osmosis-1/osmosis.zone_assets.json` — source edits to the two entries
- `osmosis-1/generated/frontend/assetlist.json` — regenerated via `node generate_assetlist.mjs`

## Testing

- `node validate_zone_files.mjs` passes
- `node generate_assetlist.mjs` run; generated diff contains only the two XRP entries
- Live SQS router quotes used to confirm the trading behaviour described above
- Unrelated testnet line-ending churn and a `state.json` trailing-newline strip were reverted to keep the diff scoped

## Note

`transfer_methods` on both entries still point at the Sologenic TX Bridge deposit/withdraw URLs, which currently lead to a halted bridge. Left as-is here since the halt flags should suppress those paths in the UI, but worth a follow-up if the bridge stays down.
