### PR TITLE
fix(osmosis-1): halt deposits and withdrawals on the XRP alloy

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -28025,8 +28025,12 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "manual",
       "preview": false,
-      "tooltipMessage": "XRP on Osmosis is backed in majority by XRP.coreum, whose bridge was exploited on 9 August 2026 and is halted. Minting and redeeming against the underlying assets is paused, and XRP.coreum cannot be deposited or withdrawn, so XRP may not be fully backed. Take care when trading.",
+      "tooltipMessage": "XRP on Osmosis is backed in majority by XRP.coreum, whose bridge was exploited on 9 August 2026 and is halted. All of its underlying assets are halted, so deposits and withdrawals of XRP are disabled and minting and redeeming against the underlying assets is paused. XRP may not be fully backed. Take care when trading.",
       "listingDate": "2024-12-05T17:03:58.027Z"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -7199,7 +7199,11 @@
       "_comment": "Ripple $XRP",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "tooltip_message": "XRP on Osmosis is backed in majority by XRP.coreum, whose bridge was exploited on 9 August 2026 and is halted. Minting and redeeming against the underlying assets is paused, and XRP.coreum cannot be deposited or withdrawn, so XRP may not be fully backed. Take care when trading."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "XRP on Osmosis is backed in majority by XRP.coreum, whose bridge was exploited on 9 August 2026 and is halted. All of its underlying assets are halted, so deposits and withdrawals of XRP are disabled and minting and redeeming against the underlying assets is paused. XRP may not be fully backed. Take care when trading."
     },
     {
       "chain_name": "xion",


### PR DESCRIPTION
## What

Adds `osmosis_halt_deposits` and `osmosis_halt_withdrawals` (reason `manual`) to the **allXRP alloy**, and updates its tooltip to say so. Follow-up to #3714.

## Why

Both of the alloy's underlying assets are now halted in both directions:

| Constituent | Share of alloy | Status |
| --- | ---: | --- |
| XRP.coreum | 98.15% | Halted in #3714 after the 9 August XRPL to Coreum bridge exploit |
| XRP.xrplevm | 1.85% | Halted since 2026-05-16, IBC client `07-tendermint-3499` expired |

With no transferable constituent left, a deposit or withdrawal of the alloy itself cannot succeed. Previously the alloy was marked `unstable` but still advertised transfer routes that would fail.

## This is not inferred automatically

Worth recording, since the reasonable expectation is that an alloy inherits its constituents' halts.

The alloy-aware logic in `lifecycle_helpers.mjs` (`fetchAlloyConstituentMap`, `resolveMarket`) exists only for **market signals**: a constituent inherits `max(self, alloy)` volume so a healthy alloy's constituent is not falsely flagged as low-market. That mapping runs constituent ← alloy, and covers liquidity only. **Halt and unstable state is not propagated in either direction.**

So an alloy whose constituents are all halted stays transferable in the UI until a human sets the flags. If that inheritance is wanted generally, it should be a separate change to the automation, not assumed here.

## Tooltip

Before: "Minting and redeeming against the underlying assets is paused, and XRP.coreum cannot be deposited or withdrawn…"

After: "All of its underlying assets are halted, so deposits and withdrawals of XRP are disabled and minting and redeeming against the underlying assets is paused. XRP may not be fully backed. Take care when trading."

The alloy transmuter remains paused onchain (`is_active: false`). Note this still does not stop allXRP trading in AMM pools, which is why the tooltip keeps the trading caution rather than claiming transfers are impossible.

## Changes

- `osmosis-1/osmosis.zone_assets.json` — source
- `osmosis-1/generated/frontend/assetlist.json` — regenerated via `node generate_assetlist.mjs`

## Testing

- `node validate_zone_files.mjs` passes
- Generated diff contains only the allXRP entry
