### PR TITLE
fix(osmosis-1): halt TX deposits after the Coreum bridge exploit

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -14110,9 +14110,13 @@
       "name": "TX",
       "isAlloyed": false,
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
-      "preview": false
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "preview": false,
+      "tooltipMessage": "The XRPL to Coreum bridge was exploited on 9 August 2026 and is halted. The exploit minted unbacked tokens on Coreum, so TX may be affected. Deposits are disabled while the situation is assessed. Withdrawals remain open."
     },
     {
       "chainName": "celestia",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3420,7 +3420,12 @@
       "categories": [
         "bridges"
       ],
-      "_comment": "TX $TX"
+      "_comment": "TX $TX",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "tooltip_message": "The XRPL to Coreum bridge was exploited on 9 August 2026 and is halted. The exploit minted unbacked tokens on Coreum, so TX may be affected. Deposits are disabled while the situation is assessed. Withdrawals remain open."
     },
     {
       "chain_name": "celestia",


### PR DESCRIPTION
## What

Marks **TX** (formerly CORE) as `osmosis_unstable` and halts **deposits only**, with a `tooltip_message`. Withdrawals are deliberately left open so existing holders can still exit.

Follow-up to #3714 and #3715, which covered XRP.coreum and the allXRP alloy.

## Why

Tracing the 9 August XRPL to Coreum bridge exploit onchain shows it did not only drain XRP. The attacker's Coreum address `core1e7y6qwktg7l6ajr8e2eal5j4dnc2jyceftnjce` received **6,181,069.428 CORE** in 10 transfers directly from the bridge contract, against XRPL deposits that never happened, and pushed roughly **4,356,826 CORE** back out through `send_to_xrpl`. The residue, 1,824,243.66 CORE, is still sitting in that address.

That is unbacked supply the bridge issued. Halting deposits stops users bridging further funds into an asset whose issuer is mid-incident, while open withdrawals let anyone already holding it leave.

## Important caveat, stated plainly

**TX is native `ucore` over IBC** (`transfer/channel-2188`, base denom `ucore`), not a bridge-issued representation. Its backing is therefore **not** impaired the way XRP.coreum's is, and the IBC transfer path itself is working.

This flag is a precaution against the unbacked supply the exploit created on Coreum, not a claim that the denom is broken. The tooltip is worded to say "may be affected" rather than asserting impairment.

## Scope

Other Coreum-origin assets on Osmosis were checked and are **not** flagged, per direction:

| Symbol | Supply on Osmosis |
| --- | ---: |
| CCD | 3,914,839.11 |
| SARA | 90,110.82 |
| SOLO | 23.81 |
| RLUSD | 1.80 |
| COREZ / LICORE | 0 |

The community pool holds **none** of the Coreum-origin assets directly. Its only Coreum-linked position is Margined vault 2970 (allXRP/USDC), which is tracked separately.

## Changes

- `osmosis-1/osmosis.zone_assets.json` — source
- `osmosis-1/generated/frontend/assetlist.json` — regenerated via `node generate_assetlist.mjs`

Reason is `manual` (curator-owned, outside `OWNED_HALT_REASONS`), and the `tooltip_message` independently locks the entry, so neither will be auto-cleared by `check_ibc_clients.mjs`.

## Testing

- `node validate_zone_files.mjs` passes
- Generated diff contains only the TX entry: `unstable`, `unstableReason`, `haltDeposits`, `depositHaltReason`, `tooltipMessage`. No `haltWithdrawals`, as intended.
