### PR TITLE
feat(osmosis-1): register Injective USDC (USDC.inj)

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -7441,7 +7441,7 @@
       "chain_name": "injective",
       "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
       "path": "transfer/channel-122/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
-      "osmosis_verified": true,
+      "osmosis_verified": false,
       "categories": [
         "stablecoin"
       ],

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -7438,6 +7438,16 @@
       "_comment": "Neptune Receipt USDC $nUSDC"
     },
     {
+      "chain_name": "injective",
+      "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+      "path": "transfer/channel-122/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
+      "osmosis_verified": true,
+      "categories": [
+        "stablecoin"
+      ],
+      "_comment": "Injective USDC $USDC.inj"
+    },
+    {
       "chain_name": "kopi",
       "base_denom": "ukusd",
       "path": "transfer/channel-97998/ukusd",


### PR DESCRIPTION
Registers the Injective-native USDC variant on Osmosis, arriving over the direct Injective channel.

- Base denom `erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a` (Injective MultiVM token standard)
- Path `transfer/channel-122/erc20:0xa00C59fF...`, giving `ibc/794C7D7F3B857713878A3A1927251FA6AC1EEE520424C1F6FAFE9BA26D476138`
- 6 decimals, confirmed from Injective bank metadata and the ERC20 contract `decimals()`
- Already on chain: this denom is a constituent of the alloyed USDC pool 3497 and is registered as a txfees fee token

## Draft: blocked on the upstream chain-registry entry

The source asset needs registering in `cosmos/chain-registry` first. [PR 7897](https://github.com/cosmos/chain-registry/pull/7897) covers this, but its Osmosis entry currently uses the two-hop `transfer/channel-0/transfer/channel-220/...` route via the Cosmos Hub (`ibc/105737AB...`) rather than the direct channel-122 path used here.

Osmosis has a direct channel to Injective, `injective:channel-8 <-> osmosis:channel-122`, marked preferred and ACTIVE in the registry, and current supply on Osmosis is ~1,728 on the direct denom against ~1.24 on the via-Hub one. Holding this as a draft until that is resolved.

## Note on case sensitivity

The mixed-case EIP-55 address must be preserved verbatim in both `base_denom` and `path`. Lowercasing it produces a different and wrong IBC denom (`ibc/D3B2A035...`). The denom in this PR was verified by recomputing `sha256(path)`.