### PR TITLE
chore(osmosis): unhalt allDOGE withdrawals after Int3face frontend removal

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -27334,10 +27334,7 @@
       "verified": true,
       "unstable": false,
       "disabled": false,
-      "haltWithdrawals": true,
-      "withdrawalHaltReason": "manual",
       "preview": false,
-      "tooltipMessage": "DOGE withdrawals are temporarily paused while bridge routing is updated. Trading and existing balances are unaffected. Please check back shortly.",
       "listingDate": "2024-11-19T20:00:00.000Z"
     },
     {

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6986,10 +6986,7 @@
       "categories": [
         "meme"
       ],
-      "_comment": "Dogecoin $DOGE",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "DOGE withdrawals are temporarily paused while bridge routing is updated. Trading and existing balances are unaffected. Please check back shortly."
+      "_comment": "Dogecoin $DOGE"
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## Description

Reverts #3707, which paused DOGE withdrawals as interim cover while the hardcoded Int3face routing was removed from the frontend. That removal (osmosis-frontend #4432) is in the production release going out today, so the cover is no longer needed.

Removes from the `allDOGE` entry:

```json
"osmosis_halt_withdrawals": true,
"osmosis_withdrawal_halt_reason": "manual",
"tooltip_message": "DOGE withdrawals are temporarily paused while bridge routing is updated. Trading and existing balances are unaffected. Please check back shortly."
```

Includes the matching change to `osmosis-1/generated/frontend/assetlist.json`.

### Post-unhalt routing

The allDOGE transmuter pool now holds only `cbDOGE.axl` (verified onchain via `get_total_pool_liquidity`), so withdrawals surface through the cbDOGE.axl variant and its Squid connector. DOGE.int3 and ckDOGE are no longer pool members, so their routes stay suppressed by the frontend's membership gate. The `DOGE.int3` deposit halt is untouched.

### Merge ordering

The frontend reads this assetlist from `main` at runtime. Merge only after the frontend release containing the Int3face provider removal is live in production; until then the live app still has the halt-blind routing this flag was covering.

### Verification

- `node validate_zone_files.mjs` passes against the latest chain-registry (the submodule pointer is intentionally not bumped here).
- `node generate_assetlist.mjs` reproduces the committed `generated/frontend/assetlist.json` DOGE entry exactly; unrelated registry drift was left for the daily auto-update.

## Checklist

Not adding an asset or chain, and not upgrading verification status, so the template's sections do not apply.