### PR TITLE
Add Sovren (SOVR) to Osmosis zone assets and chains

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -12992,6 +12992,13 @@
       "osmosis_deposit_halt_reason": "bridge_down",
       "osmosis_halt_withdrawals": true,
       "osmosis_withdrawal_halt_reason": "bridge_down"
+    },
+    {
+      "chain_name": "sovr",
+      "base_denom": "usovr",
+      "path": "transfer/channel-110679/usovr",
+      "_comment": "Sovren $SOVR",
+      "osmosis_verified": false
     }
   ]
 }

--- a/osmosis-1/osmosis.zone_chains.json
+++ b/osmosis-1/osmosis.zone_chains.json
@@ -1581,6 +1581,17 @@
       "rpc": "https://rpc.trusttails.io",
       "rest": "https://api.trusttails.io",
       "explorer_tx_url": "https://explorer.trusttails.io/tail/tx/${txHash}"
+    },
+    {
+      "chain_name": "sovr",
+      "rpc": "https://rpc.sovrchain.net",
+      "rest": "https://api.sovrchain.net",
+      "explorer_tx_url": "https://sovrscan.com/transactions/${txHash}",
+      "keplr_features": [
+        "ibc-go",
+        "cosmwasm",
+        "wasmd_0.24+"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds Sovren (SOVR) to the Osmosis zone assets (unverified tier) and zone chains.

- Chain-registry entries merged: [`sovr/chain.json`](https://github.com/cosmos/chain-registry/blob/master/sovr/chain.json), [`sovr/assetlist.json`](https://github.com/cosmos/chain-registry/blob/master/sovr/assetlist.json), [`_IBC/osmosis-sovr.json`](https://github.com/cosmos/chain-registry/blob/master/_IBC/osmosis-sovr.json)
- Route: `sovr-1 channel-0` ↔ `osmosis-1 channel-110679`, `STATE_OPEN` both sides, in active use
- Denom on Osmosis: `ibc/FB26E04E71EACCCCCD6D81F0F7666D5567C3A1686E2AC577FCC03F28F5B5874F`
- Live pool: **3496** (SOVR/USDC, concentrated liquidity, 0.2% spread)
- Endpoints verified at submission: RPC reports `sovr-1`; REST healthy; **WSS enabled** (a `tm.event='NewBlock'` subscription over `wss://rpc.sovrchain.net/websocket` received a live block); CORS allows `https://osmosis.zone` and `https://app.osmosis.zone` on both RPC and REST
- `explorer_tx_url` copied from the merged chain-registry `tx_page` and verified against a live transaction
- `keplr_features`: chain runs ibc-go v10.5.0 and CosmWasm (wasmd v0.60.7)