### PR TITLE
Set Sovren (SOVR) to Osmosis verified

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -12997,7 +12997,7 @@
       "base_denom": "usovr",
       "path": "transfer/channel-110679/usovr",
       "_comment": "Sovren $SOVR",
-      "osmosis_verified": false
+      "osmosis_verified": true
     }
   ]
 }


### PR DESCRIPTION
Requesting **Verified** status for Sovren (SOVR).

**Validation pool: 3496** (SOVR/USDC, concentrated liquidity, 0.2% spread factor).

All requirements re-verified live at submission (2026-08-21):

- **Over $1,000 of each asset provided as liquidity** — pool 3496 currently holds ~$27.7k USDC and ~237,000 SOVR (≈$14.3k at spot)
- **±2% depth exceeds $50 in both directions** — live LCD swap estimates: a $50 USDC buy quotes **$49.99** of SOVR; a $50-worth SOVR sell quotes **$49.69** USDC (both ≥ $49, well inside tolerance at the 0.2% spread)
- **`extended_description` and `socials`** registered at the Cosmos Chain Registry ([`sovr/assetlist.json`](https://github.com/cosmos/chain-registry/blob/master/sovr/assetlist.json))
- **Square logo under 250 KB** — 512×512 PNG (193 KB) + SVG, both in the registry
- **`sovr-1` is live** and not marked killed (genesis 2026-05-06; currently at height ~1.65M)
- **Endpoints** — RPC reports `sovr-1`; REST healthy; **WSS enabled** (`wss://rpc.sovrchain.net/websocket` upgrade → 101, live `NewBlock` subscription verified); CORS allows `https://osmosis.zone` and `https://app.osmosis.zone` on both RPC and REST
- **Explorer** — `explorer_tx_url` verified opening a live transaction on sovrscan.com
- The asset resolves on the frontend data plane: present in `generated/frontend/assetlist.json` (post-#3730 generation) and priced by SQS
