### PR TITLE
fix(osmosis-1): mark Int3face assets as bridge shut down

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -26491,9 +26491,9 @@
       "unstableReason": "manual",
       "disabled": false,
       "haltDeposits": true,
-      "depositHaltReason": "planned_shutdown",
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -26569,9 +26569,9 @@
       "unstableReason": "manual",
       "disabled": false,
       "haltDeposits": true,
-      "depositHaltReason": "planned_shutdown",
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -26647,8 +26647,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -26724,8 +26726,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -27381,8 +27385,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which has shut down.",
       "listingDate": "2025-07-08T09:08:38.621Z",
       "lastDowntimeDate": "2026-05-28T09:17:16.684Z"
     },
@@ -27428,8 +27434,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which has shut down.",
       "listingDate": "2025-07-08T09:08:38.621Z",
       "lastDowntimeDate": "2026-05-28T09:17:16.684Z"
     },
@@ -28227,9 +28235,9 @@
       "unstableReason": "manual",
       "disabled": false,
       "haltDeposits": true,
-      "depositHaltReason": "planned_shutdown",
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -31456,9 +31464,9 @@
       "unstableReason": "manual",
       "disabled": false,
       "haltDeposits": true,
-      "depositHaltReason": "planned_shutdown",
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -31588,9 +31596,9 @@
       "unstableReason": "manual",
       "disabled": false,
       "haltDeposits": true,
-      "depositHaltReason": "planned_shutdown",
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -32672,8 +32680,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -32748,8 +32758,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -32955,8 +32967,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which has shut down.",
       "listingDate": "2025-08-07T23:39:39.154Z",
       "lastDowntimeDate": "2026-05-28T09:17:16.684Z"
     },
@@ -33002,8 +33016,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which has shut down.",
       "listingDate": "2025-08-07T23:39:39.154Z",
       "lastDowntimeDate": "2026-05-28T09:17:16.684Z"
     },
@@ -33447,8 +33463,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "The Int3face bridge has shut down.",
       "sortWith": {
         "chainName": "int3face",
         "sourceDenom": "uint3"
@@ -33498,8 +33516,10 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "bridge_down",
       "preview": false,
-      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "tooltipMessage": "This alloyed asset is backed solely by the Int3face bridge, which has shut down.",
       "listingDate": "2025-11-03T09:38:27.413Z",
       "lastDowntimeDate": "2026-05-30T15:33:12.966Z"
     },

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -6777,8 +6777,8 @@
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged."
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "int3face",
@@ -6798,8 +6798,8 @@
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged."
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "int3face",
@@ -6818,8 +6818,9 @@
       "_comment": "Bitcoin Cash (Int3) $BCH.int3",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "int3face",
@@ -6838,8 +6839,9 @@
       "_comment": "Litecoin (Int3) $LTC.int3",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "axelar",
@@ -7011,8 +7013,9 @@
       "_comment": "Litecoin $LTC",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which has shut down."
     },
     {
       "chain_name": "osmosis",
@@ -7026,8 +7029,9 @@
       "_comment": "Bitcoin Cash $BCH",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged.",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which has shut down.",
       "transfer_methods": [
         {
           "name": "Int3face Bridge",
@@ -7283,8 +7287,8 @@
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged."
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "fetchhub",
@@ -8159,8 +8163,8 @@
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged."
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "atomone",
@@ -8187,8 +8191,8 @@
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
       "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "planned_shutdown",
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are disabled. Please withdraw your int3 assets back to their native chains before then, after that they can no longer be bridged."
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "migaloo",
@@ -8382,8 +8386,9 @@
       "_comment": "Pudgy Penguins (Int3) $PENGU.int3",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "int3face",
@@ -8405,8 +8410,9 @@
       "_comment": "Official Trump (Int3) $TRUMP.int3",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "qfs",
@@ -8457,8 +8463,9 @@
       "_comment": "Official Trump $TRUMP",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which has shut down."
     },
     {
       "chain_name": "osmosis",
@@ -8484,8 +8491,9 @@
       "_comment": "Pudgy Penguins $PENGU",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which has shut down."
     },
     {
       "chain_name": "neutron",
@@ -8598,8 +8606,9 @@
       "_comment": "Zcash (Int3) $ZEC.int3",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "The Int3face bridge is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "The Int3face bridge has shut down."
     },
     {
       "chain_name": "osmosis",
@@ -8625,8 +8634,9 @@
       "_comment": "Zcash $ZEC",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": false,
-      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which is being wound down and is planned to shut down on 10 August 2026. Deposits are temporarily re-enabled so funds held on Int3face can be returned to Osmosis. Withdraw using the Int3face Bridge option under More Withdraw Options before then, after that they can no longer be bridged."
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "bridge_down",
+      "tooltip_message": "This alloyed asset is backed solely by the Int3face bridge, which has shut down."
     },
     {
       "chain_name": "osmosis",


### PR DESCRIPTION
## What

Marks all 15 Int3face assets as shut down, with one consistent message.

| Assets | Change |
|---|---|
| `ZEC.int3`, `BCH.int3`, `LTC.int3`, `PENGU.int3`, `TRUMP.int3` | `osmosis_halt_deposits: false` → `true`, reason → `bridge_down`, new tooltip |
| `allZEC`, `allBCH`, `allLTC`, `allPENGU`, `allTRUMP` | same, with the alloy-specific tooltip |
| `DOGE.int3`, `BTC.int3`, `TON.int3`, `SOL.int3`, `XRP.xrpl.int3` | already halted; reason `planned_shutdown` → `bridge_down`, new tooltip |

## Why

Deposits on the five Int3face-only assets were temporarily re-enabled so holders could return funds to Osmosis and exit via the in-app Int3face withdraw route.

That route no longer exists. The Int3face bridge provider has since been removed from the frontend, so the tooltips were instructing users to "withdraw using the Int3face Bridge option under More Withdraw Options", a path the UI no longer offers. They also cited a planned shutdown date of 10 August 2026, which has passed.

The five already-halted variants carried the same stale date, so the app was showing two different messages for the same bridge. All 15 now read the same.

## Tooltips

Variants:

> The Int3face bridge has shut down.

Alloys:

> This alloyed asset is backed solely by the Int3face bridge, which has shut down.

No date, since every previously published date slipped, and no link to the bridge site, which will not stay functional.

## Verification

- `validate_zone_files.mjs` exit 0
- `validate_zone_data.mjs` exit 0
- `generate_assetlist.mjs` re-run; only `generated/frontend/assetlist.json` carries content changes, all 15 entries confirmed with `haltDeposits: true` / `depositHaltReason: bridge_down` / new `tooltipMessage`
- Diff confined to `halt_deposits`, `deposit_halt_reason` and `tooltip_message` fields; zero off-target lines in either file
- Generated files touched with line-ending-only or unrelated drift reverted; `chain-registry` submodule pointer left unstaged
- No remaining Int3face entry references the old date or `planned_shutdown` (the 4 remaining `planned_shutdown` uses are Comdex and Noble USDN, unrelated)