### PR TITLE
feat(osmosis-1): set allUSDC and USDC.inj to verified

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5465,7 +5465,7 @@
         "chain_name": "ethereum",
         "base_denom": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
       },
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "is_alloyed": true,
       "_comment": "USDC $USDC",
       "categories": [
@@ -7502,7 +7502,7 @@
       "chain_name": "injective",
       "base_denom": "erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
       "path": "transfer/channel-122/erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a",
-      "osmosis_verified": false,
+      "osmosis_verified": true,
       "categories": [
         "stablecoin"
       ],


### PR DESCRIPTION
Promotes both new USDC entries from unverified to verified, so they appear without the "Show Unverified Assets" toggle.

| Asset | Denom |
|---|---|
| **allUSDC** | `factory/osmo147h5x9p…/alloyed/allUSDC` |
| **USDC.inj** | `erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a` |

Both were listed `osmosis_verified: false` per the convention that assets start unverified.

## Against the LISTING.md criteria

**Qualification.** `LISTING.md:28` — *"Constituents of Alloyed Assets automatically qualify."* USDC.inj is a constituent of allUSDC. allUSDC is the alloy itself and is now the canonical USDC on Osmosis, superseding the Noble variant.

**Metadata.** Both are registered in the Cosmos Chain Registry with name, symbol, base, display, `type_asset` and a description. Neither carries `socials`, matching the existing verified Noble USDC entry, which has neither `socials` nor `extended_description` — so this is consistent with how the USDC family is already treated. `LISTING.md:37-38` also exempts variant assets where the origin defines the metadata.

**Liquidity.** allUSDC holds ~2,146 across 56 concentrated liquidity pools, the largest being pool 3511 (ETH/allUSDC) at ~796 on the alloy side. USDC.inj holds ~3,668 in the alloy pool 3497, which is a transmuter: 1:1 with no curve and no swap fee, so the quote-depth tests pass trivially on that leg. Taken across pools rather than per-pool.

**Transfers validated.** Deposit and withdraw were exercised end to end on a branch build:

- **Withdraw to Injective** — settled exactly 1:1 as native `erc20:0xa00C59fF…`
- **Withdraw to Noble** — settled as `uusdc`
- **Withdraw to Ethereum** — via Noble CCTP, minted native USDC to the destination
- **Deposit from Ethereum** — arrived over Axelar (channel-208) and auto-converted to allUSDC in a single atomic transaction

**Chain status.** Neither origin chain is marked killed.

## Note

`verified` in the generated output follows this field, so both will show as verified once the next `[AUTO]` generation cycle runs.
