### PR TITLE
fix(osmosis-1): halt GNOD and EPIX deposits after chain security incidents

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -33746,9 +33746,13 @@
       "name": "Epix (Epix)",
       "isAlloyed": false,
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
       "preview": false,
+      "tooltipMessage": "Deposits are paused as a precaution while a security issue affecting this chain is reviewed. Withdrawals remain open.",
       "listingDate": "2026-01-07T10:33:24.712Z"
     },
     {
@@ -33843,9 +33847,13 @@
       "isAlloyed": true,
       "contract": "osmo130tfawc7katf7jwzt2rjdranhqju929rjra3xwsrfsd85hedh3tsssy9j7",
       "verified": false,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
-      "preview": false
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "preview": false,
+      "tooltipMessage": "Deposits are paused as a precaution while a security issue affecting the Epix chain is reviewed. Withdrawals remain open."
     },
     {
       "chainName": "divine",
@@ -34023,9 +34031,15 @@
       "name": "Gnodi",
       "isAlloyed": false,
       "verified": false,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
-      "preview": false
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "manual",
+      "preview": false,
+      "tooltipMessage": "Deposits and withdrawals are unavailable while a security issue affecting the Gnodi chain is reviewed. GNOD cannot be moved to or from Osmosis."
     },
     {
       "chainName": "neutron",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8813,7 +8813,12 @@
         "defi",
         "dweb"
       ],
-      "_comment": "Epix (Epix) $EPIX.epix"
+      "_comment": "Epix (Epix) $EPIX.epix",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "tooltip_message": "Deposits are paused as a precaution while a security issue affecting this chain is reviewed. Withdrawals remain open."
     },
     {
       "chain_name": "mirage",
@@ -8844,7 +8849,12 @@
       "categories": [
         "defi",
         "dweb"
-      ]
+      ],
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "tooltip_message": "Deposits are paused as a precaution while a security issue affecting the Epix chain is reviewed. Withdrawals remain open."
     },
     {
       "chain_name": "divine",
@@ -8899,7 +8909,14 @@
       "base_denom": "uGNOD",
       "path": "transfer/channel-108866/uGNOD",
       "osmosis_verified": false,
-      "_comment": "Gnodi $GNOD"
+      "_comment": "Gnodi $GNOD",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "Deposits and withdrawals are unavailable while a security issue affecting the Gnodi chain is reviewed. GNOD cannot be moved to or from Osmosis."
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
## What

Halts deposits on three assets affected by ongoing chain security incidents, and adds user-facing tooltips explaining why.

| Asset | Deposits | Withdrawals | Reason |
|---|---|---|---|
| GNOD | halted | halted | `manual` |
| EPIX.epix | halted | open | `manual` |
| EPIX (allEPIX alloy) | halted | open | `manual` |

## Why

**Gnodi** is affected by a security issue on the chain, and the chain is not currently processing transfers. Both deposits and withdrawals are halted: leaving withdrawals enabled while transfers cannot complete would only produce failing transactions for users.

**Epix** is paused as a precaution while a security issue affecting the chain is reviewed. Withdrawals stay open so existing holders can unwind their positions.

The `allEPIX` alloy is included because it is backed entirely by the `EPIX.epix` IBC variant (27,017,654 EPIX alloy supply against exactly 27,017,654 EPIX.epix held by the transmuter, a single constituent). Without tagging it, the alloy would continue to display as a healthy asset while its only backing carries a warning. Its four pools are currently empty, so this is a labelling and inflow-path fix rather than a response to at-risk liquidity.

## Notes for reviewers

- All three use the `manual` reason. The closed enums (`ibc_client`, `source_chain_killed`, `market`, `bridge_down`, `planned_shutdown`) have no member covering a chain-side security incident, and per the schema the curator-written context belongs in `tooltip_message`.
- Tooltips are deliberately non-technical and non-specific. They name no software versions or components, and do not detail the nature of the incidents.
- A non-empty `tooltip_message` acts as a curator lock that pauses `check_market_health`, `check_extended_halts` and `check_ibc_clients` for these assets. That is intended here. No `tooltip_expiry_date` is set, since these document conditions that should persist until a curator clears them by hand.
- GNOD's withdrawal halt will need clearing by hand if the chain resumes normal operation, as the lifecycle automation is paused for it.
- Other assets from chains sharing the same framework were deliberately left untouched, as the evidence does not currently support halting them.

## Generated files

`generated/frontend/assetlist.json` contains only the halt output for these three assets.

The other generated files were left at their committed state. Note that they already lag their source on `main` regarding the allUSDC identity handover (#3727, #3741, #3742 merged source-only without regenerating), so the next full generator run will produce that catch-up. It is deliberately excluded here to keep this PR reviewable.

## Testing

- `node validate_zone_files.mjs` passes clean
- `zone_assets.schema.json` validates
- `node generate_assetlist.mjs` run; frontend output confirms `haltDeposits`, `haltWithdrawals` and `tooltipMessage` propagate for all three
- Asset count unchanged at 1,339
