### PR TITLE
fix(osmosis-1): re-enable EPIX deposits after chain upgrade

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -33992,13 +33992,9 @@
       "name": "Epix (Epix)",
       "isAlloyed": false,
       "verified": true,
-      "unstable": true,
-      "unstableReason": "manual",
+      "unstable": false,
       "disabled": false,
-      "haltDeposits": true,
-      "depositHaltReason": "manual",
       "preview": false,
-      "tooltipMessage": "Deposits are paused as a precaution while a security issue affecting this chain is reviewed. Withdrawals remain open.",
       "listingDate": "2026-01-07T10:33:24.712Z"
     },
     {
@@ -34093,13 +34089,9 @@
       "isAlloyed": true,
       "contract": "osmo130tfawc7katf7jwzt2rjdranhqju929rjra3xwsrfsd85hedh3tsssy9j7",
       "verified": false,
-      "unstable": true,
-      "unstableReason": "manual",
+      "unstable": false,
       "disabled": false,
-      "haltDeposits": true,
-      "depositHaltReason": "manual",
-      "preview": false,
-      "tooltipMessage": "Deposits are paused as a precaution while a security issue affecting the Epix chain is reviewed. Withdrawals remain open."
+      "preview": false
     },
     {
       "chainName": "divine",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8827,12 +8827,7 @@
         "defi",
         "dweb"
       ],
-      "_comment": "Epix (Epix) $EPIX.epix",
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "manual",
-      "tooltip_message": "Deposits are paused as a precaution while a security issue affecting this chain is reviewed. Withdrawals remain open."
+      "_comment": "Epix (Epix) $EPIX.epix"
     },
     {
       "chain_name": "mirage",
@@ -8863,12 +8858,7 @@
       "categories": [
         "defi",
         "dweb"
-      ],
-      "osmosis_unstable": true,
-      "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "manual",
-      "tooltip_message": "Deposits are paused as a precaution while a security issue affecting the Epix chain is reviewed. Withdrawals remain open."
+      ]
     },
     {
       "chain_name": "divine",


### PR DESCRIPTION
## What

Re-enables EPIX deposits on Osmosis by removing the manual halt added in #3743.

| Asset | Deposits | Withdrawals |
|---|---|---|
| EPIX.epix | open | open |
| EPIX (allEPIX alloy) | open | open |

Removes `osmosis_unstable`, `osmosis_halt_deposits`, their reasons, and the tooltip from both entries in `osmosis.zone_assets.json`, and mirrors that in the generated frontend assetlist so the change takes effect without waiting for the weekly regeneration, the same way #3743 was applied. GNOD is untouched.

## Why

The precautionary pause is no longer needed. The Epix chain has completed its upgrade to [EpixChain v0.7.3](https://github.com/EpixZone/EpixChain/releases/tag/v0.7.3), which aligns the chain with upstream cosmos/evm v0.7.3 and the StateDB hardening published in that release (GHSA-367m-g444-9mg3). The network reviewed its full history against the issue and was not impacted: total supply matches the emission schedule at every block and no funds were affected.

Current state of the chain and the Osmosis route, checked today:

- Chain is producing blocks normally, with all bonded validators signing and more than 86% of voting power confirmed on v0.7.3.
- IBC client `07-tendermint-3641` for `epix_1916-1` on Osmosis is Active, with a post-upgrade Epix header. The Epix-side client for `osmosis-1` is Active as well.
- `transfer/channel-0` (Epix) to `transfer/channel-108456` (Osmosis) is open with no pending packets in either direction. A transfer sent from Epix after the upgrade was received on Osmosis and acknowledged back on Epix within three blocks.

## Notes for reviewers

- This is a pure reversal of the EPIX portion of #3743. Both entries return to exactly their pre-halt shape.
- `osmosis.zone_assets.json` validates against `zone_assets.schema.json` with no errors.

## Companion action needed on chain

The IBC Rate Limit Controller subDAO also set an on-chain quota for EPIX on 2026-08-26 (proposal A78, "Precautionary halt of EVM chain transfers"): `EPIX-DAY-1` with `send_recv: [100, 0]` on channel `any` for `ibc/776917313EC3252954ED622945D4979651ACD909A18E528283F46D7B166F20BF`. With inbound at 0%, every Epix to Osmosis transfer is currently received and then rejected with `rate limit exceeded`, then refunded on Epix. Please pair this merge with a subDAO proposal that removes that path or restores a normal inbound quota, otherwise the UI will show deposits as open while the chain still rejects them.
