### PR TITLE
fix(osmosis-1): re-enable GNOD transfers after chain recovery

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -34281,12 +34281,8 @@
       "unstable": true,
       "unstableReason": "manual",
       "disabled": false,
-      "haltDeposits": true,
-      "depositHaltReason": "manual",
-      "haltWithdrawals": true,
-      "withdrawalHaltReason": "manual",
       "preview": false,
-      "tooltipMessage": "Deposits and withdrawals are unavailable while a security issue affecting the Gnodi chain is reviewed. GNOD cannot be moved to or from Osmosis."
+      "tooltipMessage": "The Gnodi chain experienced a security incident in August 2026 that briefly halted the chain and affected GNOD's supply. The chain has since resumed normal operation and transfers are open again."
     },
     {
       "chainName": "neutron",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -8927,11 +8927,8 @@
       "_comment": "Gnodi $GNOD",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "manual",
-      "osmosis_halt_deposits": true,
-      "osmosis_deposit_halt_reason": "manual",
-      "osmosis_halt_withdrawals": true,
-      "osmosis_withdrawal_halt_reason": "manual",
-      "tooltip_message": "Deposits and withdrawals are unavailable while a security issue affecting the Gnodi chain is reviewed. GNOD cannot be moved to or from Osmosis."
+      "tooltip_message": "The Gnodi chain experienced a security incident in August 2026 that briefly halted the chain and affected GNOD's supply. The chain has since resumed normal operation and transfers are open again.",
+      "tooltip_expiry_date": "2026-11-04"
     },
     {
       "chain_name": "neutron",


### PR DESCRIPTION
## What

Re-enables GNOD deposits and withdrawals on Osmosis by removing the manual halts added in #3743, and replaces the halt tooltip with an informational notice about the August incident.

| Asset | Deposits | Withdrawals |
|---|---|---|
| GNOD | open | open |

Removes `osmosis_halt_deposits`, `osmosis_halt_withdrawals` and their reasons, and mirrors the change in the generated frontend assetlist so it takes effect without waiting for the next regeneration, the same way #3743 was applied. EPIX is untouched here — that is covered by #3755.

`osmosis_unstable` is deliberately kept. The asset is still unverified and thinly traded, so the warning badge remains appropriate even with transfers open. The tooltip carries a `tooltip_expiry_date` of 2026-11-04 so the notice clears itself after two months.

## Why

The Gnodi chain halted for roughly 21 hours on 25–26 August following a supply-inflation incident. It restarted with the inflation reversed and has run continuously since.

State verified onchain 4 September:

- Chain producing blocks normally at height ~695,500 with ~23s block times, confirmed on all three public RPCs.
- Supply is 12,477,901,969 GNOD, a normal 17-digit figure consistent with 10.47B bonded (84%). The anomalous value present during the incident is gone.
- The IBC escrow on Gnodi and the GNOD voucher supply on Osmosis reconcile exactly at 22,872,492.772359.
- Both clients on the route are Active and unfrozen: `07-tendermint-3665` (gnodi on Osmosis, 14d trusting period) and `07-tendermint-1` (osmosis-1 on Gnodi, 9d 8h). Both sit at a conservative 67% of unbonding with over 8 days of headroom.

Roughly 14.87M GNOD of legitimate user balances currently cannot leave Osmosis. Keeping withdrawals closed against a healthy counterparty chain has no protective effect.
