### PR TITLE
fix(osmosis-1): halt nBTC transfers, Nomic chain down

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -14332,9 +14332,15 @@
       "name": "Nomic Bitcoin",
       "isAlloyed": false,
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": true,
-      "preview": false
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "manual",
+      "preview": false,
+      "tooltipMessage": "The Nomic chain is not producing blocks. Deposits and withdrawals are halted."
     },
     {
       "chainName": "nois",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -3485,7 +3485,14 @@
           "withdraw_url": "https://app.nomic.io/ibc"
         }
       ],
-      "_comment": "Nomic Bitcoin $nBTC"
+      "_comment": "Nomic Bitcoin $nBTC",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "The Nomic chain is not producing blocks. Deposits and withdrawals are halted."
     },
     {
       "chain_name": "nois",


### PR DESCRIPTION
## What

Marks nBTC unstable and halts both transfer directions, with a tooltip explaining the state.

| Asset | Deposits | Withdrawals |
|---|---|---|
| nBTC | halted | halted |

Adds `osmosis_unstable`, `osmosis_halt_deposits`, `osmosis_halt_withdrawals` and their reasons, all `manual`, plus a `tooltip_message`. The generated frontend assetlist is mirrored in the same commit so this takes effect without waiting for the next regeneration.

The tooltip is deliberately short and states only the observed fact.

nBTC already carried `osmosis_disabled: true`. That flag alone gives no halt semantics and no user-facing explanation, so the explicit halts and tooltip are still needed.

## Why

The Nomic chain has stopped producing blocks, confirmed by validators on Nomic chain
