### PR TITLE
fix(osmosis-1): pause allBTC transfers pending nBTC investigation

### DIFF
--- a/osmosis-1/generated/frontend/assetlist.json
+++ b/osmosis-1/generated/frontend/assetlist.json
@@ -21943,9 +21943,15 @@
       "isAlloyed": true,
       "contract": "osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3",
       "verified": true,
-      "unstable": false,
+      "unstable": true,
+      "unstableReason": "manual",
       "disabled": false,
-      "preview": false
+      "haltDeposits": true,
+      "depositHaltReason": "manual",
+      "haltWithdrawals": true,
+      "withdrawalHaltReason": "manual",
+      "preview": false,
+      "tooltipMessage": "Alloyed BTC deposits and withdrawals are paused while an issue affecting nBTC, one of its backing variants, is investigated. The Nomic chain is not producing blocks. Trading remains available and other Bitcoin variants are unaffected."
     },
     {
       "chainName": "bitsong",

--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -5583,6 +5583,13 @@
       "osmosis_verified": true,
       "is_alloyed": true,
       "_comment": "Bitcoin $BTC",
+      "osmosis_unstable": true,
+      "osmosis_unstable_reason": "manual",
+      "osmosis_halt_deposits": true,
+      "osmosis_deposit_halt_reason": "manual",
+      "osmosis_halt_withdrawals": true,
+      "osmosis_withdrawal_halt_reason": "manual",
+      "tooltip_message": "Alloyed BTC deposits and withdrawals are paused while an issue affecting nBTC, one of its backing variants, is investigated. The Nomic chain is not producing blocks. Trading remains available and other Bitcoin variants are unaffected.",
       "canonical": {
         "chain_name": "bitcoin",
         "base_denom": "sat"


### PR DESCRIPTION
The allBTC transmuter has been set inactive by the alloy moderator while an issue affecting the nBTC backing variant is investigated. This marks allBTC unstable and halts both transfer directions so the frontend matches the contract state, rather than offering deposits and withdrawals that cannot succeed.

Verified before committing, and re-checked before opening:

- `is_active: false` on the transmuter (`osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3`)
- Nomic still halted, last block `2026-09-07T15:30:21Z`, all public RPCs down
- Osmosis light client `07-tendermint-3010` has not advanced since Nomic height 34828745

Tooltip:

> Alloyed BTC deposits and withdrawals are paused while an issue affecting nBTC, one of its backing variants, is investigated. The Nomic chain is not producing blocks. Trading remains available and other Bitcoin variants are unaffected.

Two things it says deliberately. **Trading remains available** because pool swaps do not route through the transmuter, so a halt badge would otherwise read as "your funds are stuck". And **other Bitcoin variants are unaffected**, since the remaining alloy constituents are functioning normally.

Follows #3760, which halted nBTC itself when Nomic stopped producing blocks. This extends the same treatment to the alloy that holds it.

`generated/frontend/assetlist.json` was regenerated with `node generate_assetlist.mjs`. Only the frontend output is included; other generated files showed unrelated churn from a stale local `chain-registry` submodule and were reverted.