### PR TITLE
fix(osmosis-1): update AMTS IBC path for Amitis channel renewal

### DIFF
--- a/osmosis-1/osmosis.zone_assets.json
+++ b/osmosis-1/osmosis.zone_assets.json
@@ -12217,7 +12217,7 @@
     {
       "chain_name": "amitis",
       "base_denom": "uamts",
-      "path": "transfer/channel-110089/uamts",
+      "path": "transfer/channel-111069/uamts",
       "_comment": "Amitis Network $AMTS",
       "osmosis_unstable": true,
       "osmosis_unstable_reason": "ibc_client",


### PR DESCRIPTION
## Problem

Zone-data validation is failing on `main`-targeting PRs with:

```
Error: IBC Channel for Path: transfer/channel-110089/uamts does not exist in the chain registry.
```

This is ambient breakage, not caused by the PR it surfaced on (#3763, an unrelated allBTC pause).

## Cause

Amitis Network renewed its IBC connection to Osmosis. `cosmos/chain-registry#7928` ("IBC channel renewal") landed 2026-09-09 08:17 UTC and replaced the connection wholesale:

|  | old | new |
|---|---|---|
| Osmosis channel | `channel-110089` | `channel-111069` |
| Amitis channel | `channel-1` | `channel-3` |
| connection | `connection-11055` | `connection-11095` |
| Osmosis client | `07-tendermint-3701` | `07-tendermint-3751` |

The chain did **not** de-register: `amitis/chain.json` and `amitis/assetlist.json` are both still present upstream. Only the channel identifiers changed. Because the `zone data` job runs `git submodule update --init --remote`, CI resolves against upstream `master` rather than the pinned submodule, so the old path stopped resolving as soon as that PR merged.

## Why this is safe

A channel swap on a live asset would normally strand holders on the old denom hash. That risk does not apply here:

- Old denom `ibc/7E577151E593349028AAC4A9FCC33258D70749FDF3CBB48F7744262DD18FC89D`: **supply 0**
- Old escrow `osmo1gax57s6867dmzw3d407luj5ryr7k6t53f2cn5v`: **empty**
- New escrow `osmo12ncyvx5sxlcyqwk3c6h0zw3rcrsuvss4rfqmdk`: **empty**

Both channels are still `STATE_OPEN` onchain; the old one was superseded rather than closed. Nothing is in flight and no holders exist, so repointing the path has no user impact.

New path resolves to `ibc/4793BB9CA6FFCF1A8AEA9BA386200D8D32413E0986BDD7812891A361B57F1C31`.

## Halts retained

Deposit and withdrawal halts are deliberately left in place. AMTS was already halted (`bridge_down`, `osmosis_unstable: ibc_client`) and the underlying bridge condition is unchanged and unverified. This PR fixes path resolution only; it does not re-enable transfers.

## Testing

- `node validate_zone_files.mjs` against a registry synced to upstream `master`: passes (exit 0)
- Reverted the path to `channel-110089` to confirm the check genuinely gates this value: reproduces the CI error exactly (exit 1)
- `node --test *.test.mjs`: 60/60 pass

Submodule pin intentionally untouched; the diff is one line.

## Risk

Low. Single path change on a zero-supply, fully halted asset. Remaining risk is that the renewed channel is itself unproven, which is why the halts stay on until the bridge is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
